### PR TITLE
feat: semicolon comment syntax highlighting for website

### DIFF
--- a/syntaxes/phel.sublime-syntax
+++ b/syntaxes/phel.sublime-syntax
@@ -18,8 +18,8 @@ contexts:
     #- include: symbol
 
   comment:
-    - match: (#).*$\n?
-      scope: comment.line.hash.phel
+    - match: (#|;).*$\n?
+      scope: comment.line.hash-or-semicolon.phel
       captures:
         1: punctuation.definition.comment.phel
 


### PR DESCRIPTION
Adds same rule to support `;` as comment character as was added in Phel lexer, so code snippets using it are highlighted correctly after https://github.com/phel-lang/phel-lang.org/pull/126 is merged.

I changed the identifier in `scope: comment.line.hash-or-semicolon.phel` which I'm not sure if it might break something somewhere, but on my basic test things seem to work fine.

<img width="821" height="417" alt="Screenshot_20250901_062203" src="https://github.com/user-attachments/assets/35dc9193-427b-4cae-a026-10a61c98a25c" />
