### PR TITLE
Exercise Tutorial

### DIFF
--- a/content/documentation/tutorials.md
+++ b/content/documentation/tutorials.md
@@ -1,0 +1,11 @@
++++
+title = "Tutorials"
+weight = 9999
+redirect_to = "tutorials"
++++
+
+### Exercises
+
+- [Basic](../../tutorials/exercises/basic)
+- [Conditionals and boolean operations](../../tutorials/exercises/conditionals-and-structures)
+- [Functional programming](../../tutorials/exercises/functional-programming)

--- a/content/tutorials/exercises/basic.md
+++ b/content/tutorials/exercises/basic.md
@@ -1,13 +1,184 @@
 +++
 title = "Basic syntax"
+weight = 1
 +++
 
-Compute `1+1`.
+{% question() %}
+Compute `1 + 1`
+{% end %}
 {% solution() %}
-`(+ 1 1)`
+```phel
+(+ 1 1)
+```
 {% end %}
 
+{% question() %}
 Call the function `get` with arguments `"hello"` and `1`
+{% end %}
 {% solution() %}
-`(get "hello" 1)`
+```phel
+(get "hello" 1)
+```
+{% end %}
+
+{% question() %}
+Compute `(3 + 4 / 5) * 6`
+{% end %}
+{% solution() %}
+```phel
+(* (+ 3 (/ 4 5)) 6)
+```
+{% end %}
+
+{% question() %}
+Define a vector with the elements `2`, `"nice"` and `true`
+{% end %}
+{% solution() %}
+```phel
+[2 "nice" true]
+```
+{% end %}
+
+{% question() %}
+Define a vector that contains the keywords `:key` and `:word`
+{% end %}
+{% solution() %}
+```phel
+[:key :word]
+```
+{% end %}
+
+{% question() %}
+Define a map with the key `1` associated with the value `"hello"`
+{% end %}
+{% solution() %}
+```phel
+{1 "hello"}
+```
+{% end %}
+
+{% question() %}
+Use `def` to define a variable `my-map` that refers to the map `{1 2}`.
+Use the `put` function to add a new key and value to `my-map`.
+What does the `put` call return?
+What is the value of `my-map` after the call?
+{% end %}
+{% solution() %}
+```phel
+(def my-map {1 2})
+(put my-map 3 4)
+(def my-new-map (put my-map 5 6))
+```
+{% end %}
+
+{% question() %}
+Use `push` to add a value to a vector
+{% end %}
+{% solution() %}
+```phel
+(def vector8 [1 2])
+(def new-vector8 (push vector8 3))
+```
+{% end %}
+
+{% question() %}
+Use the function `get` to get the second element from a vector
+{% end %}
+{% solution() %}
+```phel
+(def vector9 [1 2])
+(get vector9 1)
+```
+{% end %}
+
+{% question() %}
+Use the function `get` to get the value of a key from a map
+{% end %}
+{% solution() %}
+```phel
+(def my-map {:k1 "v1" :k2 "v2"})
+(get my-map :k2)
+```
+{% end %}
+
+{% question() %}
+Get the value of a key from a map using the map itself as a function
+{% end %}
+{% solution() %}
+```phel
+(def my-map {:k1 "v1" :k2 "v2"})
+(my-map :k2)
+```
+{% end %}
+
+{% question() %}
+Get the value of a key from a map using a keyword as a function
+{% end %}
+{% solution() %}
+```phel
+(def my-map {:k1 "v1" :k2 "v2"})
+(:k2 my-map)
+```
+{% end %}
+
+{% question() %}
+Use the function `get-in` to return the value `:treasure` from the map:
+ ```phel
+{:description "cave"
+ :crossroads [{:contents :monster}
+              nil
+              {:contents [:trinket :treasure]}]}
+ ```
+{% end %}
+{% solution() %}
+```phel
+(def my-map {:description "cave"
+             :crossroads [{:contents :monster}
+                          nil
+                          {:contents [:trinket :treasure]}]})
+(get-in my-map [:crossroads 2 :contents 1])
+```
+{% end %}
+
+{% question() %}
+Use `defn` to define a function hello that works like this: 
+`(hello) ==> "hello!"`
+{% end %}
+{% solution() %}
+```phel
+(defn hello [] "hello!")
+```
+{% end %}
+
+{% question() %}
+Define a function double that works like this: `(double 5) ==> 10`
+{% end %}
+{% solution() %}
+```phel
+(defn double [n] (* n 2))
+```
+{% end %}
+
+{% question() %}
+Add a docstring to the function double. Then show it using `(doc double)`
+{% end %}
+{% solution() %}
+```phel
+(defn double
+  "It doubles the received number."
+  [n]
+  (* n 2))
+```
+{% end %}
+
+{% question() %}
+Implement a `factorial` function using recursion
+{% end %}
+{% solution() %}
+```phel
+(defn factorial [n]
+  (if (<= n 1)
+  n
+  (* n (factorial (dec n)))))
+```
 {% end %}

