### PR TITLE
Fix `/documentation` url

### DIFF
--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -4,4 +4,16 @@ insert_anchor_links = "right"
 paginate_by = 5
 +++
 
-Documentation
+# Documentation
+
+Welcome to the Phel documentation. Here you'll find comprehensive guides and references for using Phel.
+
+<div class="redirect-notice">
+    <p><strong>Notice:</strong> You will be automatically redirected to the <a href="/documentation/getting-started/">Getting Started</a> guide in a few seconds.</p>
+</div>
+
+<script>
+    setTimeout(function() {
+        window.location.href = "/documentation/getting-started/";
+    }, 3000);
+</script>

--- a/templates/section.html
+++ b/templates/section.html
@@ -7,6 +7,16 @@
     {% block content %}
     <div class="page__content">
         {{ section.content | safe }}
+        
+        {% if section.pages %}
+        <ul>
+            {% for page in section.pages %}
+            <li>
+                <a href="{{ page.permalink }}">{{ page.title }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
     </div>
     {% endblock %}
 

--- a/templates/section.html
+++ b/templates/section.html
@@ -5,7 +5,7 @@
 
 <div class="page">
     {% block content %}
-    <div class="page__content">
+    <div class="page__content" style="max-width: 800px; margin: 0 auto; padding: 0 20px;">
         {{ section.content | safe }}
         
         {% if section.pages %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block body %}
+{% include "header.html" %}
+
+<div class="page">
+    {% block content %}
+    <div class="page__content">
+        {{ section.content | safe }}
+    </div>
+    {% endblock %}
+
+    {% include "footer.html" %}
+</div>
+
+{% endblock body %}


### PR DESCRIPTION
Closing: https://github.com/phel-lang/phel-lang.org/issues/109

There was this `section.html` template missing. Now that it's added, it could be also utilized better but as it's requires some work for now I added just a simple JS redirect and a link to the Getting Started guide.

<img width="954" height="453" alt="Screenshot_20250903_152739" src="https://github.com/user-attachments/assets/37efa229-9e41-4c2b-972f-f34f626eab60" />
