### PR TITLE
Use the new ApiFacade

### DIFF
--- a/build/src/php/FileGenerator/Domain/ApiMarkdownGenerator.php
+++ b/build/src/php/FileGenerator/Domain/ApiMarkdownGenerator.php
@@ -17,13 +17,11 @@ final class ApiMarkdownGenerator
     public function generate(): array
     {
         $result = $this->zolaHeaders();
-        $groupedPhelFns = $this->repository->getAllGroupedFunctions();
+        $groupedPhelFns = $this->repository->getAllPhelFunctions();
 
-        foreach ($groupedPhelFns as $phelFunctions) {
-            foreach ($phelFunctions as $fn) {
-                $result[] = "## `{$fn->fnName()}`";
-                $result[] = $fn->doc();
-            }
+        foreach ($groupedPhelFns as $fn) {
+            $result[] = "## `{$fn->fnName()}`";
+            $result[] = $fn->doc();
         }
 
         return $result;

--- a/build/src/php/FileGenerator/Domain/ApiSearchGenerator.php
+++ b/build/src/php/FileGenerator/Domain/ApiSearchGenerator.php
@@ -34,29 +34,28 @@ final class ApiSearchGenerator
          */
         $groupFnNameAppearances = [];
         $result = [];
-        $groupedPhelFns = $this->repository->getAllGroupedFunctions();
+        $groupedPhelFns = $this->repository->getAllPhelFunctions();
 
-        foreach ($groupedPhelFns as $groupKey => $phelFns) {
-            $groupFnNameAppearances[$groupKey] = 0;
-
-            foreach ($phelFns as $fn) {
-                $fnName = $fn->fnName();
-
-                if ($groupFnNameAppearances[$groupKey] === 0) {
-                    $anchor = $groupKey;
-                    $groupFnNameAppearances[$groupKey]++;
-                } else {
-                    $sanitizedFnName = str_replace(['/', ...self::SPECIAL_ENDING_CHARS], ['-', ''], $fnName);
-                    $anchor = rtrim($sanitizedFnName, '-') . '-' . $groupFnNameAppearances[$groupKey]++;
-                }
-
-                $result[] = [
-                    'fnName' => $fn->fnName(),
-                    'fnSignature' => $fn->fnSignature(),
-                    'desc' => $this->formatDescription($fn->description()),
-                    'anchor' => $anchor,
-                ];
+        foreach ($groupedPhelFns as $fn) {
+            $groupKey = $fn->groupKey();
+            if (!isset($groupFnNameAppearances[$groupKey])) {
+                $groupFnNameAppearances[$groupKey] = 0;
             }
+
+            if ($groupFnNameAppearances[$groupKey] === 0) {
+                $anchor = $groupKey;
+                $groupFnNameAppearances[$groupKey]++;
+            } else {
+                $sanitizedFnName = str_replace(['/', ...self::SPECIAL_ENDING_CHARS], ['-', ''], $fn->fnName());
+                $anchor = rtrim($sanitizedFnName, '-') . '-' . $groupFnNameAppearances[$groupKey]++;
+            }
+
+            $result[] = [
+                'fnName' => $fn->fnName(),
+                'fnSignature' => $fn->fnSignature(),
+                'desc' => $this->formatDescription($fn->description()),
+                'anchor' => $anchor,
+            ];
         }
 
         return $result;

--- a/build/src/php/FileGenerator/Domain/ApiSearchGenerator.php
+++ b/build/src/php/FileGenerator/Domain/ApiSearchGenerator.php
@@ -38,9 +38,7 @@ final class ApiSearchGenerator
 
         foreach ($groupedPhelFns as $fn) {
             $groupKey = $fn->groupKey();
-            if (!isset($groupFnNameAppearances[$groupKey])) {
-                $groupFnNameAppearances[$groupKey] = 0;
-            }
+            $groupFnNameAppearances[$groupKey] ??= 0;
 
             if ($groupFnNameAppearances[$groupKey] === 0) {
                 $anchor = $groupKey;

--- a/build/src/php/FileGenerator/Domain/PhelFunctionRepositoryInterface.php
+++ b/build/src/php/FileGenerator/Domain/PhelFunctionRepositoryInterface.php
@@ -9,7 +9,7 @@ use Phel\Api\Transfer\PhelFunction;
 interface PhelFunctionRepositoryInterface
 {
     /**
-     * @return array<string,list<PhelFunction>>
+     * @return list<PhelFunction>
      */
-    public function getAllGroupedFunctions(): array;
+    public function getAllPhelFunctions(): array;
 }

--- a/build/src/php/FileGenerator/Infrastructure/PhelFunctionRepository.php
+++ b/build/src/php/FileGenerator/Infrastructure/PhelFunctionRepository.php
@@ -17,10 +17,10 @@ final class PhelFunctionRepository implements PhelFunctionRepositoryInterface
     }
 
     /**
-     * @return array<string,list<PhelFunction>>
+     * @return list<PhelFunction>
      */
-    public function getAllGroupedFunctions(): array
+    public function getAllPhelFunctions(): array
     {
-        return $this->apiFacade->getGroupedFunctions($this->allNamespaces);
+        return $this->apiFacade->getPhelFunctions($this->allNamespaces);
     }
 }

--- a/build/tests/php/FileGenerator/Domain/ApiMarkdownGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Domain/ApiMarkdownGeneratorTest.php
@@ -33,14 +33,13 @@ final class ApiMarkdownGeneratorTest extends TestCase
     public function test_generate_page_with_one_phel_function(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'group-1' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'function-1',
-                        'doc' => 'The doc from function 1',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'function-1',
+                    'doc' => 'The doc from function 1',
+                    'groupKey' => 'group-1',
+                ]),
             ]);
 
         $generator = new ApiMarkdownGenerator($repository);
@@ -63,18 +62,16 @@ final class ApiMarkdownGeneratorTest extends TestCase
     public function test_generate_page_with_multiple_phel_functions_in_same_group(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'group-1' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'function-1',
-                        'doc' => 'The doc from function 1',
-                    ]),
-                    PhelFunction::fromArray([
-                        'fnName' => 'function-2',
-                        'doc' => 'The doc from function 2',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'function-1',
+                    'doc' => 'The doc from function 1',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'function-2',
+                    'doc' => 'The doc from function 2',
+                ]),
             ]);
 
         $generator = new ApiMarkdownGenerator($repository);
