### PR TITLE
docs / control-flow: fix exception heading level, rearrange

### DIFF
--- a/content/documentation/control-flow.md
+++ b/content/documentation/control-flow.md
@@ -155,6 +155,19 @@ have the form `:modifier argument`. The following modifiers are supported:
 (for [x :range [0 4] y :range [0 x]] [x y]) # Evaluates to [[1 0] [2 0] [2 1] [3 0] [3 1] [3 2]]
 ```
 
+# Do
+
+```phel
+(do expr*)
+```
+
+Evaluates the expressions in order and returns the value of the last expression. If no expression is given, `nil` is returned.
+
+```phel
+(do 1 2 3 4) # Evaluates to 4
+(do (print 1) (print 2) (print 3)) # Print 1, 2, and 3
+```
+
 # Dofor
 
 ```
@@ -164,7 +177,7 @@ have the form `:modifier argument`. The following modifiers are supported:
 
 Iterating over collections for side-effects is also possible with `dofor` which has similar behavior to `for` otherwise but returns `nil` as `foreach` does.
 
-## Exceptions
+# Exceptions
 
 ```phel
 (throw expr)
@@ -195,17 +208,4 @@ All expressions are evaluated and if no exception is thrown the value of the las
   (throw (php/new \Exception))
   (catch \Exception e "error")
   (finally (print "test"))) # Evaluates to "error" and prints "test"
-```
-
-## Statements (do)
-
-```phel
-(do expr*)
-```
-
-Evaluates the expressions in order and returns the value of the last expression. If no expression is given, `nil` is returned.
-
-```phel
-(do 1 2 3 4) # Evaluates to 4
-(do (print 1) (print 2) (print 3)) # Print 1, 2, and 3
 ```


### PR DESCRIPTION
Heading arrangement was a bit off. Also changed "Statements (do)" into "Do" as it fits better before Dofor. Maybe upper level heading "Statements" would make sense to sort things with but would require a bit of work, I don't understand this vocabulary that deep.

Old state:
![image](https://github.com/user-attachments/assets/0846f667-7dd2-44d4-9cc5-4b2e6a605dc7)
