### PR TITLE
Add next/previous links to the blog

### DIFF
--- a/sass/_site-navigation.scss
+++ b/sass/_site-navigation.scss
@@ -5,19 +5,18 @@
 }
 
 .related-container {
-  margin-top: 3rem;
-  margin-bottom: 4rem;
-  display: flex;
+  border: 1px solid $color-gray-base;
+  margin: 4rem 0 4rem 0;
+  float-displace: unset;
   text-align: center;
 
   .link {
-    flex-shrink: 0;
-    padding: 1rem;
-    box-sizing: border-box;
-    width: 50%;
-
-    span {
-      display: block;
-    }
+    padding: .4rem;
+  }
+  .link-previous {
+    float: left;
+  }
+  .link-next {
+    float: right;
   }
 }

--- a/sass/_site-navigation.scss
+++ b/sass/_site-navigation.scss
@@ -1,6 +1,23 @@
 .site-navigation {
+  li.active {
+    font-weight: bold;
+  }
+}
 
-    li.active {
-        font-weight: bold;
+.related-container {
+  margin-top: 3rem;
+  margin-bottom: 4rem;
+  display: flex;
+  text-align: center;
+
+  .link {
+    flex-shrink: 0;
+    padding: 1rem;
+    box-sizing: border-box;
+    width: 50%;
+
+    span {
+      display: block;
     }
+  }
 }

--- a/templates/blog-entry.html
+++ b/templates/blog-entry.html
@@ -11,5 +11,21 @@
       <div class="meta">Published <time datetime="{{page.date}}">{{ page.date | date(format="%b, %e %Y") }}</time></div>
     {% endif %}
     {{page.content | safe}}
+
+    <div class="related-container">
+      {% if page.earlier %}
+      <div class="link">
+        <span>Previous</span>
+        <a href="{{ page.earlier.permalink }}">{{ page.earlier.title }}</a>
+      </div>
+      {% endif %}
+
+      {% if page.later %}
+      <div class="link">
+        <span>Next</span>
+        <a href="{{ page.later.permalink }}">{{ page.later.title }}</a>
+      </div>
+      {% endif %}
+    </div>
   </div>
 {% endblock content %}

--- a/templates/blog-entry.html
+++ b/templates/blog-entry.html
@@ -14,16 +14,16 @@
 
     <div class="related-container">
       {% if page.earlier %}
-      <div class="link">
-        <span>Previous</span>
+      <div class="link link-previous">
+        <span>&larr;</span>
         <a href="{{ page.earlier.permalink }}">{{ page.earlier.title }}</a>
       </div>
       {% endif %}
 
       {% if page.later %}
-      <div class="link">
-        <span>Next</span>
+      <div class="link link-next">
         <a href="{{ page.later.permalink }}">{{ page.later.title }}</a>
+        <span>&rarr;</span>
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## 📚  Description

Related to: https://github.com/phel-lang/phel-lang.org/issues/33

## 🔖 Changes

- Add Previous and Next blog posts at the footer of blog-entry

## 🖼️  Screenshots

First blog post
<img width="946" alt="Screenshot 2022-04-08 at 14 44 32" src="https://user-images.githubusercontent.com/5256287/162438046-eb828437-6e7e-4202-8ca8-ddf9bfcf720c.png">

Random blog post in the middle
<img width="936" alt="Screenshot 2022-04-08 at 14 45 03" src="https://user-images.githubusercontent.com/5256287/162438129-b098f438-07f5-4166-bb7f-7041d3c72f23.png">

Last blog post
<img width="917" alt="Screenshot 2022-04-08 at 14 45 16" src="https://user-images.githubusercontent.com/5256287/162438158-ed5ccbbf-b5cc-41fc-acdc-f4b930f63e67.png">