### PR TITLE
Sync the question with the solution for the conditional exercises

### DIFF
--- a/content/tutorials/exercises/conditionals-and-structures.md
+++ b/content/tutorials/exercises/conditionals-and-structures.md
@@ -31,8 +31,8 @@ Define a function `small?` that returns `true` for numbers under 100.
 Define a function `message` that has three cases:
 ```phel
 (message :boink) # -> "Boink!"
-(message :pig)   # -> "oink"
-(message :ping)  # -> "pong"
+(message :pig)   # -> "Oink!"
+(message :ping)  # -> "Pong"
 ```
 {% end %}
 {% solution() %}


### PR DESCRIPTION
While it should be clear that the answer is good anyway, it is probably a low hanging fruit to have the question 3 show the exact same strings that are proposed as solution for the questions 3, 4, 5 and 6 anyway, so in this PR I am proposing to fix the capitalization of the strings in the question.

Another point is that when trying the exercise, due to being lowercase, one can think that it is printing the keywords rather than the strings.