@@ -99,20 +96,16 @@ final class ApiMarkdownGeneratorTest extends TestCase
     public function test_generate_page_with_multiple_phel_functions_in_different_groups(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'group-1' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'function-1',
-                        'doc' => 'The doc from function 1',
-                    ]),
-                ],
-                'group-2' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'function-2',
-                        'doc' => 'The doc from function 2',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'function-1',
+                    'doc' => 'The doc from function 1',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'function-2',
+                    'doc' => 'The doc from function 2',
+                ]),
             ]);
 
         $generator = new ApiMarkdownGenerator($repository);

--- a/build/tests/php/FileGenerator/Domain/ApiSearchGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Domain/ApiSearchGeneratorTest.php
@@ -14,15 +14,14 @@ final class ApiSearchGeneratorTest extends TestCase
     public function test_generate_search_index_one_item(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'table' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'table?',
-                        'fnSignature' => '(table? x)',
-                        'desc' => 'doc for table?',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'table?',
+                    'fnSignature' => '(table? x)',
+                    'desc' => 'doc for table?',
+                    'groupKey' => 'table'
+                ]),
             ]);
 
         $generator = new ApiSearchGenerator($repository);
@@ -43,22 +42,20 @@ final class ApiSearchGeneratorTest extends TestCase
     public function test_multiple_items_in_different_groups(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'table' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'table',
-                        'fnSignature' => '(table & xs)',
-                        'desc' => 'doc for table',
-                    ]),
-                ],
-                'not' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'not',
-                        'fnSignature' => '(not x)',
-                        'desc' => 'doc for not',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'table',
+                    'fnSignature' => '(table & xs)',
+                    'desc' => 'doc for table',
+                    'groupKey' => 'table',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'not',
+                    'fnSignature' => '(not x)',
+                    'desc' => 'doc for not',
+                    'groupKey' => 'not',
+                ]),
             ]);
 
         $generator = new ApiSearchGenerator($repository);
@@ -85,20 +82,20 @@ final class ApiSearchGeneratorTest extends TestCase
     public function test_multiple_items_in_the_same_group(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'table' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'table',
-                        'fnSignature' => '(table & xs)',
-                        'desc' => 'doc for table',
-                    ]),
-                    PhelFunction::fromArray([
-                        'fnName' => 'table?',
-                        'fnSignature' => '(table? x)',
-                        'desc' => 'doc for table?',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'table',
+                    'fnSignature' => '(table & xs)',
+                    'desc' => 'doc for table',
+                    'groupKey' => 'table',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'table?',
+                    'fnSignature' => '(table? x)',
+                    'desc' => 'doc for table?',
+                    'groupKey' => 'table',
+                ]),
             ]);
 
         $generator = new ApiSearchGenerator($repository);
