### PR TITLE
Group API page top functions by namespaces

### DIFF
--- a/build/src/php/FileGenerator/Application/ApiMarkdownGenerator.php
+++ b/build/src/php/FileGenerator/Application/ApiMarkdownGenerator.php
@@ -21,17 +21,29 @@ final readonly class ApiMarkdownGenerator
     {
         $result = $this->zolaHeaders();
 
-        /** @var list<PhelFunction> $groupedPhelFns */
-        $groupedPhelFns = $this->apiFacade->getPhelFunctions();
+        /** @var list<PhelFunction> $phelFns */
+        $phelFns = $this->apiFacade->getPhelFunctions();
 
-        foreach ($groupedPhelFns as $fn) {
-            $result[] = "## `{$fn->name()}`";
-            $result[] = "<small><strong>Namespace</strong> `{$fn->namespace()}`</small>";
-            $result[] = $fn->doc();
-            if ($fn->githubUrl() !== '') {
-                $result[] = sprintf('<small>[[View source](%s)]</small>', $fn->githubUrl());
-            }elseif ($fn->docUrl() !== '') {
-                $result[] = sprintf('<small>[[Read more](%s)]</small>', $fn->docUrl());
+        $groupedByNamespace = [];
+        foreach ($phelFns as $fn) {
+            $groupedByNamespace[$fn->namespace()][] = $fn;
+        }
+
+        foreach ($groupedByNamespace as $namespace => $fns) {
+
+            $result[] = "";
+            $result[] = "---";
+            $result[] = "";
+            $result[] = "## `{$namespace}`";
+
+            foreach ($fns as $fn) {
+                $result[] = "### `{$fn->nameWithNamespace()}`";
+                $result[] = $fn->doc();
+                if ($fn->githubUrl() !== '') {
+                    $result[] = sprintf('<small>[[View source](%s)]</small>', $fn->githubUrl());
+                } elseif ($fn->docUrl() !== '') {
+                    $result[] = sprintf('<small>[[Read more](%s)]</small>', $fn->docUrl());
+                }
             }
         }
 

--- a/build/src/php/FileGenerator/Application/ApiSearchGenerator.php
+++ b/build/src/php/FileGenerator/Application/ApiSearchGenerator.php
@@ -46,14 +46,14 @@ final readonly class ApiSearchGenerator
                 $anchor = $groupKey;
                 $groupFnNameAppearances[$groupKey]++;
             } else {
-                $sanitizedFnName = str_replace(['/', ...self::SPECIAL_ENDING_CHARS], ['-', ''], $fn->fnName());
+                $sanitizedFnName = str_replace(['/', ...self::SPECIAL_ENDING_CHARS], ['-', ''], $fn->name());
                 $anchor = rtrim($sanitizedFnName, '-') . '-' . $groupFnNameAppearances[$groupKey]++;
             }
 
             $result[] = [
                 'id' => 'api_' . $fn->name(),
-                'fnName' => $fn->name(),
-                'fnSignature' => $fn->signature(),
+                'name' => $fn->nameWithNamespace(),
+                'signature' => $fn->signature(),
                 'desc' => $this->formatDescription($fn->description()),
                 'anchor' => $anchor,
                 'type' => 'api',

--- a/build/tests/php/FileGenerator/Domain/ApiMarkdownGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Domain/ApiMarkdownGeneratorTest.php
@@ -36,9 +36,10 @@ final class ApiMarkdownGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'function-1',
+                    'name' => 'function-1',
                     'doc' => 'The doc from function 1',
                     'groupKey' => 'group-1',
+                    'namespace' => 'ns-1',
                 ]),
             ]);
 
@@ -52,7 +53,11 @@ final class ApiMarkdownGeneratorTest extends TestCase
             'aliases = [ "/api" ]',
             '+++',
             '',
-            '## `function-1`',
+            '',
+            '---',
+            '',
+            '## `ns-1`',
+            '### `ns-1/function-1`',
             'The doc from function 1',
         ];
 
