### PR TITLE
Typo fix

### DIFF
--- a/content/documentation/destructuring.md
+++ b/content/documentation/destructuring.md
@@ -8,7 +8,7 @@ Destructuring works for function parameters, `let` and `loop` bindings.
 
 ### Sequential data structures
 
-Sequential data structures can be extract using the vector syntax.
+Sequential data structures can be extracted using the vector syntax.
 
 ```phel
 (let [[a b] [1 2]]


### PR DESCRIPTION
Just a small typo fix.
Noted the document English texts could use some reformatting also to be more fluent, but maybe not the most critical thing.