### PR TITLE
Fix some typos in doc

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -58,4 +58,4 @@ Phel requires PHP 8.0 or higher and Composer. Read the [Getting Started Guide](/
 
 ## Status of Development
 
-Phel is fairly complete but not marked as ready. We still want to envolve this language without thinking to much about breaking changes. Maybe some of you are willing to test it out and give feedback.
+Phel is fairly complete but not marked as ready. We still want to evolve this language without thinking too much about breaking changes. Maybe some of you are willing to test it out and give feedback.

--- a/content/blog/functional-programming-in-php.md
+++ b/content/blog/functional-programming-in-php.md
@@ -4,7 +4,7 @@ template = "blog-entry.html"
 date = "2020-06-05"
 +++
 
-PHP was one of my first languages I learned. Even so, this dates back over 10 years, I still use PHP every day at work. However, in the meantime I also learned a lot of other languages like Java, Clojure, Scala, Python, Javascript and Scheme. By learning all the languages and their concepts, the concept of functional programming always was my favorite and so I tried to make my PHP programming style more functional. In the following article you can read some approaches I tried.
+PHP was one of my first languages I learned. Even so, this dates back over 10 years, I still use PHP every day at work. However, in the meantime I also learned a lot of other languages like Java, Clojure, Scala, Python, Javascript and Scheme. By learning all the languages and their concepts, the concept of functional programming always was my favorite, and so I tried to make my PHP programming style more functional. In the following article you can read some approaches I tried.
 
 ## Functions as arguments
 
@@ -18,7 +18,7 @@ function inc($number) {
 }
 ```
 
-However, one of the most common things you do in functional programming is to pass a function as argument to another function. If you try that, PHP will response to you with an error message.
+However, one of the most common things you do in functional programming is to pass a function as argument to another function. If you try that, PHP will respond to you with an error message.
 
 ```php
 <?php
@@ -129,7 +129,7 @@ class MyProgram {
 }
 ```
 
-A big disadvantage of this approach is, that we have to resolve all conflicting function names ourself. Not only for public methods but also for private methods. This becomes next to impossible if the program grows.
+A big disadvantage of this approach is, that we have to resolve all conflicting function names ourselves. Not only for public methods but also for private methods. This becomes next to impossible if the program grows.
 
 A combination of the class module approach and the trait module approach would be a good solution to get started with functional programming in PHP. However, the trick with the magic method `_get` cannot be used for the class module approach, since PHP has no magic method for static properties.
 
@@ -139,4 +139,4 @@ One last alternative is to use a language that is functional and compiles to PHP
 
 ## Introducing Phel
 
-Since I didn't found a good solution for this problem, I used my coronavirus spare time to solve it by myself. This is what turns out to be Phel. Phel is a functional programming language that compiles to PHP. It is a dialect of Lisp inspired by [Clojure](https://clojure.org/) and [Janet](https://janet-lang.org/). While the status of Phel is currently alpha, it is fairly complete. If you want to try it, go ahead and read the [Getting started guide](/documentation/getting-started/). I'm looking for your feedback.
+Since I didn't find a good solution for this problem, I used my coronavirus spare time to solve it by myself. This is what turns out to be Phel. Phel is a functional programming language that compiles to PHP. It is a dialect of Lisp inspired by [Clojure](https://clojure.org/) and [Janet](https://janet-lang.org/). While the status of Phel is currently alpha, it is fairly complete. If you want to try it, go ahead and read the [Getting started guide](/documentation/getting-started/). I'm looking for your feedback.

--- a/content/blog/release-0.2.md
+++ b/content/blog/release-0.2.md
@@ -3,4 +3,4 @@ title = "Release: v0.2.0"
 date = "2021-02-22"
 +++
 
-With this release it is possible to call Phel functions from PHP. Additionally it is possible to set PHP object properties from Phel.
+With this release it is possible to call Phel functions from PHP. Additionally, it is possible to set PHP object properties from Phel.

--- a/content/blog/release-0.3.md
+++ b/content/blog/release-0.3.md
@@ -3,7 +3,7 @@ title = "Release: v0.3.0"
 date = "2021-05-12"
 +++
 
-The third release of Phel make big improvent in the data structure. Phel now uses persistent data structures. The old data structures are marked as deprecated and will be removed in future versions.
+The third release of Phel make big improvement in the data structure. Phel now uses persistent data structures. The old data structures are marked as deprecated and will be removed in future versions.
 
 Other changes:
 - Rename fmt command to format

--- a/content/blog/release-0.4.md
+++ b/content/blog/release-0.4.md
@@ -3,4 +3,4 @@ title = "Release: v0.4.0"
 date = "2021-10-05"
 +++
 
-In the forth release of Phel a lot of changes happened to the machine room of Phel. The way Phel compiles code has changed from a buttom up approach to a top down approach.
+In the forth release of Phel a lot of changes happened to the machine room of Phel. The way Phel compiles code has changed from a bottom up approach to a top-down approach.

--- a/content/blog/release-0.6.md
+++ b/content/blog/release-0.6.md
@@ -47,4 +47,4 @@ Finally, a new function was added to the core library. The `coerce-in` function 
 (coerce-in -0.5 0 1) # evaluates to 0
 ```
 
-All other changes can be found the in the [Changlog](https://github.com/phel-lang/phel-lang/blob/master/Changelog.md)
+All other changes can be found the in the [Changelog](https://github.com/phel-lang/phel-lang/blob/master/Changelog.md)

--- a/content/documentation/basic-types.md
+++ b/content/documentation/basic-types.md
@@ -67,7 +67,7 @@ float numbers the reader also supports binary, octal and hexadecimal number form
 
 ## Strings
 
-Strings are surrounded by double quotes. They almost work the same as PHP double quoted strings. One difference is that the dollar sign (`$`) must not be escaped. Internally Phel strings are represented by PHP strings. Therefore, every PHP string function can be used to operate on the string.
+Strings are surrounded by double quotes. They almost work the same as PHP double-quoted strings. One difference is that the dollar sign (`$`) must not be escaped. Internally Phel strings are represented by PHP strings. Therefore, every PHP string function can be used to operate on the string.
 
 String can be written in multiple lines. The line break character is then ignored by the reader.
 

--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -40,7 +40,7 @@ A list of directories in which the test files are located.
 
 ### `vendor-dir`
 
-The name of the compsoer vendor directory. Default is `vendor`.
+The name of the composer vendor directory. Default is `vendor`.
 
 ### `export`
 

--- a/content/documentation/control-flow.md
+++ b/content/documentation/control-flow.md
@@ -108,7 +108,7 @@ The `foreach` special form can be used to iterate over all kind of PHP datastruc
 
 ## For
 
-A more powerful loop functionality is provided by the `for` loop. The `for` loop is a elegant way to define and create arrays based on existing collections. It combines the functionality of `foreach`, `let` and `if` in one call.
+A more powerful loop functionality is provided by the `for` loop. The `for` loop is an elegant way to define and create arrays based on existing collections. It combines the functionality of `foreach`, `let` and `if` in one call.
 
 ```phel
 (for head body+)

--- a/content/documentation/data-structures.md
+++ b/content/documentation/data-structures.md
@@ -9,7 +9,7 @@ Phel has four main data structures. All data structures are persistent data stru
 
 A persistent list is simple a linked list. Access or modifications on the first element is efficient, random access is not. In Phel, a list has a special meaning. They are interpreted as function calls, macro calls or special forms by the compiler.
 
-To create a list surrond the white space separeted values with parentheses or use the `list` function.
+To create a list surround the white space separated values with parentheses or use the `list` function.
 
 ```phel
 (do 1 2 3) # list with 4 entries
@@ -54,7 +54,7 @@ To create a vector wrap the white space seperated values with brackets or use th
 (vector 1 2 3) # Creates a new vector with three values
 ```
 
-To get a value by it's index use the `get` function. Similar to list you can use the `first` and `second` function to access the first or second values of the vector.
+To get a value by its index use the `get` function. Similar to list you can use the `first` and `second` function to access the first or second values of the vector.
 
 ```phel
 (get [1 2 3] 0) # Evaluates to 1
@@ -68,7 +68,7 @@ New values can be appended by using the `push` function.
 (push [1 2 3] 4) # Evaluates to [1 2 3 4]
 ```
 
-To change an exsting value use the `put` function
+To change an existing value use the `put` function
 
 ```phel
 (put [1 2 3] 0 4) # Evaluates to [4 2 3]
@@ -93,7 +93,7 @@ To create a map wrap the key and values in curly brackets or use the `hash-map` 
 (hash-map :key1 value1 :key2 value2) # Create a new map using the hash-map function
 ```
 
-Use the `get` function to access a value by it's key
+Use the `get` function to access a value by its key
 
 ```phel
 (get {:a 1 :b 2} :a) # Evaluates to 1
@@ -133,7 +133,7 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
   (put x :a 12) # Evaluates to (my-struct 12 2 3)
 ```
 
-Internally, Phel Structs are PHP classes where each key correspondence to a object property. Therefore, Structs can be faster than Maps.
+Internally, Phel Structs are PHP classes where each key correspondence to an object property. Therefore, Structs can be faster than Maps.
 
 ## Sets
 
@@ -197,7 +197,7 @@ The symmetric difference of two sets or more is the set of elements which are in
 
 ## Transients
 
-Nearly all persistent data structures have a transient version (except for Persistent List). The transient version of each persistent data structure is a mutable version of them. It store the value in the same way as the persistent version but instead of returning a new persistent version with every modification it modifies the current version. Transient versions are a little bit faster and can be used as builders for new persistent collections. Since transients use the same underlying storage it is very fast to convert a persistent data structure to a transient and back.
+Nearly all persistent data structures have a transient version (except for Persistent List). The transient version of each persistent data structure is a mutable version of them. It stores the value in the same way as the persistent version but instead of returning a new persistent version with every modification it modifies the current version. Transient versions are a bit faster and can be used as builders for new persistent collections. Since transients use the same underlying storage it is very fast to convert a persistent data structure to a transient and back.
 
 For example, if we want to convert a PHP Array to a persistent map. This function can be used:
 

--- a/content/documentation/functions-and-recursion.md
+++ b/content/documentation/functions-and-recursion.md
@@ -11,7 +11,7 @@ weight = 7
 
 Defines a function. A function consists of a list of parameters and a list of expression. The value of the last expression is returned as the result of the function. All other expression are only evaluated for side effects. If no expression is given, the function returns `nil`.
 
-Function also introduce a new lexical scope that is not accessible outside of the function.
+Function also introduce a new lexical scope that is not accessible outside the function.
 
 ```phel
 (fn []) # Function with no arguments that returns nil
@@ -20,7 +20,7 @@ Function also introduce a new lexical scope that is not accessible outside of th
 (fn [a b] (+ a b)) # A function that returns the sum of a and b
 ```
 
-Function can also be defined as variadic function with an infite amount of arguments using the `&` separator.
+Function can also be defined as variadic function with an infinite amount of arguments using the `&` separator.
 
 ```phel
 (fn [& args] (count args)) # A variadic function that counts the arguments

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -9,7 +9,7 @@ Phel requires PHP 8.0 or higher and [Composer](https://getcomposer.org/).
 
 ## Quick start
 
-To get started right away the [Scaffolding project on Github](https://github.com/phel-lang/phel-scaffolding) can be used.
+To get started right away the [Scaffolding project on GitHub](https://github.com/phel-lang/phel-scaffolding) can be used.
 
 ```bash
 git clone https://github.com/phel-lang/phel-scaffolding.git

--- a/content/documentation/http-request-and-response.md
+++ b/content/documentation/http-request-and-response.md
@@ -5,7 +5,7 @@ weight = 15
 
 ## HTTP Request
 
-Phel provides an easy method to access the current HTTP request. While in PHP the request is distribute in different globals variables (`$_GET`, `$_POST`, `$_SERVER`, `$_COOKIES` and `$_FILES`) Phel normalizes them into a single struct. All functions and structs are defined in the `phel\http` module.
+Phel provides an easy method to access the current HTTP request. While in PHP the request is distributed in different globals variables (`$_GET`, `$_POST`, `$_SERVER`, `$_COOKIES` and `$_FILES`) Phel normalizes them into a single struct. All functions and structs are defined in the `phel\http` module.
 
 The request struct is defined like this:
 

--- a/content/documentation/in-the-wild.md
+++ b/content/documentation/in-the-wild.md
@@ -3,7 +3,7 @@ title = "In the wild"
 weight = 120
 +++
 
-This page contains a list of libraries and projects that use Phel. If you want to add your project/library to this page please create a Pull Request on Github.
+This page contains a list of libraries and projects that use Phel. If you want to add your project/library to this page please create a Pull Request on GitHub.
 
 ## Libraries
 

--- a/content/documentation/macros.md
+++ b/content/documentation/macros.md
@@ -25,7 +25,7 @@ The quote operator is a special form, it returns its argument without evaluating
 (quote my-sym) # Evaluates to my-sym
 'my-sym # Shorthand for (same as above)
 ```
-Quote make macros possible, since its helps to distinguish between code and data. Literals like numbers and string evaluate to themself.
+Quote make macros possible, since its helps to distinguish between code and data. Literals like numbers and string evaluate to themselves.
 
 ```phel
 (quote 1) # Evaluates to 1

--- a/content/documentation/namespaces.md
+++ b/content/documentation/namespaces.md
@@ -101,7 +101,7 @@ In some cases it is necessary to load external PHP file via PHP's `require_once`
   (:require-file "vendor/autoload.php"))
 ```
 
-As alternative you can also call `(php/require_once "vendor/autload.php")` anywhere in your code. However, especially for the autload file this statement is executed to late, because Phel's core library needs to load PHP files via the autoloader. Therefore, it is recommended to use the `:require-file` method.
+As alternative, you can also call `(php/require_once "vendor/autload.php")` anywhere in your code. However, especially for the autoload file this statement is executed to late, because Phel's core library needs to load PHP files via the autoloader. Therefore, it is recommended to use the `:require-file` method.
 
 ## Namespaced keywords
 

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -191,7 +191,7 @@ return [
 
 A detailed description of the options can be found in the [Configuration](/documentation/configuration/#export) chapter.
 
-To mark a function as exported the following meta data needs to be added to the function:
+To mark a function as exported the following metadata needs to be added to the function:
 
 ```phel
 (defn my-function

--- a/content/documentation/repl.md
+++ b/content/documentation/repl.md
@@ -64,7 +64,7 @@ phel:3>
 
 ### use
 
-The `use` function can be used to add a alias for a PHP class. The arguments are the same as the `:use` statement in the `ns` function.
+The `use` function can be used to add an alias for a PHP class. The arguments are the same as the `:use` statement in the `ns` function.
 ```bash
 phel:1> (use \Phel\Lang\Symbol :as PhelSymbol)
 \Phel\Lang\Symbol

--- a/content/documentation/testing.md
+++ b/content/documentation/testing.md
@@ -7,7 +7,7 @@ Phel comes with an integrated unit testing framework.
 
 ## Assertions
 
-The core of the libray is the `is` macro, which can be used to defined assertions.
+The core of the library is the `is` macro, which can be used to defined assertions.
 
 ```phel
 (is (= 4 (+ 2 2)) "my test description")
@@ -75,7 +75,7 @@ Test can be defined by using the `deftest` macro. This macro is like a function 
 
 Tests can be run using the `./vendor/bin/phel test` command. Therefore, the `test` configuration entry must be set (see [Configuration](/documentation/configuration/)).
 
-I can use want to run the test manually on your own, the `run-tests` function can be used.  As arguments it takes a list of namespaces that should be tested.
+I can use want to run the test manually on your own, the `run-tests` function can be used. As arguments, it takes a list of namespaces that should be tested.
 
 ```phel
 (run-tests 'my\ns\a 'my\ns\b)

--- a/content/documentation/truth-and-boolean-operations.md
+++ b/content/documentation/truth-and-boolean-operations.md
@@ -3,7 +3,7 @@ title = "Truth and Boolean operations"
 weight = 4
 +++
 
-Phel has a different concept of truthniss. In Phel only `false` and `nil` represent falsity. Everything else evaluates to true. The function `truthy?` can be used to check if a value is truthy. To check for the values `true` and `false` the functions `true?` and `false?` can be used.
+Phel has a different concept of truthiness. In Phel only `false` and `nil` represent falsity. Everything else evaluates to true. The function `truthy?` can be used to check if a value is truthy. To check for the values `true` and `false` the functions `true?` and `false?` can be used.
 
 ```phel
 (truthy? false) # Evaluates to false
@@ -38,7 +38,7 @@ The function `id` returns `true` if two values are identical. Identical is stric
 (id {} {}) # Evaluates to false
 ```
 
-To check if to two values are equal the equal function (`=`) can be used. Two values are equal if they have the same type and value. Lists, Vectors, Maps and Sets are equal if they have same values but they must not point to the same reference.
+To check if to two values are equal the equal function (`=`) can be used. Two values are equal if they have the same type and value. Lists, Vectors, Maps and Sets are equal if they have same values, but they must not point to the same reference.
 
 ```phel
 (= true true) # Evaluates to true


### PR DESCRIPTION
# 📚 Description

I found some typos, so, I checked all documentation to catch them all 🐭 

![pokemon](https://img.search.brave.com/sbntrySMMFx4p5hYdiBMk5ptGSH_Q6BVnSMV4HHZ4cs/rs:fit:1200:342:1/g:ce/aHR0cHM6Ly8yMmRh/a2lrYS5vcmcvd3At/Y29udGVudC91cGxv/YWRzLzIwMTYvMDEv/Q2F0Y2gtZW0tQWxs/LnBuZw)