### PR TITLE
Rename compile by build in CLI commands section

### DIFF
--- a/content/documentation/cli-commands.md
+++ b/content/documentation/cli-commands.md
@@ -10,12 +10,12 @@ Phel includes a series of commands out-of-the-box.
 vendor/bin/phel list
 ```
 
-## Compile the project
+## Build the project
 
 ```bash
-php phel compile
+php phel build
 # Usage:
-#   compile [options]
+#   build [options]
 #
 # Options:
 #       --cache|--no-cache            Enable cache


### PR DESCRIPTION
## 📚 Description

In latest Phel version ([0.9](https://github.com/phel-lang/phel-lang/tree/v0.9.0)) we created a new alias for compiling the code for making it more explicit between the ["compiler" module](https://github.com/phel-lang/phel-lang/blob/master/adrs/php/0002_compiler_module.md) & building the code (generating PHP output code) once it was everything compiled.

So, the command `phel compile` still existing, but to make it more clear, it is an alias from `phel build`.