### PR TITLE
getting-started.md: Add link to ILT Emacs

### DIFF
--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -159,3 +159,5 @@ To try Phel you can run a REPL by executing the `./vendor/bin/phel repl` command
 ## Editor support
 
 Phel comes with basic editor support for VSCode. Please check out the [plugin's README file](https://github.com/phel-lang/phel-vs-code-extension) for more information.
+
+There's also an [Emacs mode with interactive capabilities](https://codeberg.org/mmontone/interactive-lang-tools/src/branch/master/backends/phel) in the making.


### PR DESCRIPTION
Add link to Emacs mode for Phel: https://codeberg.org/mmontone/interactive-lang-tools/src/branch/master/backends/phel