### PR TITLE
Improve "Basic Types", "Arithmetic", and "Truth and Boolean" pages

### DIFF
--- a/content/documentation/arithmetic.md
+++ b/content/documentation/arithmetic.md
@@ -1,39 +1,9 @@
 +++
-title = "Numbers and Arithmetic"
+title = "Arithmetic"
 weight = 3
 +++
 
-## Numbers
-
-Phel support integer and floating-point numbers. Both use the underlying PHP implementation. Integers can be specified
-in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2) notation. Binary, octal and hexadecimal
-formats may contain underscores (`_`) between digits for better readability.
-
-```phel
-1337 # integer
-+1337 # positive integer
--1337 # negative integer
-
-1.234 # float
-+1.234 # positive float
--1.234 # negative float
-1.2e3 # float
-7E-10 # float
-
-0b10100111001 # binary number
--0b10100111001 # negative binary number
-0b101_0011_1001 # binary number with underscores for better readability
-
-0x539 # hexadecimal number
--0x539 # negative hexadecimal number
--0x5_39 # hexadecimal number with underscores
-
-02471 # octal number
--02471 # negativ octal number
-024_71 # octal number with underscores
-```
-
-### Arithmetic operators
+## Arithmetic Operators
 
 All arithmetic operators are entered in prefix notation.
 
@@ -66,11 +36,11 @@ Some operators support zero, one or multiple arguments.
 
 Further numeric operations are `%` to compute the remainder of two values and `**` to raise a number to the power. All numeric operations can be found in the API documentation.
 
-Some numeric operations can result in an undefined or unrepresentable value. These values are call _Not a Number_ (NaN). Phel represents this values by the constant `NAN`. You can check if a result is NaN by using the `nan?` function.
+Some numeric operations can result in an undefined or unrepresentable value. These values are called _Not a Number_ (NaN). Phel represents these values by the constant `NAN`. You can check if a result is NaN by using the `nan?` function.
 
 ```phel
 (nan? 1) # false
-(nan? (log -1)) # true
+(nan? (php/log -1)) # true
 (nan? NAN) # true
 ```
 
@@ -101,7 +71,7 @@ Phel allows the evaluation and manipulation of specific bits within an integer.
 (bit-set 0b1011 2) # Evalutes to (0b1111)
 
 # Clear bit at index n
-(bit-clear 0b1011 3) # Evaluates to 15 (0b0011)
+(bit-clear 0b1011 3) # Evaluates to 3 (0b0011)
 
 # Flip bit at index n
 (bit-flip 0b1011 2) # Evaluates to 15 (0b1111)

--- a/content/documentation/basic-types.md
+++ b/content/documentation/basic-types.md
@@ -38,8 +38,7 @@ A keyword is like a symbol that begins with a colon character. However, it is us
 
 ## Numbers
 
-Numbers in Phel are equivalent to numbers in PHP. Next to decimal and
-float numbers, the reader also supports binary, octal and hexadecimal number formats. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
+Phel supports integers and floating-point numbers. Both use the underlying PHP implementation. Integers can be specified in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2) notations. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
 
 ```phel
 1337 # integer

--- a/content/documentation/basic-types.md
+++ b/content/documentation/basic-types.md
@@ -5,7 +5,7 @@ weight = 2
 
 ## Nil, True, False
 
-Nil, true and false are literal constants. In Phel `nil` is the same as `null` in PHP. Phel's `true` and `false` are the same as PHP's `true` and `false`.
+Nil, true and false are literal constants. In Phel, `nil` is the same as `null` in PHP. Phel's `true` and `false` are the same as PHP's `true` and `false`.
 
 ```phel
 nil
@@ -26,7 +26,7 @@ my-module/my-function
 
 ## Keywords
 
-Keywords are like symbols that begin with a colon character. However, they are used as constants rather than a name for something.
+A keyword is like a symbol that begins with a colon character. However, it is used as a constant rather than a name for something.
 
 ```phel
 :keyword
@@ -39,7 +39,7 @@ Keywords are like symbols that begin with a colon character. However, they are u
 ## Numbers
 
 Numbers in Phel are equivalent to numbers in PHP. Next to decimal and
-float numbers the reader also supports binary, octal and hexadecimal number formats. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
+float numbers, the reader also supports binary, octal and hexadecimal number formats. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
 
 ```phel
 1337 # integer
@@ -53,23 +53,26 @@ float numbers the reader also supports binary, octal and hexadecimal number form
 7E-10 # float
 
 0b10100111001 # binary number
