### PR TITLE
Edit me link broken at documentation/api

### DIFF
--- a/templates/layouts/two-column-layout.html
+++ b/templates/layouts/two-column-layout.html
@@ -9,10 +9,7 @@
             {% include "navigation/site-navigation.html" %}
         </aside>
         <main class="two-column-layout__content">
-            <span class="found-a-typo">
-              {% set url = config.extra.repo_content_url ~ page.relative_path %}
-              <a href="{{url}}">Edit me</a>
-            </span>
+            {% block editable %} {% endblock %}
             {% block content %} {% endblock %}
 
             {% include "footer.html" %}

--- a/templates/page-api.html
+++ b/templates/page-api.html
@@ -4,6 +4,7 @@
     <title>{{ page.title }} | {{ config.title }}</title>
     <meta property="og:title" content="{{ page.title }} | {{ config.title }}" />
 {% endblock meta_content %}
+
 {% block content %}
     <h1>{{page.title}}</h1>
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,6 +4,7 @@
     <title>{{ page.title }} | {{ config.title }}</title>
     <meta property="og:title" content="{{ page.title }} | {{ config.title }}" />
 {% endblock meta_content %}
+
 {% block content %}
     <h1>{{page.title}}</h1>
     <aside>
@@ -15,3 +16,10 @@
         </div>
     </div>
 {% endblock content %}
+
+{% block editable %}
+<span class="found-a-typo">
+  {% set url = config.extra.repo_content_url ~ page.relative_path %}
+  <a href="{{url}}">Edit me</a>
+</span>
+{% endblock editable %}


### PR DESCRIPTION
## 🔗  Related

Closes: https://github.com/phel-lang/phel-lang.org/issues/94 

## 📖  Changes

Extract editable block from 2-column-layout and use it only on page template; not on page-api template

## 🖼️  Demo

Edit me link on pages...

<img width="1177" alt="Screenshot 2024-11-29 at 18 27 18" src="https://github.com/user-attachments/assets/01cf20ca-0e2d-40dc-86be-2c48b9030629">

Except API page: 

<img width="1183" alt="Screenshot 2024-11-29 at 18 27 25" src="https://github.com/user-attachments/assets/e8f3c471-0b37-463f-8a33-9fba49027769">