@@ -65,12 +70,14 @@ final class ApiMarkdownGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'function-1',
+                    'name' => 'function-1',
                     'doc' => 'The doc from function 1',
+                    'namespace' => 'core',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'function-2',
+                    'name' => 'function-2',
                     'doc' => 'The doc from function 2',
+                    'namespace' => 'core',
                 ]),
             ]);
 
@@ -84,9 +91,13 @@ final class ApiMarkdownGeneratorTest extends TestCase
             'aliases = [ "/api" ]',
             '+++',
             '',
-            '## `function-1`',
+            '',
+            '---',
+            '',
+            '## `core`',
+            '### `function-1`',
             'The doc from function 1',
-            '## `function-2`',
+            '### `function-2`',
             'The doc from function 2',
         ];
 
@@ -99,12 +110,14 @@ final class ApiMarkdownGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'function-1',
+                    'name' => 'function-1',
                     'doc' => 'The doc from function 1',
+                    'namespace' => 'ns-1',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'function-2',
+                    'name' => 'function-2',
                     'doc' => 'The doc from function 2',
+                    'namespace' => 'ns-2',
                 ]),
             ]);
 
@@ -118,9 +131,17 @@ final class ApiMarkdownGeneratorTest extends TestCase
             'aliases = [ "/api" ]',
             '+++',
             '',
-            '## `function-1`',
+            '',
+            '---',
+            '',
+            '## `ns-1`',
+            '### `ns-1/function-1`',
             'The doc from function 1',
-            '## `function-2`',
+            '',
+            '---',
+            '',
+            '## `ns-2`',
+            '### `ns-2/function-2`',
             'The doc from function 2',
         ];
 

--- a/build/tests/php/FileGenerator/Domain/ApiSearchGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Domain/ApiSearchGeneratorTest.php
@@ -17,8 +17,8 @@ final class ApiSearchGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'table?',
-                    'fnSignature' => '(table? x)',
+                    'name' => 'table?',
+                    'signature' => '(table? x)',
                     'desc' => 'doc for table?',
                     'groupKey' => 'table'
                 ]),
@@ -30,8 +30,8 @@ final class ApiSearchGeneratorTest extends TestCase
         $expected = [
             [
                 'id' => 'api_table?',
-                'fnName' => 'table?',
-                'fnSignature' => '(table? x)',
+                'name' => 'table?',
+                'signature' => '(table? x)',
                 'desc' => 'doc for table?',
                 'anchor' => 'table',
                 'type' => 'api',
@@ -51,14 +51,14 @@ final class ApiSearchGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'table',
-                    'fnSignature' => '(table & xs)',
+                    'name' => 'table',
+                    'signature' => '(table & xs)',
                     'desc' => 'doc for table',
                     'groupKey' => 'table',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'not',
-                    'fnSignature' => '(not x)',
+                    'name' => 'not',
+                    'signature' => '(not x)',
                     'desc' => 'doc for not',
                     'groupKey' => 'not',
                 ]),
@@ -70,16 +70,16 @@ final class ApiSearchGeneratorTest extends TestCase
         $expected = [
             [
                 'id' => 'api_table',
-                'fnName' => 'table',
-                'fnSignature' => '(table & xs)',
+                'name' => 'table',
+                'signature' => '(table & xs)',
                 'desc' => 'doc for table',
                 'anchor' => 'table',
                 'type' => 'api',
             ],
             [
                 'id' => 'api_not',
-                'fnName' => 'not',
-                'fnSignature' => '(not x)',
+                'name' => 'not',
+                'signature' => '(not x)',
                 'desc' => 'doc for not',
                 'anchor' => 'not',
                 'type' => 'api',
@@ -99,14 +99,14 @@ final class ApiSearchGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'table',
-                    'fnSignature' => '(table & xs)',
+                    'name' => 'table',
+                    'signature' => '(table & xs)',
                     'desc' => 'doc for table',
                     'groupKey' => 'table',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'table?',
-                    'fnSignature' => '(table? x)',
+                    'name' => 'table?',
+                    'signature' => '(table? x)',
                     'desc' => 'doc for table?',
                     'groupKey' => 'table',
                 ]),
