### PR TITLE
Add phpstorm to editor support

### DIFF
--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -158,6 +158,7 @@ To try Phel you can run a REPL by executing the `./vendor/bin/phel repl` command
 
 ## Editor support
 
-Phel comes with basic editor support for VSCode. Please check out the [plugin's README file](https://github.com/phel-lang/phel-vs-code-extension) for more information.
-
-There's also an [Emacs mode with interactive capabilities](https://codeberg.org/mmontone/interactive-lang-tools/src/branch/master/backends/phel) in the making.
+Phel comes with basic support for <a href="https://github.com/phel-lang/phel-vs-code-extension" target="_blank">
+VSCode</a>, <a href="https://github.com/phel-lang/phel-phpstorm-syntax" target="_blank">PhpStorm</a>
+and a <a href="https://codeberg.org/mmontone/interactive-lang-tools/src/branch/master/backends/phel" target="_blank">
+Emacs mode with interactive capabilities</a> in the making.

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
   <meta property="og:image:height" content="512" />
 
   {% block rss %}
-  <link rel="alternate" type="application/atom+xml" title="Blog" href="{{ get_url(path="atom.xml", trailing_slash=false) }}">
+  <link rel="alternate" type="application/atom+xml" title="Blog" href="{{ get_url(path='atom.xml', trailing_slash=false) }}">
   {% endblock %}
 </head>
 

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -16,7 +16,7 @@
                 {% set doc_section = get_section(path="documentation/_index.md") %}
                 {% for page in doc_section.pages %}
                     <li class="{% if current_path == page.path %}active{% endif %}">
-                        <a href="{{page.permalink}}">{{page.title}}</a>
+                        <a href="{{ page.permalink }}">{{page.title}}</a>
                     </li>
                 {% endfor %}
             </ol>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,4 +1,4 @@
 <footer>
     &copy; <time datetime="{{now() | date(format='%Y')}}">2020-{{now() | date(format="%Y")}}</time> Jens Haase
-    <a href="{{ get_url(path="@/legal/disclosure.md") }}">Legal Disclosure</a> | <a href="{{ get_url(path="@/legal/data-protection.md") }}">Data protection</a>
+    <a href="{{ get_url(path='@/legal/disclosure.md') }}">Legal Disclosure</a> | <a href="{{ get_url(path='@/legal/data-protection.md') }}">Data protection</a>
 </footer>

--- a/templates/logo.html
+++ b/templates/logo.html
@@ -1,3 +1,7 @@
 <a href="/">
-    <svg class="phel-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200.3 167.7"><path d="M6 66l95 96h36V93l-36-74H42L6 56v106h36l24-35"/><path d="M137 93l58-3-12-58-32-26h-34l-16 13-23 9-12 22 46 52z"/><path d="M195 90l-12 57h-13l-2-56M170 147l-13-11h12"/></svg>
+  <svg class="phel-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200.3 167.7">
+    <path d="M6 66l95 96h36V93l-36-74H42L6 56v106h36l24-35"/>
+    <path d="M137 93l58-3-12-58-32-26h-34l-16 13-23 9-12 22 46 52z"/>
+    <path d="M195 90l-12 57h-13l-2-56M170 147l-13-11h12"/>
+  </svg>
 </a>

--- a/templates/navigation/site-navigation.html
+++ b/templates/navigation/site-navigation.html
@@ -3,7 +3,7 @@
         {% set doc_section = get_section(path=page.ancestors | reverse | first) %}
         {% for page in doc_section.pages %}
             <li class="site-navigation__entry {% if current_path == page.path %}active{% endif %}">
-                <a href="{{page.permalink}}">{{page.title}}</a>
+                <a href="{{ page.permalink }}">{{page.title}}</a>
             </li>
         {% endfor %}
     {% endif %}

--- a/templates/page-api.html
+++ b/templates/page-api.html
@@ -10,7 +10,7 @@
     <ul class="api-index">
     {% for h1 in page.toc %}
         <li>
-            <a href="{{h1.permalink | safe}}">{{ h1.title }}</a>
+            <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
         </li>
     {% endfor %}
     </ul>

--- a/templates/shortcodes/solution.html
+++ b/templates/shortcodes/solution.html
@@ -1,5 +1,5 @@
 <div class="solution">
-    <input type="checkbox" style="display: none" id="cb{{nth}}">
-    <label for="cb{{nth}}">&rarr; Show solution</label>
+    <input type="checkbox" style="display: none" id="cb{{ nth }}">
+    <label for="cb{{ nth }}">&rarr; Show solution</label>
     {{ body | markdown | safe }}
 </div>


### PR DESCRIPTION
# 📚 Description

Update in `getting started` page the section `Editor support` with `PhpStorm`, also, I replaced the basic `[text](url)` to an HTML `<a href="url" target="_blank">text</a>` in order to add the target attribute, this is done because those links are redirecting the user to an external page.

Also, minor changes like adding some empty spaces or replacing double with single quotes (all content and links still working as before) ✅ 