### PR TITLE
Add project to in-the-wild page. phel-mml2wav

### DIFF
--- a/content/documentation/in-the-wild.md
+++ b/content/documentation/in-the-wild.md
@@ -23,4 +23,5 @@ This page contains a list of libraries and projects that use Phel. If you want t
 * [phel-lifegame](https://github.com/smeghead/phel-lifegame) The Lifegame using the CLI terminal written in phel.
 * [phel-saraudon](https://github.com/smeghead/phel-saraudon) A command to Visualize result of `git log --stat`.
 * [phel-cellular-automaton](https://github.com/smeghead/phel-cellular-automaton) The cellular automaton using the CLI terminal written in phel.
+* [phel-mml2wav](https://github.com/smeghead/phel-mml2wav) Experimental tool to generate wav format files from MML(Music Macro Language).
 


### PR DESCRIPTION
I have created a new repository using phel-lang and would like to add it to the in-the-wild page.

- [phel-mml2wav](https://github.com/smeghead/phel-mml2wav) Experimental tool to generate wav format files from MML(Music Macro Language).