### PR TITLE
Add phel/repl namespace to documentation

### DIFF
--- a/build/src/php/FileGenerator/Config.php
+++ b/build/src/php/FileGenerator/Config.php
@@ -15,6 +15,7 @@ final class Config extends AbstractConfig
     {
         return [
             'phel\\core',
+            'phel\\repl',
             'phel\\http',
             'phel\\html',
             'phel\\test',


### PR DESCRIPTION
## 📚 Description

[Solves issue](https://github.com/phel-lang/phel-lang/issues/595)

Add `phel/repl` commands to the documentation.

![image](https://user-images.githubusercontent.com/6381924/233297015-a630b2bc-ff58-48fb-9618-590d8966c874.png)