--- a/content/tutorials/exercises/basic.md
+++ b/content/tutorials/exercises/basic.md
@@ -1,0 +1,13 @@
++++
+title = "Basic syntax"
++++
+
+Compute `1+1`.
+{% solution() %}
+`(+ 1 1)`
+{% end %}
+
+Call the function `get` with arguments `"hello"` and `1`
+{% solution() %}
+`(get "hello" 1)`
+{% end %}

--- a/content/tutorials/exercises/conditionals-and-structures.md
+++ b/content/tutorials/exercises/conditionals-and-structures.md
@@ -1,0 +1,99 @@
++++
+title = "Conditionals & Structures"
+weight = 2
++++
+
+{% question() %}
+Use the `let` structure inside a function `f1` to define a local variable `b` with
+the value `"funcy"`. Then use the `str` function to combine two `b`s into `"funcyfuncy"`.
+{% end %}
+{% solution() %}
+```phel
+(defn f1 []
+  (let [b "funcy"]
+    (str b b)))
+(f1)
+```
+{% end %}
+
+{% question() %}
+Define a function `small?` that returns `true` for numbers under 100.
+{% end %}
+{% solution() %}
+```phel
+(defn small? [n] (< n 100))
+(small? 99)  # true
+(small? 100) # false
+```
+{% end %}
+
+{% question() %}
+Define a function `message` that has three cases:
+```phel
+(message :boink) # -> "Boink!"
+(message :pig)   # -> "oink"
+(message :ping)  # -> "pong"
+```
+{% end %}
+{% solution() %}
+```phel
+(defn message [k]
+  (let [m {:boink "Boink!"
+           :pig "Oink!"
+           :ping "Pong"}]
+    (get m k)))
+```
+{% end %}
+
+{% question() %}
+Reimplement `message` using the `if` structure.
+{% end %}
+{% solution() %}
+```phel
+(defn message [k]
+  (if (= k :boink)
+    "Boink!"
+    (if (= k :pig)
+      "Oink!"
+      (if (= k :ping)
+        "Pong!"))))
+```
+{% end %}
+
+{% question() %}
+Reimplement `message` using the `cond` structure.
+{% end %}
+{% solution() %}
+```phel
+(defn message [k]
+  (cond
+    (= k :boink) "Boink!"
+    (= k :pig) "Oink!"
+    (= k :ping) "Pong!"))
+```
+{% end %}
+
+{% question() %}
+Reimplement `message` using the `case` structure.
+{% end %}
+{% solution() %}
+```phel
+(defn message [k]
+  (case k
+    :boink "Boink!"
+    :pig "Oink!"
+    :ping "Pong!"))
+```
+{% end %}
+
+{% question() %}
+Use the `loop` structure to add `1` to an empty vector until it has 10 elements.
+{% end %}
+{% solution() %}
+```phel
+(loop [v []]
+  (if (= (count v) 10)
+       v
+       (recur (push v 1))))
+```
+{% end %}

