### PR TITLE
Fix underline menu item

### DIFF
--- a/templates/navigation/top-navigation.html
+++ b/templates/navigation/top-navigation.html
@@ -2,13 +2,13 @@
     <li class="top-navigation__item {% if current_path and current_path == '/' %}active{% endif %}">
         <a href="/">Features</a>
     </li>
-    <li class="top-navigation__item {% if current_path and current_path == '/documentation/getting-started/' %}active{% endif %}">
+    <li class="top-navigation__item {% if current_path and current_path is starting_with('/documentation/') %}active{% endif %}">
         <a href="/documentation/getting-started/">Docs</a>
     </li>
-    <li class="top-navigation__item {% if current_path and current_path == '/tutorials/exercises/basic/' %}active{% endif %}">
+    <li class="top-navigation__item {% if current_path and current_path is starting_with('/tutorials/exercises/') %}active{% endif %}">
         <a href="/tutorials/exercises/basic">Exercises</a>
     </li>
-    <li class="top-navigation__item {% if current_path and current_path == '/blog/' %}active{% endif %}">
+    <li class="top-navigation__item {% if current_path and current_path is starting_with('/blog/') %}active{% endif %}">
         <a href="/blog">Blog</a>
     </li>
     <li class="top-navigation__item top-navigation__item--github">


### PR DESCRIPTION
## 📚 Description

Currently we lose the underline context if you navigate to another section/page from the current menu.

Zola uses the [Tera](https://tera.netlify.com/) template engine, and I found in its docs that you can [check if a string is starting with another string](https://tera.netlify.app/docs/#starting-with), among many other things. And that solves the current issue that we have in the menu.


## 🖼️ Screenshots

### BEFORE

Notice the "Docs" is **not** underlined.

<img width="970" alt="Screenshot 2023-01-22 at 15 04 08" src="https://user-images.githubusercontent.com/5256287/213919911-cafb36d7-01d0-438c-b1b0-b1d905383da4.png">


### AFTER
Notice the "Docs" **is** underlined.
<img width="980" alt="Screenshot 2023-01-22 at 15 03 55" src="https://user-images.githubusercontent.com/5256287/213919900-5bb7b513-77d7-4b15-b4ff-e620541cf670.png">


