### PR TITLE
Update namespace "PhelDocBuildTests" to "PhelWeb"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ yarn-error.log*
 .DS_Store
 Thumbs.db
 
-/build/
-/dist/
-
 .phel-repl-history
 .phpunit.result.cache
 static/api_search.js

--- a/build/api-page.php
+++ b/build/api-page.php
@@ -6,7 +6,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Gacela\Framework\Gacela;
 use Phel\Phel;
-use PhelDocBuild\FileGenerator\Facade as FileGeneratorFacade;
+use PhelWeb\FileGenerator\Facade as FileGeneratorFacade;
 
 Gacela::bootstrap(__DIR__, Phel::configFn());
 

--- a/build/api-search.php
+++ b/build/api-search.php
@@ -6,7 +6,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Gacela\Framework\Gacela;
 use Phel\Phel;
-use PhelDocBuild\FileGenerator\Facade as FileGeneratorFacade;
+use PhelWeb\FileGenerator\Facade as FileGeneratorFacade;
 
 Gacela::bootstrap(__DIR__, Phel::configFn());
 

--- a/build/src/php/FileGenerator/Application/ApiMarkdownGenerator.php
+++ b/build/src/php/FileGenerator/Application/ApiMarkdownGenerator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator\Application;
+namespace PhelWeb\FileGenerator\Application;
 
 use Phel\Api\Transfer\PhelFunction;
 use Phel\Shared\Facade\ApiFacadeInterface;

--- a/build/src/php/FileGenerator/Application/ApiSearchGenerator.php
+++ b/build/src/php/FileGenerator/Application/ApiSearchGenerator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator\Application;
+namespace PhelWeb\FileGenerator\Application;
 
 use Phel\Shared\Facade\ApiFacadeInterface;
 

--- a/build/src/php/FileGenerator/DependencyProvider.php
+++ b/build/src/php/FileGenerator/DependencyProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator;
+namespace PhelWeb\FileGenerator;
 
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;

--- a/build/src/php/FileGenerator/Facade.php
+++ b/build/src/php/FileGenerator/Facade.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator;
+namespace PhelWeb\FileGenerator;
 
 use Gacela\Framework\AbstractFacade;
 

--- a/build/src/php/FileGenerator/Factory.php
+++ b/build/src/php/FileGenerator/Factory.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator;
+namespace PhelWeb\FileGenerator;
 
 use Gacela\Framework\AbstractFactory;
 use Gacela\Framework\Config\Config;
 use Phel\Shared\Facade\ApiFacadeInterface;
-use PhelDocBuild\FileGenerator\Application\ApiMarkdownGenerator;
-use PhelDocBuild\FileGenerator\Application\ApiSearchGenerator;
-use PhelDocBuild\FileGenerator\Infrastructure\ApiMarkdownFile;
-use PhelDocBuild\FileGenerator\Infrastructure\ApiSearchFile;
+use PhelWeb\FileGenerator\Application\ApiMarkdownGenerator;
+use PhelWeb\FileGenerator\Application\ApiSearchGenerator;
+use PhelWeb\FileGenerator\Infrastructure\ApiMarkdownFile;
+use PhelWeb\FileGenerator\Infrastructure\ApiSearchFile;
 
 /**
  * @method Config getConfig()

--- a/build/src/php/FileGenerator/Infrastructure/ApiMarkdownFile.php
+++ b/build/src/php/FileGenerator/Infrastructure/ApiMarkdownFile.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator\Infrastructure;
+namespace PhelWeb\FileGenerator\Infrastructure;
 
-use PhelDocBuild\FileGenerator\Application\ApiMarkdownGenerator;
+use PhelWeb\FileGenerator\Application\ApiMarkdownGenerator;
 
 final readonly class ApiMarkdownFile
 {

--- a/build/src/php/FileGenerator/Infrastructure/ApiSearchFile.php
+++ b/build/src/php/FileGenerator/Infrastructure/ApiSearchFile.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuild\FileGenerator\Infrastructure;
+namespace PhelWeb\FileGenerator\Infrastructure;
 
-use PhelDocBuild\FileGenerator\Application\ApiSearchGenerator;
+use PhelWeb\FileGenerator\Application\ApiSearchGenerator;
 
 use function json_encode;
 

--- a/build/tests/php/FileGenerator/Domain/ApiMarkdownGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Domain/ApiMarkdownGeneratorTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuildTests\FileGenerator\Domain;
+namespace PhelWebTests\FileGenerator\Domain;
 
 use Phel\Api\Transfer\PhelFunction;
 use Phel\Shared\Facade\ApiFacadeInterface;
-use PhelDocBuild\FileGenerator\Application\ApiMarkdownGenerator;
+use PhelWeb\FileGenerator\Application\ApiMarkdownGenerator;
 use PHPUnit\Framework\TestCase;
 
 final class ApiMarkdownGeneratorTest extends TestCase

--- a/build/tests/php/FileGenerator/Domain/ApiSearchGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Domain/ApiSearchGeneratorTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuildTests\FileGenerator\Domain;
+namespace PhelWebTests\FileGenerator\Domain;
 
 use Phel\Api\Transfer\PhelFunction;
 use Phel\Shared\Facade\ApiFacadeInterface;
-use PhelDocBuild\FileGenerator\Application\ApiSearchGenerator;
+use PhelWeb\FileGenerator\Application\ApiSearchGenerator;
 use PHPUnit\Framework\TestCase;
 
 final class ApiSearchGeneratorTest extends TestCase

--- a/build/tests/php/FileGenerator/Integration/ApiMarkdownGeneratorTest.php
+++ b/build/tests/php/FileGenerator/Integration/ApiMarkdownGeneratorTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace PhelDocBuildTests\Integration;
+namespace PhelWebTests\FileGenerator\Integration;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Api\ApiFacade;
-use PhelDocBuild\FileGenerator\Application\ApiMarkdownGenerator;
+use PhelWeb\FileGenerator\Application\ApiMarkdownGenerator;
 use PHPUnit\Framework\TestCase;
 
 final class ApiMarkdownGeneratorTest extends TestCase
@@ -17,7 +17,7 @@ final class ApiMarkdownGeneratorTest extends TestCase
      */
     public function test_generate_api_markdown_file(): void
     {
-        Gacela::bootstrap(__DIR__ . '/../../..', static function (GacelaConfig $config): void {
+        Gacela::bootstrap(__DIR__ . '/../../../..', static function (GacelaConfig $config): void {
             $config->addAppConfig('phel-config.php', 'phel-config-local.php');
         });
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     },
     "autoload": {
         "psr-4": {
-            "PhelDocBuild\\": "build/src/php/"
+            "PhelWeb\\": "build/src/php/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "PhelDocBuildTests\\": "build/tests/php"
+            "PhelWebTests\\": "build/tests/php"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
## 📚 Description

I want to create a new module (`VersionUpdater`), so having the namespace defined as `PhelDocBuild` doesn't make sense anymore.

This PR focuses mainly on:
- Update namespace from `composer` and files from `PhelDocBuild` to `PhelWeb`
- Remove incorrectly ignored folders from the `.gitignore` file
- Move integration test (`ApiMarkdownGeneratorTest`) from `test/integration` to `test/FileGenerator/integration` folder