@@ -118,16 +118,16 @@ final class ApiSearchGeneratorTest extends TestCase
         $expected = [
             [
                 'id' => 'api_table',
-                'fnName' => 'table',
-                'fnSignature' => '(table & xs)',
+                'name' => 'table',
+                'signature' => '(table & xs)',
                 'desc' => 'doc for table',
                 'anchor' => 'table',
                 'type' => 'api',
             ],
             [
                 'id' => 'api_table?',
-                'fnName' => 'table?',
-                'fnSignature' => '(table? x)',
+                'name' => 'table?',
+                'signature' => '(table? x)',
                 'desc' => 'doc for table?',
                 'anchor' => 'table-1',
                 'type' => 'api',
@@ -147,14 +147,14 @@ final class ApiSearchGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'http/response',
-                    'fnSignature' => '',
+                    'name' => 'http/response',
+                    'signature' => '',
                     'desc' => '',
                     'groupKey' => 'http-response',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'http/response?',
-                    'fnSignature' => '',
+                    'name' => 'http/response?',
+                    'signature' => '',
                     'desc' => '',
                     'groupKey' => 'http-response-1',
                 ]),
@@ -166,16 +166,16 @@ final class ApiSearchGeneratorTest extends TestCase
         $expected = [
             [
                 'id' => 'api_http/response',
-                'fnName' => 'http/response',
-                'fnSignature' => '',
+                'name' => 'http/response',
+                'signature' => '',
                 'desc' => '',
                 'anchor' => 'http-response',
                 'type' => 'api',
             ],
             [
                 'id' => 'api_http/response?',
-                'fnName' => 'http/response?',
-                'fnSignature' => '',
+                'name' => 'http/response?',
+                'signature' => '',
                 'desc' => '',
                 'anchor' => 'http-response-1',
                 'type' => 'api',
@@ -195,14 +195,14 @@ final class ApiSearchGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'defn',
-                    'fnSignature' => '',
+                    'name' => 'defn',
+                    'signature' => '',
                     'desc' => '',
                     'groupKey' => 'defn',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'defn-',
-                    'fnSignature' => '',
+                    'name' => 'defn-',
+                    'signature' => '',
                     'desc' => '',
                     'groupKey' => 'defn',
                 ]),