@@ -125,20 +122,20 @@ final class ApiSearchGeneratorTest extends TestCase
     public function test_fn_name_with_slash_in_the_middle(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'http-response' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'http/response',
-                        'fnSignature' => '',
-                        'desc' => '',
-                    ]),
-                    PhelFunction::fromArray([
-                        'fnName' => 'http/response?',
-                        'fnSignature' => '',
-                        'desc' => '',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'http/response',
+                    'fnSignature' => '',
+                    'desc' => '',
+                    'groupKey' => 'http-response',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'http/response?',
+                    'fnSignature' => '',
+                    'desc' => '',
+                    'groupKey' => 'http-response-1',
+                ]),
             ]);
 
         $generator = new ApiSearchGenerator($repository);
@@ -165,20 +162,20 @@ final class ApiSearchGeneratorTest extends TestCase
     public function test_fn_name_ending_with_minus(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'defn' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'defn',
-                        'fnSignature' => '',
-                        'desc' => '',
-                    ]),
-                    PhelFunction::fromArray([
-                        'fnName' => 'defn-',
-                        'fnSignature' => '',
-                        'desc' => '',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'defn',
+                    'fnSignature' => '',
+                    'desc' => '',
+                    'groupKey' => 'defn',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'defn-',
+                    'fnSignature' => '',
+                    'desc' => '',
+                    'groupKey' => 'defn',
+                ]),
             ]);
 
         $generator = new ApiSearchGenerator($repository);
@@ -205,20 +202,20 @@ final class ApiSearchGeneratorTest extends TestCase
     public function test_fn_name_with_upper_case(): void
     {
         $repository = $this->createStub(PhelFunctionRepositoryInterface::class);
-        $repository->method('getAllGroupedFunctions')
+        $repository->method('getAllPhelFunctions')
             ->willReturn([
-                'nan' => [
-                    PhelFunction::fromArray([
-                        'fnName' => 'NAN',
-                        'fnSignature' => '',
-                        'desc' => '',
-                    ]),
-                    PhelFunction::fromArray([
-                        'fnName' => 'nan?',
-                        'fnSignature' => '',
-                        'desc' => '',
-                    ]),
-                ],
+                PhelFunction::fromArray([
+                    'fnName' => 'NAN',
+                    'fnSignature' => '',
+                    'desc' => '',
+                    'groupKey' => 'nan',
+                ]),
+                PhelFunction::fromArray([
+                    'fnName' => 'nan?',
+                    'fnSignature' => '',
+                    'desc' => '',
+                    'groupKey' => 'nan',
+                ]),
             ]);
 
         $generator = new ApiSearchGenerator($repository);

--- a/composer.lock
+++ b/composer.lock
@@ -90,12 +90,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "08fb32008d113542f2b2b41626836550ed642426"
+                "reference": "af27bfc9a790523de39dd246edba30263e796fe5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/08fb32008d113542f2b2b41626836550ed642426",
-                "reference": "08fb32008d113542f2b2b41626836550ed642426",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/af27bfc9a790523de39dd246edba30263e796fe5",
+                "reference": "af27bfc9a790523de39dd246edba30263e796fe5",
                 "shasum": ""
             },
             "require": {
@@ -106,14 +106,14 @@
             },
             "require-dev": {
                 "ext-readline": "*",
-                "friendsofphp/php-cs-fixer": "^3.13",
+                "friendsofphp/php-cs-fixer": "^3.14",
                 "phpbench/phpbench": "^1.2",
                 "phpmetrics/phpmetrics": "^2.8",
                 "phpstan/phpstan": "^1.9",
                 "phpunit/phpunit": "^9.5",
                 "psalm/plugin-phpunit": "^0.18",
                 "symfony/var-dumper": "^6.0",
-                "vimeo/psalm": "^5.4"
+                "vimeo/psalm": "^5.6"
             },
             "default-branch": true,
             "bin": [
@@ -147,7 +147,7 @@
                 "issues": "https://github.com/phel-lang/phel-lang/issues",
                 "source": "https://github.com/phel-lang/phel-lang/tree/master"
             },
