### PR TITLE
Fixed the sample code on the macro page

### DIFF
--- a/content/documentation/macros.md
+++ b/content/documentation/macros.md
@@ -48,7 +48,7 @@ Together with `quote` and `defmarco`, it is now possible to define a custom `def
 
 ```phel
 (defmacro mydefn [name args & body]
-  (list 'def name (apply list 'fn name args body)))
+  (list 'def name (apply list 'fn args body)))
 ```
 This macro is very simple at does not support all the feature of `defn`. But it illustrates the basics of a macro.
 
@@ -58,4 +58,4 @@ For better readability of marcos the `quasiquote` special form is defined. It tu
 
 ```phel
 (defmacro mydefn [name args & body]
-  `(def ,name (fn ,name ,args ,@body)))
+  `(def ,name (fn ,args ,@body)))


### PR DESCRIPTION
There seems to be an error in the sample code on the following page.
https://phel-lang.org/documentation/macros/

```
(defmacro mydefn [name args & body]
  (list 'def name (apply list 'fn name args body)))
```

When I try to use the above macro, an error occurs.

```
phel:39> (mydefn myinc [a] (inc a))
Second argument of 'fn must be a vector
in string:39

39| (mydefn myinc [a] (inc a))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I think the code below is correct, so please check it.

```
(defmacro mydefn [name args & body]
  (list 'def name (apply list 'fn args body)))
```