@@ -214,16 +214,16 @@ final class ApiSearchGeneratorTest extends TestCase
         $expected = [
             [
                 'id' => 'api_defn',
-                'fnName' => 'defn',
-                'fnSignature' => '',
+                'name' => 'defn',
+                'signature' => '',
                 'desc' => '',
                 'anchor' => 'defn',
                 'type' => 'api',
             ],
             [
                 'id' => 'api_defn-',
-                'fnName' => 'defn-',
-                'fnSignature' => '',
+                'name' => 'defn-',
+                'signature' => '',
                 'desc' => '',
                 'anchor' => 'defn-1',
                 'type' => 'api',
@@ -243,14 +243,14 @@ final class ApiSearchGeneratorTest extends TestCase
         $apiFacade->method('getPhelFunctions')
             ->willReturn([
                 PhelFunction::fromArray([
-                    'fnName' => 'NAN',
-                    'fnSignature' => '',
+                    'name' => 'NAN',
+                    'signature' => '',
                     'desc' => '',
                     'groupKey' => 'nan',
                 ]),
                 PhelFunction::fromArray([
-                    'fnName' => 'nan?',
-                    'fnSignature' => '',
+                    'name' => 'nan?',
+                    'signature' => '',
                     'desc' => '',
                     'groupKey' => 'nan',
                 ]),
@@ -262,16 +262,16 @@ final class ApiSearchGeneratorTest extends TestCase
         $expected = [
             [
                 'id' => 'api_NAN',
-                'fnName' => 'NAN',
-                'fnSignature' => '',
+                'name' => 'NAN',
+                'signature' => '',
                 'desc' => '',
                 'anchor' => 'nan',
                 'type' => 'api',
             ],
             [
                 'id' => 'api_nan?',
-                'fnName' => 'nan?',
-                'fnSignature' => '',
+                'name' => 'nan?',
+                'signature' => '',
                 'desc' => '',
                 'anchor' => 'nan-1',
                 'type' => 'api',

--- a/composer.lock
+++ b/composer.lock
@@ -164,12 +164,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "43828309586392d1412fb65319198be5ab7cc619"
+                "reference": "4e128ee40e9fd09e94c66778f8c1985f8729c020"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/43828309586392d1412fb65319198be5ab7cc619",
-                "reference": "43828309586392d1412fb65319198be5ab7cc619",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/4e128ee40e9fd09e94c66778f8c1985f8729c020",
+                "reference": "4e128ee40e9fd09e94c66778f8c1985f8729c020",
                 "shasum": ""
             },
             "require": {
@@ -236,7 +236,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-09-06T10:43:50+00:00"
+            "time": "2025-09-06T12:34:11+00:00"
         },
         {
             "name": "phpunit/php-timer",

--- a/static/search.js
+++ b/static/search.js
@@ -131,7 +131,7 @@ function initSearch() {
     };
     
     const index = elasticlunr(function () {
-        this.addField("fnName");
+        this.addField("name");
         this.addField("desc");
         this.addField("title");
         this.addField("content");
@@ -233,7 +233,7 @@ function showResults(index) {
         const options = {
             bool: "OR",
             fields: {
-                fnName: {boost: 3},
+                name: {boost: 3},
                 title: {boost: 2},
                 desc: {boost: 1},
                 content: {boost: 1}
@@ -243,8 +243,8 @@ function showResults(index) {
         const results = index.search(term, options);
         if (results.length === 0) {
             let emptyResult = {
-                fnName: "Symbol not found",
-                fnSignature: "",
+                name: "Symbol not found",
+                signature: "",
                 desc: "Cannot provide any Phel symbol. Try something else",
                 anchor: "#",
                 type: "api"
@@ -286,8 +286,8 @@ function formatSearchResultItem(item) {
         return `<a href="/documentation/api/#${item.anchor}">`
             + `<div class="search-results__item">`
             + `<span class="result-type">API: </span>`
-            + `${item.fnName} `
-            + `<small class="fn-signature">${item.fnSignature}</small>`
+            + `${item.name} `
+            + `<small class="fn-signature">${item.signature}</small>`
             + `<span class="desc">${item.desc}</span>`
             + `</div></a>`;
     }

--- a/templates/page-api.html
+++ b/templates/page-api.html
@@ -9,9 +9,16 @@
     <h1>{{page.title}}</h1>
 
     <ul class="api-index">
-    {% for h1 in page.toc %}
-        <li>
-            <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
+    {% for namespace in page.toc %}
+        <li class="api-index__entry" style="margin-top: 20px;">
+            Namespace: {{ namespace.title }}
+            <ul>
+            {% for fn in namespace.children %}
+                <li>
+                    <a href="{{ fn.permalink | safe }}">{{ fn.title }}</a>
+                </li>
+            {% endfor %}
+            </ul>
         </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
## 🖼️  Demo

### BEFORE
<img width="1105" height="815" alt="Screenshot 2025-09-06 at 14 41 20" src="https://github.com/user-attachments/assets/0fdc19fd-e4c1-4dc7-bdb6-edc3f4ceaf0c" />


### AFTER

<img width="1104" height="730" alt="Screenshot 2025-09-06 at 14 38 46" src="https://github.com/user-attachments/assets/a63b6bd3-bf08-409d-b6c7-dc0dcab7cfe9" />

<img width="1107" height="896" alt="Screenshot 2025-09-06 at 14 38 56" src="https://github.com/user-attachments/assets/3543c84a-2b88-4e7d-ad08-7aa2acfa48b9" />

---

We can improve the style in a follow up PR, but for now, this looks better structuring the different group of functions separated by namespace family.