-            "time": "2023-01-27T13:20:02+00:00"
+            "time": "2023-02-03T09:51:30+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1412,16 +1412,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "70fc8be1d0b9fad56a199a4df5f9cfabfc246f84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/70fc8be1d0b9fad56a199a4df5f9cfabfc246f84",
+                "reference": "70fc8be1d0b9fad56a199a4df5f9cfabfc246f84",
                 "shasum": ""
             },
             "require": {
@@ -1463,7 +1463,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1494,7 +1494,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.0"
             },
             "funding": [
                 {
@@ -1510,7 +1510,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-02-03T07:32:24+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -1518,12 +1518,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "85ea494f3599c1d23c81c65d0c994e0f80895a75"
+                "reference": "92f4424ad5419a427f950f7d1df1aae30b02687d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/85ea494f3599c1d23c81c65d0c994e0f80895a75",
-                "reference": "85ea494f3599c1d23c81c65d0c994e0f80895a75",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/92f4424ad5419a427f950f7d1df1aae30b02687d",
+                "reference": "92f4424ad5419a427f950f7d1df1aae30b02687d",
                 "shasum": ""
             },
             "conflict": {
@@ -1557,6 +1557,7 @@
                 "barryvdh/laravel-translation-manager": "<0.6.2",
                 "barzahlen/barzahlen-php": "<2.0.1",
                 "baserproject/basercms": "<4.7.2",
+                "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
                 "billz/raspap-webgui": "<=2.6.6",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
@@ -1613,7 +1614,7 @@
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
                 "dolibarr/dolibarr": "<16|>=16.0.1,<16.0.3|= 12.0.5|>= 3.3.beta1, < 13.0.2",
-                "dompdf/dompdf": "<2.0.1",
+                "dompdf/dompdf": "<2.0.2",
                 "drupal/core": ">=7,<7.91|>=8,<9.3.19|>=9.4,<9.4.3",
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
@@ -1667,7 +1668,7 @@
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "froala/wysiwyg-editor": "<3.2.7",
-                "froxlor/froxlor": "<2.0.8",
+                "froxlor/froxlor": "<2.0.10",
                 "fuel/core": "<1.8.1",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
@@ -1761,7 +1762,7 @@
                 "melisplatform/melis-front": "<5.0.1",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
                 "mgallegos/laravel-jqgrid": "<=1.3",
-                "microweber/microweber": "<=1.3.1",
+                "microweber/microweber": "<1.3.2",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
@@ -1827,7 +1828,7 @@
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "pimcore/data-hub": "<1.2.4",
-                "pimcore/pimcore": "<10.5.14",
+                "pimcore/pimcore": "<10.5.16",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<4.12.5|>= 4.0.0-BETA5, < 4.4.2",
                 "pressbooks/pressbooks": "<5.18",
@@ -1928,7 +1929,7 @@
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<=5.3.14|>=5.4.3,<=5.4.3|>=6.0.3,<=6.0.3|= 6.0.3|= 5.4.3|= 5.3.14",
                 "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
-                "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5|>=5.2,<5.3.12",
+                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
                 "symfony/mime": ">=4.3,<4.3.8",
@@ -1938,13 +1939,13 @@
                 "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/routing": ">=2,<2.0.19",
                 "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
-                "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11|>=5.3,<5.3.12",
+                "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
                 "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
                 "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
                 "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.3.2",
                 "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
-                "symfony/symfony": ">=2,<3.4.49|>=4,<4.4.35|>=5,<5.3.12|>=5.3.14,<=5.3.14|>=5.4.3,<=5.4.3|>=6.0.3,<=6.0.3",
+                "symfony/symfony": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
@@ -1989,6 +1990,7 @@
                 "vova07/yii2-fileapi-widget": "<0.1.9",
                 "vrana/adminer": "<4.8.1",
                 "wallabag/tcpdf": "<6.2.22",
+                "wallabag/wallabag": ">=2-alpha.1,<2.5.3",
                 "wanglelecc/laracms": "<=1.0.3",
                 "web-auth/webauthn-framework": ">=3.3,<3.3.4",
                 "webcoast/deferred-image-processing": "<1.0.2",
@@ -2000,7 +2002,7 @@
                 "wp-cli/wp-cli": "<2.5",
                 "wp-graphql/wp-graphql": "<0.3.5",
                 "wpanel/wpanel4-cms": "<=4.3.1",
-                "wwbn/avideo": "<=11.6",
+                "wwbn/avideo": "<12.4",
                 "xataface/xataface": "<3",
                 "yeswiki/yeswiki": "<4.1",
                 "yetiforce/yetiforce-crm": "<=6.4",
@@ -2078,7 +2080,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T20:04:06+00:00"
+            "time": "2023-02-03T01:33:09+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2446,16 +2448,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -2497,7 +2499,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2505,7 +2507,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2819,16 +2821,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -2867,10 +2869,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2878,7 +2880,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2937,16 +2939,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -2981,7 +2983,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -2989,7 +2991,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",


### PR DESCRIPTION
## 📚 Description

Related to https://github.com/phel-lang/phel-lang/pull/565#event-8430281922 we updated the ApiFacade; instead of "grouping the phelFunctions" from the `ApiFacade`, rather move that groupKey as a property of the `PhelFunction` and simplify the signature of the `ApiFacadeInterface`.


## 🔖 Changes

- Use the new `ApiFacade::getPhelFunctions()`

## 🖼️ Screenshots

The API page and Search logic are generated fine.

<img width="1306" alt="Screenshot 2023-02-03 at 11 17 44" src="https://user-images.githubusercontent.com/5256287/216574849-ebf93646-0851-48be-a07a-e18b1071741b.png">