++0b10100111001 # positive binary number
 -0b10100111001 # negative binary number
 0b101_0011_1001 # binary number with underscores for better readability
 
 0x539 # hexadecimal number
++0x539 # positive hexadecimal number
 -0x539 # negative hexadecimal number
 -0x5_39 # hexadecimal number with underscores
 
 02471 # octal number
--02471 # negativ octal number
++02471 # positive octal number
+-02471 # negative octal number
 024_71 # octal number with underscores
 ```
 
 ## Strings
 
-Strings are surrounded by double quotes. They almost work the same as PHP double-quoted strings. One difference is that the dollar sign (`$`) must not be escaped. Internally Phel strings are represented by PHP strings. Therefore, every PHP string function can be used to operate on the string.
+Strings are surrounded by double quotes. They almost work the same as PHP double-quoted strings. One difference is that the dollar sign (`$`) must not be escaped. Internally, Phel strings are represented by PHP strings. Therefore, every PHP string function can be used to operate on the string.
 
-String can be written in multiple lines. The line break character is then ignored by the reader.
+Strings can be written over multiple lines. The line break character is then ignored by the reader.
 
 ```phel
 "hello world"
@@ -81,7 +84,7 @@ is
 a
 string."
 
-"use backslack to escape \" string"
+"use backslash to escape \" string"
 
 "the dollar must not be escaped: $ or $abc just works"
 
@@ -92,41 +95,45 @@ string."
 
 ## Lists
 
-Lists are a sequence of white space separated values surrounded by parentheses.
+A list is a sequence of whitespace-separated values surrounded by parentheses.
 
 ```phel
 (do 1 2 3)
 ```
 
-Lists will be interpreted as a function calls, a macro call or special form by the compiler.
+A list will be interpreted as a function call, a macro call or a special form by the compiler. A list prefixed with a single quote will be interpreted as data.
+
+```phel
+'(1 2 3)
+```
 
 ## Vectors
 
-Vectors are a sequence of white space separated values surrounded by brackets.
+A vector is a sequence of whitespace-separated values surrounded by brackets.
 
 ```phel
 [1 2 3]
 ```
 
-A Vector in Phel is an indexed datastructure. In contrast to PHP arrays, Phel vectors cannot be used as Map, HashTable or Dictionary.
+A vector in Phel is an indexed data structure. In contrast to PHP arrays, Phel vectors cannot be used as maps, hashtables or dictionaries.
 
 ## Maps
 
-Maps are represented by a sequence of white-space delimited key value pairs surrounded by curly braces. There must be an even number of items between curly braces or the parser will signal a parse error. The sequence is defined as key1, value1, key2, value2, etc.
+A map is a sequence of whitespace-separated key/value pairs surrounded by curly braces, wherein the key and value of each key/value pair are separated by whitespace. There must be an even number of items between curly braces or the parser will signal a parse error. The sequence is defined as key1, value1, key2, value2, etc.
 
 ```phel
 {}
 {:key1 "value1" :key2 "value2"}
-{(1 2 3) (4 5 6)}
+{'(1 2 3) '(4 5 6)}
 {[] []}
 {1 2 3 4 5 6}
 ```
 
-In contrast to PHP associative arrays, Phel Maps can have any type of keys.
+In contrast to PHP associative arrays, Phel maps can have any types of keys.
 
 ## Sets
 
-Sets are a sequence of white space separated values prefixed by the function `set` and the whole being surrounded by parentheses.
+A set is a sequence of whitespace-separated values prefixed by the function `set` and the whole being surrounded by parentheses.
 
 ```phel
 (set 1 2 3)
@@ -134,7 +141,7 @@ Sets are a sequence of white space separated values prefixed by the function `se
 
 ## Comments
 
-Comments begin with a `#` character and continue until the end of the line. There are no multi-line comments.
+A comment begins with a `#` character and continues until the end of the line. There are no multi-line comments.
 
 ```phel
 # This is a comment

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -28,7 +28,7 @@ More information can be found in the [README](https://packagist.org/packages/phe
 
 For a web project, you can replace `cli-skeleton` in the instructions above, with `web-skeleton`. You can run the PHP development server with:
 
-```shell
+```bash
 composer run:dev
 ```
 

--- a/content/documentation/truth-and-boolean-operations.md
+++ b/content/documentation/truth-and-boolean-operations.md
@@ -3,7 +3,7 @@ title = "Truth and Boolean operations"
 weight = 4
 +++
 
