### PR TITLE
Add link to phel.vim in the docs

### DIFF
--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -161,6 +161,7 @@ To try Phel you can run a REPL by executing the `./vendor/bin/phel repl` command
 ## Editor support
 
 Phel comes with basic support for <a href="https://github.com/phel-lang/phel-vs-code-extension" target="_blank">
-VSCode</a>, <a href="https://github.com/phel-lang/phel-phpstorm-syntax" target="_blank">PhpStorm</a>
-and a <a href="https://codeberg.org/mmontone/interactive-lang-tools/src/branch/master/backends/phel" target="_blank">
-Emacs mode with interactive capabilities</a> in the making.
+VSCode</a>, <a href="https://github.com/phel-lang/phel-phpstorm-syntax" target="_blank">PhpStorm</a>, a
+<a href="https://codeberg.org/mmontone/interactive-lang-tools/src/branch/master/backends/phel" target="_blank">
+Emacs mode with interactive capabilities</a> and a <a href="https://github.com/danirod/phel.vim" target="_blank">Vim
+plugin</a> in the making.


### PR DESCRIPTION
I've started to work on phel.vim, a Vim plugin that adds support for the Phel programming language.

It is still under development because I haven't finished it yet; I want to add an indent file so that it proper uses the formatting rules, and I want to add support for `phel format` via an ALE fixer. However, at the moment it already detects *.phel files and enables the phel syntax, which is based on other Lisp-like syntaxes but I've added the list of primitives defined in https://phel-lang.org/documentation/api/ so that it can colour them right away, and add the syntax bits that are specific to Phel and not to other Lisp-like languages, like using \# for comments rather than ;

<img width="643" alt="image" src="https://github.com/phel-lang/phel-lang.org/assets/1568690/43d0988b-2765-4346-8331-980b2f373fbf">
