### PR TITLE
doc: add example of aliasing core namespace

### DIFF
--- a/content/documentation/namespaces.md
+++ b/content/documentation/namespaces.md
@@ -53,6 +53,17 @@ To prevent name collision from other modules in different namespaces, aliases ca
   (:require hello-world\util :as utilities))
 ```
 
+When names collide, names from different namespaces remain available by prefixing them with a namespace identifier (such as `phel\core`). However, care should be taken when referring to names before redefining them, as the names retain their values from the original namespaces before the redefinition.
+
+```phel
+(ns hello-world\http-client)
+
+(defn get [uri]
+  {:status 200 :body "Hello World" :headers {}})
+
+(phel\core/get (get "https://example.com") :status) # Evaluates to 200
+```
+
 Additionally, it is possible to refer symbols of other modules in the current namespace by using `:refer` keyword.
 
 ```phel


### PR DESCRIPTION
While looking for this solution noted also that Clojure has a special `(:refer-clojure :exclude [get])` facility in `ns` form e.g. https://github.com/babashka/http-client/blob/d56bc7f86903d09ff3faef1500ad36005dab037f/src/babashka/http_client/internal.clj#L3 where core function can be referred by `clojure.core/get` afterwards. I think this helps to avoid ambiguity before the original name gets re-defined in user code. Included notice to warn about this as excluding names this way is not possible with Phel currently.