--- a/content/tutorials/exercises/functional-programming.md
+++ b/content/tutorials/exercises/functional-programming.md
@@ -1,0 +1,71 @@
++++
+title = "Functional Programming?"
+weight = 3
++++
+
+{% question() %}
+Increment all the numbers in the vector `[4 7 9 10]` by one.
+Use the `map` function. Hint: the function `inc`.
+{% end %}
+{% solution() %}
+```phel
+(map (fn [x] (inc x)) [4 7 9 10])
+# or using the shorter form to define an anonymous function:
+(map |(inc $) [4 7 9 10])
+```
+{% end %}
+
+{% question() %}
+Do the same as in the previous exercise, but leave only the even results in the vector.
+Use the functions `filter` and `even?`
+{% end %}
+{% solution() %}
+```phel
+(filter even? (map |(inc $) [4 7 9 10]))
+```
+{% end %}
+
+{% question() %}
+Use the for structure to go through this vector of maps
+and return a sequence of the `:values`, aka this `[10.3 20.06 30.1]`
+```phel
+[{:id 1 :value 10.3} {:id 2 :value 20.06} {:id 7 :value 30.1}]
+```
+{% end %}
+{% solution() %}
+```phel
+(def data [{:id 1 :value 10.3} {:id 2 :value 20.06} {:id 7 :value 30.1}])
+(for [m :in data]
+  (m :value))
+```
+{% end %}
+
+{% question() %}
+Use the function `update-in` to change 3 into 4 in the value below:
+```phel
+{:shops [:shop-1]
+         :customers [{:id "Bob"
+                      :account {:balance 3}}]}
+```
+{% end %}
+{% solution() %}
+```phel
+(def data {:shops [:shop-1]
+           :customers [{:id "Bob"
+                        :account {:balance 3}}]})
+(update-in data [:customers 0 :account :balance] inc)
+```
+{% end %}
+
+{% question() %}
+Challenge! use the `reduce` function to combine a vector of maps like this:
+```
+(combine [{:a 1 :b 2} {:c 3} {:d 4 :e 5}])
+==> {:a 1 :b 2 :c 3 :d 4 :e 5}
+```
+{% end %}
+{% solution() %}
+```phel
+todo
+```
+{% end %}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -55,8 +55,8 @@ ul.api-index {
 }
 
 .solution {
-    input + label + div { display: none; }
-    input:checked + label + div { display: block; }
+    input + label + pre { display: none; }
+    input:checked + label + pre { display: block; }
 
     label {
         font-style: italic;

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -60,5 +60,11 @@ ul.api-index {
 
     label {
         font-style: italic;
+        cursor: pointer;
+        user-select: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
     }
 }

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -53,3 +53,12 @@ ul.api-index {
     font-style: italic;
     padding-left: 0.2em;
 }
+
+.solution {
+    input + label + div { display: none; }
+    input:checked + label + div { display: block; }
+
+    label {
+        font-style: italic;
+    }
+}

--- a/templates/shortcodes/question.html
+++ b/templates/shortcodes/question.html
@@ -1,0 +1,5 @@
+<div class="question" id="number-{{ nth }}">
+    {% set questionNumber = '<b>Question ' ~ nth ~ ': </b>' %}
+
+    {{ questionNumber  ~ body | markdown | safe }}
+</div>

--- a/templates/shortcodes/solution.html
+++ b/templates/shortcodes/solution.html
@@ -1,7 +1,6 @@
 <div class="solution">
     <input type='checkbox' style='display: none' id="cb{{nth}}">
     <label for="cb{{nth}}">Show solution</label>
-    <div>
+    <div class="preformatted">
         {{ body | markdown | safe }}
-    </div>
 </div>

--- a/templates/shortcodes/solution.html
+++ b/templates/shortcodes/solution.html
@@ -1,6 +1,5 @@
 <div class="solution">
-    <input type='checkbox' style='display: none' id="cb{{nth}}">
+    <input type="checkbox" style="display: none" id="cb{{nth}}">
     <label for="cb{{nth}}">Show solution</label>
-    <div class="preformatted">
-        {{ body | markdown | safe }}
+    {{ body | markdown | safe }}
 </div>

--- a/templates/shortcodes/solution.html
+++ b/templates/shortcodes/solution.html
@@ -1,0 +1,7 @@
+<div class="solution">
+    <input type='checkbox' style='display: none' id="cb{{nth}}">
+    <label for="cb{{nth}}">Show solution</label>
+    <div>
+        {{ body | markdown | safe }}
+    </div>
+</div>


### PR DESCRIPTION
Exercise Tutorial:

The current URL is: http://127.0.0.1:1111/tutorials/exercises/basic

### Added "Tutorials" to the left navbar

<img width="1007" alt="Screenshot 2021-08-19 at 09 42 16" src="https://user-images.githubusercontent.com/5256287/130028388-f2a30f70-35ea-4ed1-90fa-b28f08b99198.png">

### An example of a tutorial/exercise page

<img width="1164" alt="Screenshot 2021-08-19 at 09 43 01" src="https://user-images.githubusercontent.com/5256287/130028479-0259da08-7c53-46b4-ab4d-14e454f03569.png">

#### Important to consider!
I don't really like the tutorials/exercises in the documentation section BUT for now, it's not possible to add it somewhere else easily. We'll work on another design for the website, in the meanwhile, we could simply leave this new thing/tutorial in the navbar. I don't think it will be a problem, also it will be temporal.