-Phel has a different concept of truthiness. In Phel only `false` and `nil` represent falsity. Everything else evaluates to true. The function `truthy?` can be used to check if a value is truthy. To check for the values `true` and `false` the functions `true?` and `false?` can be used.
+Phel has a different concept of truthiness. In Phel, only `false` and `nil` represent falsity. Everything else evaluates to true. The function `truthy?` can be used to check if a value is truthy. To check for the values `true` and `false` the functions `true?` and `false?` can be used.
 
 ```phel
 (truthy? false) # Evaluates to false
@@ -25,20 +25,20 @@ Phel has a different concept of truthiness. In Phel only `false` and `nil` repre
 
 ## Identity vs Equality
 
-The function `id` returns `true` if two values are identical. Identical is stricter than equality. It first checks if both types are identical and then compares their values. Phel Keywords and Symbol with the same name are always identical. Lists, Vectors, Maps and Sets are only identical if they point to the same reference.
+The function `id` returns `true` if two values are identical. Identity is stricter than equality. It first checks if both types are identical and then compares their values. Phel keywords and symbols with the same names are always identical. Lists, vectors, maps and sets are only identical if they point to the same references.
 
 ```phel
 (id true true) # Evaluates to true
 (id true false) # Evaluates to false
 (id 5 "5") # Evaluates to false
 (id :test :test) # Evaluates to true
-(id 'sym 'sym') # Evaluates to true
+(id 'sym 'sym) # Evaluates to true
 (id '() '()) # Evaluates to false
 (id [] []) # Evaluates to false
 (id {} {}) # Evaluates to false
 ```
 
-To check if to two values are equal the equal function (`=`) can be used. Two values are equal if they have the same type and value. Lists, Vectors, Maps and Sets are equal if they have same values, but they must not point to the same reference.
+To check if two values are equal, the equal function (`=`) can be used. Two values are equal if they have the same type and value. Lists, vectors, maps and sets are equal if they have same values, but they must not point to the same references.
 
 ```phel
 (= true true) # Evaluates to true
@@ -47,7 +47,7 @@ To check if to two values are equal the equal function (`=`) can be used. Two va
 (= 5 5) # Evaluates to true
 (= 5 5.0) # Evaluates to false
 (= :test :test) # Evaluates to true
-(= 'sym 'sym') # Evaluates to true
+(= 'sym 'sym) # Evaluates to true
 (= '() '()) # Evaluates to true
 (= [] []) # Evaluates to true
 (= {} {}) # Evaluates to true
@@ -55,16 +55,16 @@ To check if to two values are equal the equal function (`=`) can be used. Two va
 
 The function `id` is equivalent to PHP's identity operator (`===`) with support for Phel types. However, the equality function `=` is not equivalent to PHP's equal operator (`==`). If you want to test if two values are PHP equal, the function `php/==` can be used. To check if two values are unequal the `not=` function can be used.
 
-### Comparison operation
+## Comparison Operations
 
 Further comparison function are:
 
-* `<=`: Checks if each argument is less than or equal to the following argument. Returns a boolean.
-* `<`: Checks if each argument is strictly less than the following argument. Returns a boolean.
-* `>=`: Checks if each argument is greater than or equal to the following argument. Returns a boolean.
-* `>`: Checks if each argument is strictly greater than the following argument. Returns a boolean.
+- `<=`: Checks if each argument is less than or equal to the following argument. Returns a boolean.
+- `<`: Checks if each argument is strictly less than the following argument. Returns a boolean.
+- `>=`: Checks if each argument is greater than or equal to the following argument. Returns a boolean.
+- `>`: Checks if each argument is strictly greater than the following argument. Returns a boolean.
 
-### Logical operation
+## Logical Operations
 
 The `and` function evaluates each expression one at a time, from left to right. If a form returns logical false, `and` returns that value and doesn't evaluate any of the other expressions, otherwise it returns the value of the last expression. Calling the `and` function without arguments returns true.
 
@@ -88,5 +88,8 @@ The `not` function returns `true` if the given value is logical false and `false
 
 ```phel
 (not 1) # Evaluates to false
-(not 0) # Evaluates to true
+(not 0) # Evaluates to false
+(not true) # Evaluates to false
+(not false) # Evaluates to true
+(not nil) # Evaluates to true
 ```


### PR DESCRIPTION
The "Numbers" section of the "Arithmetic" page was a duplication of the "Numbers" section of the "Basic Types" page.

Ensured that subject and object agreed in number in some descriptions of types.

Fixed some code examples.

Fixed grammar and spelling.