### PR TITLE
feat(home): immersive phel repl showcase + 0.33 syntax refresh

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -124,7 +124,7 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 ;; => "Tuesday, May 19th"
 
 ;; Exact rational math + tagged literals, read into native PHP values
-(+ 1/2 1/3 1/6)           ;; => 1
+(+ 1/2 1/3 1/6)           ; => 1
 #uuid "550e8400-e29b-41d4-a716-446655440000"
 ```
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -30,7 +30,7 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
       <span class="phel-terminal-dot phel-terminal-dot--yellow"></span>
       <span class="phel-terminal-dot phel-terminal-dot--green"></span>
     </div>
-    <div class="phel-terminal-title">~/phel-example — phel repl</div>
+    <div class="phel-terminal-title">phel repl</div>
     <div class="phel-terminal-chrome-spacer"></div>
   </div>
   <div class="phel-terminal-tabs" role="tablist" aria-label="Phel feature examples">

--- a/content/_index.md
+++ b/content/_index.md
@@ -25,123 +25,74 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 
 ## See Phel in Action
 
-<div class="homepage-tabs" data-homepage-tabs>
-  <div class="homepage-tabs-nav" role="tablist" aria-label="Phel feature examples">
-    <button type="button" class="homepage-tab-btn is-active" data-tab="hello" role="tab" aria-selected="true" aria-controls="tab-hello">Hello World</button>
-    <button type="button" class="homepage-tab-btn" data-tab="data" role="tab" aria-selected="false" aria-controls="tab-data">Data Structures</button>
-    <button type="button" class="homepage-tab-btn" data-tab="pipeline" role="tab" aria-selected="false" aria-controls="tab-pipeline">Functional Pipeline</button>
-    <button type="button" class="homepage-tab-btn" data-tab="macros" role="tab" aria-selected="false" aria-controls="tab-macros">Macros</button>
-    <button type="button" class="homepage-tab-btn" data-tab="interop" role="tab" aria-selected="false" aria-controls="tab-interop">PHP Interop</button>
+<div class="phel-terminal" data-homepage-tabs>
+  <div class="phel-terminal-chrome" aria-hidden="true">
+    <div class="phel-terminal-dots">
+      <span class="phel-terminal-dot phel-terminal-dot--red"></span>
+      <span class="phel-terminal-dot phel-terminal-dot--yellow"></span>
+      <span class="phel-terminal-dot phel-terminal-dot--green"></span>
+    </div>
+    <div class="phel-terminal-title">~/phel-example — phel repl</div>
+    <div class="phel-terminal-chrome-spacer"></div>
   </div>
-
-  <div class="homepage-tab-panel is-active" id="tab-hello" data-panel="hello" role="tabpanel">
-
-```phel
-;; Every Phel file starts by declaring its namespace
-(ns my\example)
-
-;; `def` binds a name to a value (think `const` in JS)
-(def my-name "world")
-
-;; `defn` defines a function. Square brackets list the parameters.
-(defn greet [name]
-  (println "Hello," name))
-
-;; Call the function by putting it first inside parentheses
-(greet my-name)
-```
-
-<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(greet my-name)</span>
-<span class="homepage-repl-out">Hello, world</span></pre>
-
+  <div class="phel-terminal-tabs" role="tablist" aria-label="Phel feature examples">
+    <button type="button" class="phel-terminal-tab is-active" data-tab="hello" role="tab" aria-selected="true" aria-controls="tab-hello">Hello World</button>
+    <button type="button" class="phel-terminal-tab" data-tab="data" role="tab" aria-selected="false" aria-controls="tab-data">Data Structures</button>
+    <button type="button" class="phel-terminal-tab" data-tab="pipeline" role="tab" aria-selected="false" aria-controls="tab-pipeline">Functional Pipeline</button>
+    <button type="button" class="phel-terminal-tab" data-tab="macros" role="tab" aria-selected="false" aria-controls="tab-macros">Macros</button>
+    <button type="button" class="phel-terminal-tab" data-tab="interop" role="tab" aria-selected="false" aria-controls="tab-interop">PHP Interop</button>
   </div>
-
-  <div class="homepage-tab-panel" id="tab-data" data-panel="data" role="tabpanel" hidden>
-
-```phel
-;; Persistent vectors, maps, and keywords
-(def users [{:name "Ada"  :age 36}
-            {:name "Alan" :age 41}
-            {:name "Lin"  :age 28}])
-
-;; Keywords act as functions that look themselves up
-(map :name users)
-
-;; Destructuring pulls fields out directly
-(let [[{:keys [name age]} & rest] users]
-  (println name "is" age "-" (count rest) "more"))
-```
-
-<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(map :name users)</span>
-<span class="homepage-repl-out">("Ada" "Alan" "Lin")</span></pre>
-
-  </div>
-
-  <div class="homepage-tab-panel" id="tab-pipeline" data-panel="pipeline" role="tabpanel" hidden>
-
-```phel
-;; Thread a collection through a pipeline of transforms
-(->> (range 1 11)
-     (filter odd?)
-     (map #(* % %))
-     (reduce +))
-
-;; Same pipeline with transducers: one pass, no intermediate seqs
-(transduce (comp (filter odd?) (map #(* % %))) + 0 (range 1 11))
-```
-
-<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(-&gt;&gt; (range 1 11)</span>
-<span class="homepage-repl-cont">....:2&gt;</span> <span class="homepage-repl-input">     (filter odd?)</span>
-<span class="homepage-repl-cont">....:3&gt;</span> <span class="homepage-repl-input">     (map #(* % %))</span>
-<span class="homepage-repl-cont">....:4&gt;</span> <span class="homepage-repl-input">     (reduce +))</span>
-<span class="homepage-repl-out">165</span></pre>
-
-  </div>
-
-  <div class="homepage-tab-panel" id="tab-macros" data-panel="macros" role="tabpanel" hidden>
-
-```phel
-;; Macros extend the language itself at compile time
-(defmacro unless [test & body]
-  `(if (not ,test) (do ,@body)))
-
-(unless (empty? [1 2 3])
-  (println "List has items"))
-
-;; Expands at compile time to: (if (not (empty? [1 2 3])) (do (println ...)))
-```
-
-<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(unless (empty? [1 2 3])</span>
-<span class="homepage-repl-cont">....:2&gt;</span> <span class="homepage-repl-input">  (println "List has items"))</span>
-<span class="homepage-repl-out">List has items</span></pre>
-
-  </div>
-
-  <div class="homepage-tab-panel" id="tab-interop" data-panel="interop" role="tabpanel" hidden>
-
-```phel
-;; PHP and Phel interleave freely in one expression
-(->> (php/range 1 100)
-     (filter odd?)
-     (map #(* % %))
-     (reduce +)
-     (php/number_format 0 "." ","))
-
-;; Drive real PHP classes without leaving Phel
-(php/-> (php/new \DateTimeImmutable "2026-04-19")
-        (modify "+30 days")
-        (format "l, F jS"))
-
-;; Exact rational math + tagged literals, read into native PHP values
-(+ 1/2 1/3 1/6)
-#uuid "550e8400-e29b-41d4-a716-446655440000"
-```
-
-<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(php/-&gt; (php/new \DateTimeImmutable "2026-04-19")</span>
-<span class="homepage-repl-cont">....:2&gt;</span> <span class="homepage-repl-input">        (modify "+30 days")</span>
-<span class="homepage-repl-cont">....:3&gt;</span> <span class="homepage-repl-input">        (format "l, F jS"))</span>
-<span class="homepage-repl-out">"Tuesday, May 19th"</span></pre>
-
+  <div class="phel-terminal-body">
+<pre class="phel-terminal-session is-active" id="tab-hello" data-panel="hello" role="tabpanel"><span class="t-cmt">;; Welcome to Phel. `phel:N&gt;` is the prompt, `....:N&gt;` continues a form.</span>
+<span class="t-p">phel:1&gt;</span> <span class="t-in">(def my-name "world")</span>
+<span class="t-p">phel:2&gt;</span> <span class="t-in">(defn greet [name]</span>
+<span class="t-c">....:3&gt;</span> <span class="t-in">  (println "Hello," name))</span>
+<span class="t-p">phel:4&gt;</span> <span class="t-in">(greet my-name)</span>
+<span class="t-out">Hello, world</span></pre>
+<pre class="phel-terminal-session" id="tab-data" data-panel="data" role="tabpanel" hidden><span class="t-cmt">;; Persistent vectors, maps, and keywords are built in.</span>
+<span class="t-p">phel:1&gt;</span> <span class="t-in">(def users [{:name "Ada"  :age 36}</span>
+<span class="t-c">....:2&gt;</span> <span class="t-in">            {:name "Alan" :age 41}</span>
+<span class="t-c">....:3&gt;</span> <span class="t-in">            {:name "Lin"  :age 28}])</span>
+<span class="t-cmt">;; Keywords act as functions that look themselves up.</span>
+<span class="t-p">phel:4&gt;</span> <span class="t-in">(map :name users)</span>
+<span class="t-out">("Ada" "Alan" "Lin")</span>
+<span class="t-cmt">;; Destructuring pulls fields straight out of collections.</span>
+<span class="t-p">phel:5&gt;</span> <span class="t-in">(let [[{:keys [name age]} &amp; rest] users]</span>
+<span class="t-c">....:6&gt;</span> <span class="t-in">  (println name "is" age "-" (count rest) "more"))</span>
+<span class="t-out">Ada is 36 - 2 more</span></pre>
+<pre class="phel-terminal-session" id="tab-pipeline" data-panel="pipeline" role="tabpanel" hidden><span class="t-cmt">;; Thread a collection through a pipeline of transforms.</span>
+<span class="t-p">phel:1&gt;</span> <span class="t-in">(-&gt;&gt; (range 1 11)</span>
+<span class="t-c">....:2&gt;</span> <span class="t-in">     (filter odd?)</span>
+<span class="t-c">....:3&gt;</span> <span class="t-in">     (map #(* % %))</span>
+<span class="t-c">....:4&gt;</span> <span class="t-in">     (reduce +))</span>
+<span class="t-out">165</span>
+<span class="t-cmt">;; Same pipeline fused into one pass with transducers.</span>
+<span class="t-p">phel:5&gt;</span> <span class="t-in">(transduce (comp (filter odd?) (map #(* % %))) + 0 (range 1 11))</span>
+<span class="t-out">165</span></pre>
+<pre class="phel-terminal-session" id="tab-macros" data-panel="macros" role="tabpanel" hidden><span class="t-cmt">;; Macros extend the language itself at compile time.</span>
+<span class="t-p">phel:1&gt;</span> <span class="t-in">(defmacro unless [test &amp; body]</span>
+<span class="t-c">....:2&gt;</span> <span class="t-in">  `(if (not ,test) (do ,@body)))</span>
+<span class="t-p">phel:3&gt;</span> <span class="t-in">(unless (empty? [1 2 3])</span>
+<span class="t-c">....:4&gt;</span> <span class="t-in">  (println "List has items"))</span>
+<span class="t-out">List has items</span>
+<span class="t-cmt">;; Expands to: (if (not (empty? [1 2 3])) (do (println ...)))</span></pre>
+<pre class="phel-terminal-session" id="tab-interop" data-panel="interop" role="tabpanel" hidden><span class="t-cmt">;; PHP and Phel interleave freely in one expression.</span>
+<span class="t-p">phel:1&gt;</span> <span class="t-in">(-&gt;&gt; (php/range 1 100)</span>
+<span class="t-c">....:2&gt;</span> <span class="t-in">     (filter odd?)</span>
+<span class="t-c">....:3&gt;</span> <span class="t-in">     (map #(* % %))</span>
+<span class="t-c">....:4&gt;</span> <span class="t-in">     (reduce +)</span>
+<span class="t-c">....:5&gt;</span> <span class="t-in">     (php/number_format 0 "." ","))</span>
+<span class="t-out">"166,650"</span>
+<span class="t-cmt">;; Drive real PHP classes without leaving Phel.</span>
+<span class="t-p">phel:6&gt;</span> <span class="t-in">(php/-&gt; (php/new \DateTimeImmutable "2026-04-19")</span>
+<span class="t-c">....:7&gt;</span> <span class="t-in">        (modify "+30 days")</span>
+<span class="t-c">....:8&gt;</span> <span class="t-in">        (format "l, F jS"))</span>
+<span class="t-out">"Tuesday, May 19th"</span>
+<span class="t-cmt">;; Rational math and tagged literals read into native values.</span>
+<span class="t-p">phel:9&gt;</span>  <span class="t-in">(+ 1/2 1/3 1/6)</span>
+<span class="t-out">1</span>
+<span class="t-p">phel:10&gt;</span> <span class="t-in">#uuid "550e8400-e29b-41d4-a716-446655440000"</span>
+<span class="t-out">#uuid "550e8400-e29b-41d4-a716-446655440000"</span></pre>
   </div>
 </div>
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -21,8 +21,6 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
   </a>
 </div>
 
-<div class="homepage-code-section">
-
 ## See Phel in Action
 
 <div class="phel-terminal" data-homepage-tabs>
@@ -94,8 +92,6 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 <span class="t-p">phel:10&gt;</span> <span class="t-in">#uuid "550e8400-e29b-41d4-a716-446655440000"</span>
 <span class="t-out">#uuid "550e8400-e29b-41d4-a716-446655440000"</span></pre>
   </div>
-</div>
-
 </div>
 
 ## Key Features of Phel

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,7 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 
 <img src="/images/logo_phel.svg" width="380" alt="Phel language logo"/>
 
-**Phel** is a functional programming language that compiles to PHP - a modern Lisp dialect inspired by [Clojure](https://clojure.org/) and [Janet](https://janet-lang.org/), bringing functional elegance and expressive code to PHP development.
+**Phel** is a functional, Lisp-inspired language that compiles to PHP. Inspired by [Clojure](https://clojure.org/), Phel brings macros, persistent data structures, and expressive functional idioms to the PHP ecosystem.
 
 <div class="homepage-cta">
   <a href="#try-phel-instantly-with-docker" class="btn btn-primary homepage-cta-button homepage-cta-primary">
@@ -25,20 +25,111 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 
 ## See Phel in Action
 
+<div class="homepage-tabs" data-homepage-tabs>
+  <div class="homepage-tabs-nav" role="tablist" aria-label="Phel feature examples">
+    <button type="button" class="homepage-tab-btn is-active" data-tab="hello" role="tab" aria-selected="true" aria-controls="tab-hello">Hello World</button>
+    <button type="button" class="homepage-tab-btn" data-tab="data" role="tab" aria-selected="false" aria-controls="tab-data">Data Structures</button>
+    <button type="button" class="homepage-tab-btn" data-tab="pipeline" role="tab" aria-selected="false" aria-controls="tab-pipeline">Functional Pipeline</button>
+    <button type="button" class="homepage-tab-btn" data-tab="macros" role="tab" aria-selected="false" aria-controls="tab-macros">Macros</button>
+    <button type="button" class="homepage-tab-btn" data-tab="interop" role="tab" aria-selected="false" aria-controls="tab-interop">PHP Interop</button>
+  </div>
+
+  <div class="homepage-tab-panel is-active" id="tab-hello" data-panel="hello" role="tabpanel">
+
 ```phel
-# Define a namespace
+;; Every Phel file starts by declaring its namespace
 (ns my\example)
 
-# Create a variable
+;; `def` binds a name to a value (think `const` in JS)
 (def my-name "world")
 
-# Define a function
-(defn print-name [your-name]
-  (print "hello" your-name))
+;; `defn` defines a function. Square brackets list the parameters.
+(defn greet [name]
+  (println "Hello," name))
 
-# Call the function
-(print-name my-name)
+;; Call the function by putting it first inside parentheses
+(greet my-name) ; => Hello, world
 ```
+
+  </div>
+
+  <div class="homepage-tab-panel" id="tab-data" data-panel="data" role="tabpanel" hidden>
+
+```phel
+;; Persistent vectors, maps, and keywords
+(def users [{:name "Ada"  :age 36}
+            {:name "Alan" :age 41}
+            {:name "Lin"  :age 28}])
+
+;; Keywords act as functions that look themselves up
+(map :name users)
+;; => ("Ada" "Alan" "Lin")
+
+;; Destructuring pulls fields out directly
+(let [[{:keys [name age]} & rest] users]
+  (println name "is" age "-" (count rest) "more"))
+;; => Ada is 36 - 2 more
+```
+
+  </div>
+
+  <div class="homepage-tab-panel" id="tab-pipeline" data-panel="pipeline" role="tabpanel" hidden>
+
+```phel
+;; Thread a collection through a pipeline of transforms
+(->> (range 1 11)
+     (filter odd?)
+     (map #(* % %))
+     (reduce +))
+;; => 165
+
+;; Same pipeline with transducers: one pass, no intermediate seqs
+(transduce (comp (filter odd?) (map #(* % %))) + 0 (range 1 11))
+;; => 165
+```
+
+  </div>
+
+  <div class="homepage-tab-panel" id="tab-macros" data-panel="macros" role="tabpanel" hidden>
+
+```phel
+;; Macros extend the language itself at compile time
+(defmacro unless [test & body]
+  `(if (not ,test) (do ,@body)))
+
+(unless (empty? [1 2 3])
+  (println "List has items"))
+;; => List has items
+
+;; Expands at compile time to: (if (not (empty? [1 2 3])) (do (println ...)))
+```
+
+  </div>
+
+  <div class="homepage-tab-panel" id="tab-interop" data-panel="interop" role="tabpanel" hidden>
+
+```phel
+;; PHP and Phel interleave freely in one expression
+(->> (php/range 1 100)
+     (filter odd?)
+     (map #(* % %))
+     (reduce +)
+     (php/number_format 0 "." ","))
+;; => "166,650"
+
+;; Drive real PHP classes without leaving Phel
+(php/-> (php/new \DateTimeImmutable "2026-04-19")
+        (modify "+30 days")
+        (format "l, F jS"))
+;; => "Tuesday, May 19th"
+
+;; Exact rational math + tagged literals, read into native PHP values
+(+ 1/2 1/3 1/6)           ;; => 1
+#uuid "550e8400-e29b-41d4-a716-446655440000"
+```
+
+  </div>
+</div>
 
 </div>
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -48,8 +48,11 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
   (println "Hello," name))
 
 ;; Call the function by putting it first inside parentheses
-(greet my-name) ; => Hello, world
+(greet my-name)
 ```
+
+<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(greet my-name)</span>
+<span class="homepage-repl-out">Hello, world</span></pre>
 
   </div>
 
@@ -63,13 +66,14 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 
 ;; Keywords act as functions that look themselves up
 (map :name users)
-;; => ("Ada" "Alan" "Lin")
 
 ;; Destructuring pulls fields out directly
 (let [[{:keys [name age]} & rest] users]
   (println name "is" age "-" (count rest) "more"))
-;; => Ada is 36 - 2 more
 ```
+
+<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(map :name users)</span>
+<span class="homepage-repl-out">("Ada" "Alan" "Lin")</span></pre>
 
   </div>
 
@@ -81,12 +85,16 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
      (filter odd?)
      (map #(* % %))
      (reduce +))
-;; => 165
 
 ;; Same pipeline with transducers: one pass, no intermediate seqs
 (transduce (comp (filter odd?) (map #(* % %))) + 0 (range 1 11))
-;; => 165
 ```
+
+<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(-&gt;&gt; (range 1 11)</span>
+<span class="homepage-repl-cont">....:2&gt;</span> <span class="homepage-repl-input">     (filter odd?)</span>
+<span class="homepage-repl-cont">....:3&gt;</span> <span class="homepage-repl-input">     (map #(* % %))</span>
+<span class="homepage-repl-cont">....:4&gt;</span> <span class="homepage-repl-input">     (reduce +))</span>
+<span class="homepage-repl-out">165</span></pre>
 
   </div>
 
@@ -99,10 +107,13 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 
 (unless (empty? [1 2 3])
   (println "List has items"))
-;; => List has items
 
 ;; Expands at compile time to: (if (not (empty? [1 2 3])) (do (println ...)))
 ```
+
+<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(unless (empty? [1 2 3])</span>
+<span class="homepage-repl-cont">....:2&gt;</span> <span class="homepage-repl-input">  (println "List has items"))</span>
+<span class="homepage-repl-out">List has items</span></pre>
 
   </div>
 
@@ -115,18 +126,21 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
      (map #(* % %))
      (reduce +)
      (php/number_format 0 "." ","))
-;; => "166,650"
 
 ;; Drive real PHP classes without leaving Phel
 (php/-> (php/new \DateTimeImmutable "2026-04-19")
         (modify "+30 days")
         (format "l, F jS"))
-;; => "Tuesday, May 19th"
 
 ;; Exact rational math + tagged literals, read into native PHP values
-(+ 1/2 1/3 1/6)           ; => 1
+(+ 1/2 1/3 1/6)
 #uuid "550e8400-e29b-41d4-a716-446655440000"
 ```
+
+<pre class="homepage-repl" aria-label="REPL session"><span class="homepage-repl-prompt">phel:1&gt;</span> <span class="homepage-repl-input">(php/-&gt; (php/new \DateTimeImmutable "2026-04-19")</span>
+<span class="homepage-repl-cont">....:2&gt;</span> <span class="homepage-repl-input">        (modify "+30 days")</span>
+<span class="homepage-repl-cont">....:3&gt;</span> <span class="homepage-repl-input">        (format "l, F jS"))</span>
+<span class="homepage-repl-out">"Tuesday, May 19th"</span></pre>
 
   </div>
 </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -41,55 +41,59 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
     <button type="button" class="phel-terminal-tab" data-tab="interop" role="tab" aria-selected="false" aria-controls="tab-interop">PHP Interop</button>
   </div>
   <div class="phel-terminal-body">
-<pre class="phel-terminal-session is-active" id="tab-hello" data-panel="hello" role="tabpanel"><span class="t-cmt">;; Welcome to Phel. `phel:N&gt;` is the prompt, `....:N&gt;` continues a form.</span>
-<span class="t-p">phel:1&gt;</span> <span class="t-in">(def my-name "world")</span>
-<span class="t-p">phel:2&gt;</span> <span class="t-in">(defn greet [name]</span>
+<pre class="phel-terminal-session is-active" id="tab-hello" data-panel="hello" role="tabpanel"><span class="t-cmt">;; Welcome to Phel. `user:N&gt;` is the prompt, `....:N&gt;` continues a form.</span>
+<span class="t-p">user:1&gt;</span> <span class="t-in">(def my-name "world")</span>
+<span class="t-out">#'user/my-name</span>
+<span class="t-p">user:2&gt;</span> <span class="t-in">(defn greet [name]</span>
 <span class="t-c">....:3&gt;</span> <span class="t-in">  (println "Hello," name))</span>
-<span class="t-p">phel:4&gt;</span> <span class="t-in">(greet my-name)</span>
+<span class="t-out">#'user/greet</span>
+<span class="t-p">user:4&gt;</span> <span class="t-in">(greet my-name)</span>
 <span class="t-out">Hello, world</span></pre>
 <pre class="phel-terminal-session" id="tab-data" data-panel="data" role="tabpanel" hidden><span class="t-cmt">;; Persistent vectors, maps, and keywords are built in.</span>
-<span class="t-p">phel:1&gt;</span> <span class="t-in">(def users [{:name "Ada"  :age 36}</span>
+<span class="t-p">user:1&gt;</span> <span class="t-in">(def users [{:name "Ada"  :age 36}</span>
 <span class="t-c">....:2&gt;</span> <span class="t-in">            {:name "Alan" :age 41}</span>
 <span class="t-c">....:3&gt;</span> <span class="t-in">            {:name "Lin"  :age 28}])</span>
+<span class="t-out">#'user/users</span>
 <span class="t-cmt">;; Keywords act as functions that look themselves up.</span>
-<span class="t-p">phel:4&gt;</span> <span class="t-in">(map :name users)</span>
+<span class="t-p">user:4&gt;</span> <span class="t-in">(map :name users)</span>
 <span class="t-out">("Ada" "Alan" "Lin")</span>
 <span class="t-cmt">;; Destructuring pulls fields straight out of collections.</span>
-<span class="t-p">phel:5&gt;</span> <span class="t-in">(let [[{:keys [name age]} &amp; rest] users]</span>
+<span class="t-p">user:5&gt;</span> <span class="t-in">(let [[{:keys [name age]} &amp; rest] users]</span>
 <span class="t-c">....:6&gt;</span> <span class="t-in">  (println name "is" age "-" (count rest) "more"))</span>
 <span class="t-out">Ada is 36 - 2 more</span></pre>
 <pre class="phel-terminal-session" id="tab-pipeline" data-panel="pipeline" role="tabpanel" hidden><span class="t-cmt">;; Thread a collection through a pipeline of transforms.</span>
-<span class="t-p">phel:1&gt;</span> <span class="t-in">(-&gt;&gt; (range 1 11)</span>
+<span class="t-p">user:1&gt;</span> <span class="t-in">(-&gt;&gt; (range 1 11)</span>
 <span class="t-c">....:2&gt;</span> <span class="t-in">     (filter odd?)</span>
 <span class="t-c">....:3&gt;</span> <span class="t-in">     (map #(* % %))</span>
 <span class="t-c">....:4&gt;</span> <span class="t-in">     (reduce +))</span>
 <span class="t-out">165</span>
 <span class="t-cmt">;; Same pipeline fused into one pass with transducers.</span>
-<span class="t-p">phel:5&gt;</span> <span class="t-in">(transduce (comp (filter odd?) (map #(* % %))) + 0 (range 1 11))</span>
+<span class="t-p">user:5&gt;</span> <span class="t-in">(transduce (comp (filter odd?) (map #(* % %))) + 0 (range 1 11))</span>
 <span class="t-out">165</span></pre>
 <pre class="phel-terminal-session" id="tab-macros" data-panel="macros" role="tabpanel" hidden><span class="t-cmt">;; Macros extend the language itself at compile time.</span>
-<span class="t-p">phel:1&gt;</span> <span class="t-in">(defmacro unless [test &amp; body]</span>
+<span class="t-p">user:1&gt;</span> <span class="t-in">(defmacro unless [test &amp; body]</span>
 <span class="t-c">....:2&gt;</span> <span class="t-in">  `(if (not ,test) (do ,@body)))</span>
-<span class="t-p">phel:3&gt;</span> <span class="t-in">(unless (empty? [1 2 3])</span>
+<span class="t-out">#'user/unless</span>
+<span class="t-p">user:3&gt;</span> <span class="t-in">(unless (empty? [1 2 3])</span>
 <span class="t-c">....:4&gt;</span> <span class="t-in">  (println "List has items"))</span>
 <span class="t-out">List has items</span>
 <span class="t-cmt">;; Expands to: (if (not (empty? [1 2 3])) (do (println ...)))</span></pre>
 <pre class="phel-terminal-session" id="tab-interop" data-panel="interop" role="tabpanel" hidden><span class="t-cmt">;; PHP and Phel interleave freely in one expression.</span>
-<span class="t-p">phel:1&gt;</span> <span class="t-in">(-&gt;&gt; (php/range 1 100)</span>
+<span class="t-p">user:1&gt;</span> <span class="t-in">(-&gt;&gt; (php/range 1 100)</span>
 <span class="t-c">....:2&gt;</span> <span class="t-in">     (filter odd?)</span>
 <span class="t-c">....:3&gt;</span> <span class="t-in">     (map #(* % %))</span>
 <span class="t-c">....:4&gt;</span> <span class="t-in">     (reduce +)</span>
 <span class="t-c">....:5&gt;</span> <span class="t-in">     (php/number_format 0 "." ","))</span>
 <span class="t-out">"166,650"</span>
 <span class="t-cmt">;; Drive real PHP classes without leaving Phel.</span>
-<span class="t-p">phel:6&gt;</span> <span class="t-in">(php/-&gt; (php/new \DateTimeImmutable "2026-04-19")</span>
+<span class="t-p">user:6&gt;</span> <span class="t-in">(php/-&gt; (php/new \DateTimeImmutable "2026-04-19")</span>
 <span class="t-c">....:7&gt;</span> <span class="t-in">        (modify "+30 days")</span>
 <span class="t-c">....:8&gt;</span> <span class="t-in">        (format "l, F jS"))</span>
 <span class="t-out">"Tuesday, May 19th"</span>
 <span class="t-cmt">;; Rational math and tagged literals read into native values.</span>
-<span class="t-p">phel:9&gt;</span>  <span class="t-in">(+ 1/2 1/3 1/6)</span>
+<span class="t-p">user:9&gt;</span>  <span class="t-in">(+ 1/2 1/3 1/6)</span>
 <span class="t-out">1</span>
-<span class="t-p">phel:10&gt;</span> <span class="t-in">#uuid "550e8400-e29b-41d4-a716-446655440000"</span>
+<span class="t-p">user:10&gt;</span> <span class="t-in">#uuid "550e8400-e29b-41d4-a716-446655440000"</span>
 <span class="t-out">#uuid "550e8400-e29b-41d4-a716-446655440000"</span></pre>
   </div>
 </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -56,7 +56,7 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 <span class="t-out">#'user/users</span>
 <span class="t-cmt">;; Keywords act as functions that look themselves up.</span>
 <span class="t-p">user:4&gt;</span> <span class="t-in">(map :name users)</span>
-<span class="t-out">("Ada" "Alan" "Lin")</span>
+<span class="t-out">@["Ada" "Alan" "Lin"]</span>
 <span class="t-cmt">;; Destructuring pulls fields straight out of collections.</span>
 <span class="t-p">user:5&gt;</span> <span class="t-in">(let [[{:keys [name age]} &amp; rest] users]</span>
 <span class="t-c">....:6&gt;</span> <span class="t-in">  (println name "is" age "-" (count rest) "more"))</span>

--- a/content/documentation/guides/cookbook.md
+++ b/content/documentation/guides/cookbook.md
@@ -13,8 +13,8 @@ Read a CSV file and parse it into a vector of maps, where each map represents a 
 ```phel
 (ns cookbook\csv-reader)
 
-# Read a CSV file and return a vector of maps
-# Each row becomes a map with header names as keys
+;; Read a CSV file and return a vector of maps
+;; Each row becomes a map with header names as keys
 (defn read-csv [filepath]
   (let [handle (php/fopen filepath "r")]
     (if (not handle)
@@ -31,23 +31,24 @@ Read a CSV file and parse it into a vector of maps, where each map represents a 
                 rows)
               (let [row (for [[i k] :pairs header-keys]
                           [k (php/aget line i)])]
-                (recur (conj rows (apply hash-map (flatten row))))))))))))
+                (recur (conj rows (into {} row)))))))))))
 
-# Example usage:
-# Given a file "users.csv" with contents:
-#   name,email,role
-#   Alice,alice@example.com,admin
-#   Bob,bob@example.com,editor
+;; Example usage:
+;; Given a file "users.csv" with contents:
+;;   name,email,role
+;;   Alice,alice@example.com,admin
+;;   Bob,bob@example.com,editor
 
 (def users (read-csv "users.csv"))
-# => [{:name "Alice" :email "alice@example.com" :role "admin"}
-#     {:name "Bob" :email "bob@example.com" :role "editor"}]
+;; => [{:name "Alice" :email "alice@example.com" :role "admin"}
+;;     {:name "Bob" :email "bob@example.com" :role "editor"}]
 
 ;; Process the parsed data
 (def admin-emails
   (->> users
        (filter #(= "admin" (get % :role)))
-       (map :email)))
+       (map :email)
+       (into [])))
 ;; => ["alice@example.com"]
 ```
 
@@ -60,96 +61,92 @@ A command-line script that reads arguments, parses simple flags, and produces ou
 ```phel
 (ns cookbook\cli-tool)
 
-# Access command-line arguments via PHP's $argv
-# When running: vendor/bin/phel run src/cli-tool.phel --name Alice --greeting Hi
+;; Access command-line arguments via PHP's $argv
+;; When running: vendor/bin/phel run src/cli-tool.phel --name Alice --greeting Hi
 (def args (let [argv (php/aget php/$_SERVER "argv")]
-            # Skip the first two args (phel binary and script path)
+            ;; Skip the first two args (phel binary and script path)
             (for [i :range [2 (php/count argv)]]
               (php/aget argv i))))
 
-# Parse flags into a map of --key value pairs
-(defn parse-flags [args]
-  (loop [remaining args
+;; Parse flags into a map of --key value pairs
+(defn parse-flags [flag-args]
+  (loop [remaining flag-args
          flags {}]
     (if (empty? remaining)
       flags
       (let [current (first remaining)
             rest-args (rest remaining)]
         (if (php/str_starts_with current "--")
-          (let [key (keyword (php/substr current 2))
-                value (first rest-args)]
-            (recur (rest rest-args) (assoc flags key value)))
+          (let [k (keyword (php/substr current 2))
+                v (first rest-args)]
+            (recur (rest rest-args) (assoc flags k v)))
           (recur rest-args flags))))))
 
-# Build the tool
+;; Build the tool
 (defn run []
   (let [flags (parse-flags args)
-        name (get flags :name "World")
+        who (get flags :name "World")
         greeting (get flags :greeting "Hello")
         repeat-count (php/intval (get flags :repeat "1"))]
     (dotimes [_ repeat-count]
-      (println (str greeting ", " name "!")))))
+      (println (str greeting ", " who "!")))))
 
 (run)
-# Running: vendor/bin/phel run src/cli-tool.phel --name Alice --repeat 3
-# Output:
-#   Hello, Alice!
-#   Hello, Alice!
-#   Hello, Alice!
+;; Running: vendor/bin/phel run src/cli-tool.phel --name Alice --repeat 3
+;; Output:
+;;   Hello, Alice!
+;;   Hello, Alice!
+;;   Hello, Alice!
 ```
 
 **See also:** [PHP Interop](/documentation/php-interop), [Control Flow](/documentation/language/control-flow)
 
 ## HTTP Request with cURL
 
-Make an HTTP GET request using PHP's cURL functions and parse a JSON response.
+Make an HTTP GET request using the built-in `phel\http-client` module and parse a JSON response with `phel\json`.
 
 ```phel
-(ns cookbook\http-client)
+(ns cookbook\http-client
+  (:require phel\http-client :as http)
+  (:require phel\json :as json))
 
-# Perform an HTTP GET request and return the response body as a string
+;; Perform an HTTP GET request. `http/get` returns an http/response struct
+;; with :status, :headers, :body, :version, and :reason keys.
 (defn http-get [url]
-  (let [ch (php/curl_init)]
-    (php/curl_setopt ch php/CURLOPT_URL url)
-    (php/curl_setopt ch php/CURLOPT_RETURNTRANSFER true)
-    (php/curl_setopt ch php/CURLOPT_FOLLOWLOCATION true)
-    (php/curl_setopt ch php/CURLOPT_TIMEOUT 30)
-    (let [response (php/curl_exec ch)
-          error (php/curl_error ch)
-          status (php/curl_getinfo ch php/CURLINFO_HTTP_CODE)]
-      (php/curl_close ch)
-      (if (= false response)
-        {:error error :status 0}
-        {:body response :status status}))))
+  (let [resp (http/get url {:timeout 30.0 :follow-redirects true})]
+    (if (and (>= (get resp :status) 200) (< (get resp :status) 300))
+      {:body (get resp :body) :status (get resp :status)}
+      {:error (get resp :reason) :status (get resp :status)})))
 
-# Parse a JSON string into a Phel map
+;; Parse a JSON string into a Phel map using phel\json
 (defn parse-json [json-string]
-  (let [decoded (php/json_decode json-string true)]
-    (if (nil? decoded)
-      {:error (php/json_last_error_msg)}
-      decoded)))
+  (try
+    (json/decode json-string)
+    (catch \JsonException e
+      {:error (php/-> e (getMessage))})))
 
-# Fetch data from a JSON API
+;; Fetch data from a JSON API
 (defn fetch-json [url]
   (let [result (http-get url)]
     (if (get result :error)
       result
       (parse-json (get result :body)))))
 
-# Example: fetch a list of todos from a public API
+;; Example: fetch a list of todos from a public API
 (def response (fetch-json "https://jsonplaceholder.typicode.com/todos/1"))
-# response is a PHP associative array, access with php/aget
-(println (str "Title: " (php/aget response "title")))
-(println (str "Completed: " (if (php/aget response "completed") "yes" "no")))
+;; response is a Phel map (phel\json converts keys to keywords)
+(println (str "Title: " (get response :title)))
+(println (str "Completed: " (if (get response :completed) "yes" "no")))
 
-# Example: fetch multiple items and process them
+;; Example: fetch multiple items and process them
 (defn fetch-todos [limit]
   (let [data (fetch-json (str "https://jsonplaceholder.typicode.com/todos?_limit=" limit))]
-    (for [i :range [0 (php/count data)]]
-      (let [todo (php/aget data i)]
-        {:id (php/aget todo "id")
-         :title (php/aget todo "title")
-         :completed (php/aget todo "completed")}))))
+    (->> data
+         (map (fn [todo]
+                {:id (get todo :id)
+                 :title (get todo :title)
+                 :completed (get todo :completed)}))
+         (into []))))
 
 (def todos (fetch-todos 5))
 (def completed-count (count (filter :completed todos)))
@@ -166,7 +163,7 @@ Use Phel's `html` module to generate HTML markup with nested elements, attribute
 (ns cookbook\html-generator
   (:require phel\html :refer [html doctype raw-string]))
 
-# Generate a simple page layout
+;; Generate a simple page layout
 (defn page [title & body]
   (html
     (doctype :html5)
@@ -186,7 +183,7 @@ Use Phel's `html` module to generate HTML markup with nested elements, attribute
         [:h1 title]
         body]]))
 
-# Generate a user card component
+;; Generate a user card component
 (defn user-card [user]
   [:div {:class "card"}
     [:h3 (get user :name)]
@@ -194,14 +191,14 @@ Use Phel's `html` module to generate HTML markup with nested elements, attribute
     [:span {:class [:badge (if (get user :active) "active" "inactive")]}
       (if (get user :active) "Active" "Inactive")]])
 
-# Generate a navigation bar
+;; Generate a navigation bar
 (defn nav [links]
   [:nav
     [:ul {:style {:list-style "none" :display "flex" :gap "1rem" :padding "0"}}
       (for [link :in links]
         [:li [:a {:href (get link :url)} (get link :label)]])]])
 
-# Build a complete page with dynamic content
+;; Build a complete page with dynamic content
 (def users
   [{:name "Alice" :email "alice@example.com" :active true}
    {:name "Bob" :email "bob@example.com" :active false}
@@ -230,62 +227,63 @@ Use PHP's DateTime classes via Phel interop to create, format, and compare dates
 
 ```phel
 (ns cookbook\dates
-  (:use \DateTimeImmutable)
-  (:use \DateInterval)
-  (:use \DateTimeZone))
+  (:use DateTimeImmutable)
+  (:use DateInterval)
+  (:use DateTimeZone))
 
-# Create dates
-(def now (php/new DateTimeImmutable))
-(def specific-date (php/new DateTimeImmutable "2024-06-15"))
+;; Create dates -- `(ClassName. args)` is 0.33 shorthand for `(php/new ClassName args)`
+(def now (DateTimeImmutable.))
+(def specific-date (DateTimeImmutable. "2024-06-15"))
 (def from-format
   (php/:: DateTimeImmutable (createFromFormat "d/m/Y" "25/12/2024")))
 
-# Format dates
-(println (php/-> now (format "Y-m-d H:i:s")))       # 2024-03-10 14:30:00
-(println (php/-> now (format "l, F j, Y")))          # Sunday, March 10, 2024
-(println (php/-> specific-date (format "D, M j")))   # Sat, Jun 15
+;; Format dates
+(println (php/-> now (format "Y-m-d H:i:s")))       ; 2024-03-10 14:30:00
+(println (php/-> now (format "l, F j, Y")))         ; Sunday, March 10, 2024
+(println (php/-> specific-date (format "D, M j")))  ; Sat, Jun 15
 
-# Date arithmetic - add and subtract intervals
+;; Date arithmetic -- add and subtract intervals
 (def tomorrow
   (php/-> now (modify "+1 day")))
 (def next-week
   (php/-> now (modify "+7 days")))
 (def three-months-later
-  (php/-> now (add (php/new DateInterval "P3M"))))
+  (php/-> now (add (DateInterval. "P3M"))))
 
 (println (str "Tomorrow: " (php/-> tomorrow (format "Y-m-d"))))
 (println (str "Next week: " (php/-> next-week (format "Y-m-d"))))
 (println (str "In 3 months: " (php/-> three-months-later (format "Y-m-d"))))
 
-# Compare dates
+;; Compare dates
 (defn date-before? [a b]
   (< (php/-> a (getTimestamp)) (php/-> b (getTimestamp))))
 
 (defn date-after? [a b]
   (> (php/-> a (getTimestamp)) (php/-> b (getTimestamp))))
 
-(println (str "Tomorrow is after today: " (date-after? tomorrow now)))  # true
+(println (str "Tomorrow is after today: " (date-after? tomorrow now)))  ; true
 
-# Calculate the difference between two dates
+;; Calculate the difference between two dates.
+;; `(php/-> obj -prop)` reads a PHP public property (note the leading dash).
 (defn days-between [date1 date2]
   (let [interval (php/-> date1 (diff date2))]
-    (php/-> interval days)))
+    (php/-> interval -days)))
 
-(def start (php/new DateTimeImmutable "2024-01-01"))
-(def end (php/new DateTimeImmutable "2024-12-31"))
-(println (str "Days in 2024: " (days-between start end)))  # 365
+(def start (DateTimeImmutable. "2024-01-01"))
+(def end (DateTimeImmutable. "2024-12-31"))
+(println (str "Days in 2024: " (days-between start end)))  ; 365
 
-# Work with time zones
-(def utc-now (php/new DateTimeImmutable "now" (php/new DateTimeZone "UTC")))
+;; Work with time zones
+(def utc-now (DateTimeImmutable. "now" (DateTimeZone. "UTC")))
 (def tokyo-now
-  (php/-> utc-now (setTimezone (php/new DateTimeZone "Asia/Tokyo"))))
+  (php/-> utc-now (setTimezone (DateTimeZone. "Asia/Tokyo"))))
 
 (println (str "UTC:   " (php/-> utc-now (format "H:i:s"))))
 (println (str "Tokyo: " (php/-> tokyo-now (format "H:i:s"))))
 
-# Utility: human-readable relative time
+;; Utility: human-readable relative time
 (defn time-ago [date]
-  (let [seconds (- (php/-> (php/new DateTimeImmutable) (getTimestamp))
+  (let [seconds (- (php/-> (DateTimeImmutable.) (getTimestamp))
                    (php/-> date (getTimestamp)))]
     (cond
       (< seconds 60) "just now"
@@ -303,28 +301,28 @@ Read files, write files, list directories, and check file existence using PHP in
 ```phel
 (ns cookbook\filesystem)
 
-# Read entire file contents
+;; Read entire file contents
 (defn read-file [path]
   (let [contents (php/file_get_contents path)]
     (if (= false contents)
       nil
       contents)))
 
-# Write content to a file (creates or overwrites)
+;; Write content to a file (creates or overwrites)
 (defn write-file [path content]
   (let [result (php/file_put_contents path content)]
     (if (= false result)
       (do (println (str "Error: could not write to " path)) false)
       true)))
 
-# Append content to a file
+;; Append content to a file
 (defn append-file [path content]
   (let [result (php/file_put_contents path content php/FILE_APPEND)]
     (if (= false result)
       (do (println (str "Error: could not append to " path)) false)
       true)))
 
-# Check if a file or directory exists
+;; Check if a file or directory exists
 (defn exists? [path]
   (php/file_exists path))
 
@@ -334,7 +332,7 @@ Read files, write files, list directories, and check file existence using PHP in
 (defn directory? [path]
   (php/is_dir path))
 
-# List directory contents, excluding . and ..
+;; List directory contents, excluding . and ..
 (defn list-dir [path]
   (if (not (directory? path))
     []
@@ -344,7 +342,7 @@ Read files, write files, list directories, and check file existence using PHP in
             :when (and (not= entry ".") (not= entry ".."))]
         entry))))
 
-# List files matching a pattern
+;; List files matching a pattern
 (defn glob-files [pattern]
   (let [matches (php/glob pattern)]
     (if (= false matches)
@@ -352,7 +350,7 @@ Read files, write files, list directories, and check file existence using PHP in
       (for [i :range [0 (php/count matches)]]
         (php/aget matches i)))))
 
-# Get file info
+;; Get file info
 (defn file-info [path]
   (if (not (exists? path))
     nil
@@ -362,29 +360,31 @@ Read files, write files, list directories, and check file existence using PHP in
      :readable (php/is_readable path)
      :writable (php/is_writable path)}))
 
-# Create directory recursively
+;; Create directory recursively
 (defn mkdir [path]
   (when (not (exists? path))
     (php/mkdir path 0755 true)))
 
-# Example usage
+;; Example usage
 (write-file "output/example.txt" "Hello from Phel!\n")
 (append-file "output/example.txt" "Another line.\n")
 
 (when (exists? "output/example.txt")
   (println (read-file "output/example.txt")))
 
-# List all .phel files in a directory
+;; List all .phel files in a directory
 (def phel-files (glob-files "src/**/*.phel"))
 (foreach [f phel-files]
   (println (str "Found: " f)))
 
-# Get info about each file
+;; Get info about each file. `map` / `filter` are lazy -- finish the pipeline
+;; with `into` (or `vec` / `doall`) to realise the result.
 (def file-report
   (->> phel-files
        (map file-info)
        (sort-by :size)
-       (reverse)))
+       (reverse)
+       (into [])))
 ```
 
 **See also:** [PHP Interop](/documentation/php-interop)
@@ -396,7 +396,7 @@ Take raw data, filter it, transform it, and group it using Phel's threading macr
 ```phel
 (ns cookbook\data-pipeline)
 
-# Sample dataset: a vector of user maps
+;; Sample dataset: a vector of user maps
 (def users
   [{:name "Alice"   :age 32 :role "engineer" :active true}
    {:name "Bob"     :age 28 :role "designer" :active false}
@@ -406,30 +406,30 @@ Take raw data, filter it, transform it, and group it using Phel's threading macr
    {:name "Frank"   :age 52 :role "manager"  :active false}
    {:name "Grace"   :age 38 :role "engineer" :active true}])
 
-# Pipeline: get active users, uppercase names, sort by age, group by role
+;; Pipeline: get active users, uppercase names, sort by age, group by role
 (def result
   (->> users
-       (filter :active)                              ;; keep only active users
-       (map #(assoc % :name (php/strtoupper (get % :name))))  ;; uppercase names
-       (sort-by :age)                                ;; sort by age ascending
-       (group-by :role)))                            ;; group into a map by role
+       (filter :active)                                       ; keep only active users
+       (map #(assoc % :name (php/strtoupper (get % :name))))  ; uppercase names
+       (sort-by :age)                                         ; sort by age ascending
+       (group-by :role)))                                     ; group into a map by role
 
-# result =>
-# {"engineer" [{:name "ALICE"   :age 32 ...}
-#              {:name "GRACE"   :age 38 ...}
-#              {:name "CHARLIE" :age 45 ...}]
-#  "manager"  [{:name "DIANA"   :age 35 ...}]
-#  "designer" [{:name "EVE"     :age 29 ...}]}
+;; result =>
+;; {"engineer" [{:name "ALICE"   :age 32 ...}
+;;              {:name "GRACE"   :age 38 ...}
+;;              {:name "CHARLIE" :age 45 ...}]
+;;  "manager"  [{:name "DIANA"   :age 35 ...}]
+;;  "designer" [{:name "EVE"     :age 29 ...}]}
 
-# Print a summary report
+;; Print a summary report. A 3-element `foreach` binds key and value of a map.
 (foreach [role members result]
   (println (str "== " (php/strtoupper role) " (" (count members) ") =="))
   (foreach [m members]
     (println (str "  " (get m :name) " (age " (get m :age) ")"))))
 
-# More pipeline examples:
+;; More pipeline examples:
 
-# Average age of active users
+;; Average age of active users
 (def avg-age
   (let [active (filter :active users)
         total-age (reduce + 0 (map :age active))]
@@ -451,7 +451,7 @@ Take raw data, filter it, transform it, and group it using Phel's threading macr
 (println (str "Active: " (get status-counts :active)
               ", Inactive: " (get status-counts :inactive)))
 
-# Extract unique roles
+;; Extract unique roles
 (def roles
   (->> users
        (map :role)
@@ -466,86 +466,80 @@ Take raw data, filter it, transform it, and group it using Phel's threading macr
 Build a persistent key-value store backed by a JSON file, with functions for get, put, delete, and listing keys.
 
 ```phel
-(ns cookbook\kv-store)
+(ns cookbook\kv-store
+  (:require phel\json :as json))
 
-# Path to the JSON storage file
+;; Path to the JSON storage file
 (def default-store-path "data/store.json")
 
-# Load the store from disk, returning a Phel map
+;; Load the store from disk, returning a Phel map
 (defn store-load [path]
   (if (not (php/file_exists path))
     {}
     (let [contents (php/file_get_contents path)]
       (if (or (= false contents) (= "" contents))
         {}
-        (let [decoded (php/json_decode contents true)]
-          (if (nil? decoded)
-            {}
-            # Convert PHP associative array to Phel map
-            (for [[k v] :pairs decoded :reduce [m {}]]
-              (assoc m k v))))))))
+        (try
+          (json/decode contents)
+          (catch \JsonException _ {}))))))
 
-# Save the store to disk as JSON
+;; Save the store to disk as pretty-printed JSON
 (defn store-save [path data]
   (let [dir (php/dirname path)]
     (when (not (php/is_dir dir))
       (php/mkdir dir 0755 true))
-    # Convert Phel map to PHP array for json_encode
-    (let [php-arr (php/array)]
-      (foreach [k v data]
-        (php/aset php-arr k v))
-      (php/file_put_contents
-        path
-        (php/json_encode php-arr php/JSON_PRETTY_PRINT)))))
+    (php/file_put_contents
+      path
+      (json/encode data {:flags php/JSON_PRETTY_PRINT}))))
 
-# Get a value by key, with an optional default
+;; Get a value by key, with an optional default
 (defn store-get
-  ([key] (store-get default-store-path key nil))
-  ([key default] (store-get default-store-path key default))
-  ([path key default]
-    (get (store-load path) key default)))
+  ([k] (store-get default-store-path k nil))
+  ([k default] (store-get default-store-path k default))
+  ([path k default]
+    (get (store-load path) k default)))
 
-# Put a key-value pair into the store
+;; Put a key-value pair into the store
 (defn store-put
-  ([key value] (store-put default-store-path key value))
-  ([path key value]
+  ([k v] (store-put default-store-path k v))
+  ([path k v]
     (let [data (store-load path)
-          updated (assoc data key value)]
+          updated (assoc data k v)]
       (store-save path updated)
       updated)))
 
-# Delete a key from the store
+;; Delete a key from the store
 (defn store-delete
-  ([key] (store-delete default-store-path key))
-  ([path key]
+  ([k] (store-delete default-store-path k))
+  ([path k]
     (let [data (store-load path)
-          updated (dissoc data key)]
+          updated (dissoc data k)]
       (store-save path updated)
       updated)))
 
-# List all keys in the store
+;; List all keys in the store
 (defn store-keys
   ([] (store-keys default-store-path))
   ([path] (keys (store-load path))))
 
-# Check if a key exists
+;; Check if a key exists
 (defn store-has?
-  ([key] (store-has? default-store-path key))
-  ([path key] (contains? (store-load path) key)))
+  ([k] (store-has? default-store-path k))
+  ([path k] (contains? (store-load path) k)))
 
-# Example usage
-(store-put "user:1" "Alice")
-(store-put "user:2" "Bob")
-(store-put "config:theme" "dark")
+;; Example usage
+(store-put :user-1 "Alice")
+(store-put :user-2 "Bob")
+(store-put :config-theme "dark")
 
-(println (str "User 1: " (store-get "user:1")))           # Alice
-(println (str "User 3: " (store-get "user:3" "unknown"))) # unknown
-(println (str "Keys: " (store-keys)))                      # ("user:1" "user:2" "config:theme")
+(println (str "User 1: " (store-get :user-1)))             ; Alice
+(println (str "User 3: " (store-get :user-3 "unknown")))   ; unknown
+(println (str "Keys: " (store-keys)))                       ; (:user-1 :user-2 :config-theme)
 
-(store-delete "user:2")
-(println (str "Has user:2? " (store-has? "user:2")))       # false
+(store-delete :user-2)
+(println (str "Has :user-2? " (store-has? :user-2)))       ; false
 
-# Bulk operations using Phel's functional tools
+;; Bulk operations using Phel's functional tools
 (defn store-put-many [pairs]
   (let [path default-store-path
         data (store-load path)
@@ -553,7 +547,7 @@ Build a persistent key-value store backed by a JSON file, with functions for get
     (store-save path updated)
     updated))
 
-(store-put-many [["lang" "phel"] ["version" "0.30"] ["status" "awesome"]])
+(store-put-many [[:lang "phel"] [:version "0.33"] [:status "awesome"]])
 (println (str "All keys: " (store-keys)))
 ```
 
@@ -747,15 +741,9 @@ Phel v0.31.0 introduces regex literals (`#"..."`) and matching functions for wor
 (parse-color "not-a-color")
 ;; => nil
 
-;; Extract all matches from a string using PHP interop
-(defn re-find-all [pattern s]
-  (let [matches (php/array)]
-    (php/preg_match_all (str pattern) s matches)
-    (for [i :range [0 (php/count (php/aget matches 0))]]
-      (php/aget (php/aget matches 0) i))))
-
-(re-find-all #"\b[A-Z][a-z]+" "Alice met Bob and Charlie")
-;; => ["Alice" "Bob" "Charlie"]
+;; Extract all successive matches with `re-seq` (lazy sequence of matches).
+(re-seq #"\b[A-Z][a-z]+" "Alice met Bob and Charlie")
+;; => ("Alice" "Bob" "Charlie")
 ```
 
 **See also:** [Cheat Sheet -- Regular Expressions](/documentation/reference/cheat-sheet#regular-expressions)
@@ -765,7 +753,15 @@ Phel v0.31.0 introduces regex literals (`#"..."`) and matching functions for wor
 Use `ex-info` to create exceptions that carry structured data, making error handling more informative than plain string messages.
 
 ```phel
-(ns cookbook\exceptions)
+(ns cookbook\exceptions
+  (:require phel\json :as json))
+
+;; Stub user lookup -- replace with real datasource
+(def users {1 {:id 1 :name "Alice"}
+            2 {:id 2 :name "Bob"}})
+
+(defn lookup-user-by-id [id]
+  (get users id))
 
 ;; Throw a structured exception
 (defn find-user [id]
@@ -793,7 +789,7 @@ Use `ex-info` to create exceptions that carry structured data, making error hand
     (let [raw (php/file_get_contents path)]
       (when (= false raw)
         (throw (ex-info "File not readable" {:path path})))
-      (php/json_decode raw true))
+      (json/decode raw))
     (catch \Exception e
       (throw (ex-info "Config load failed"
                       {:path path :step :read}

--- a/css/components/animated-repl.css
+++ b/css/components/animated-repl.css
@@ -1,5 +1,19 @@
 /* Animated Terminal REPL */
 .terminal {
+  --t-header-bg: #e5e7eb;
+  --t-header-border: rgba(0, 0, 0, 0.06);
+  --t-title: #6b7280;
+  --t-body-bg: #ffffff;
+  --t-input: #1f2937;
+  --t-output: #6b7280;
+  --t-result: #0369a1;
+  --t-shell: #047857;
+  --t-prompt: #b45309;
+  --t-replay-border: #d1d5db;
+  --t-replay-text: #6b7280;
+  --t-replay-hover: #0369a1;
+  --t-scrollbar: #d1d5db;
+
   border-radius: var(--radius-lg);
   overflow: hidden;
   box-shadow: var(--shadow-lg);
@@ -7,10 +21,27 @@
   font-size: 14px;
   max-width: 680px;
   margin: 2rem auto;
+  border: 1px solid var(--t-header-border);
+}
+
+.dark .terminal {
+  --t-header-bg: #2d2d2d;
+  --t-header-border: rgba(255, 255, 255, 0.05);
+  --t-title: #999;
+  --t-body-bg: #1a1a2e;
+  --t-input: #e0e0e0;
+  --t-output: #888;
+  --t-result: #7ec8e3;
+  --t-shell: #28c840;
+  --t-prompt: #ffbd2e;
+  --t-replay-border: #555;
+  --t-replay-text: #999;
+  --t-replay-hover: #7ec8e3;
+  --t-scrollbar: #444;
 }
 
 .terminal-header {
-  background: #2d2d2d;
+  background: var(--t-header-bg);
   padding: 0.625rem 1rem;
   display: flex;
   align-items: center;
@@ -34,13 +65,13 @@
 .terminal-dot-green { background: #28c840; }
 
 .terminal-title {
-  color: #999;
+  color: var(--t-title);
   font-size: 13px;
   font-weight: 500;
 }
 
 .terminal-body {
-  background: #1a1a2e;
+  background: var(--t-body-bg);
   padding: 1rem 1.25rem;
   min-height: 280px;
   line-height: 1.6;
@@ -52,25 +83,25 @@
 }
 
 .terminal-input {
-  color: #e0e0e0;
+  color: var(--t-input);
 }
 
 .terminal-output {
-  color: #888;
+  color: var(--t-output);
 }
 
 .terminal-result {
-  color: #7ec8e3;
+  color: var(--t-result);
   margin-bottom: 0.25rem;
 }
 
 .terminal-shell {
-  color: #28c840;
+  color: var(--t-shell);
   user-select: none;
 }
 
 .terminal-prompt {
-  color: #ffbd2e;
+  color: var(--t-prompt);
   user-select: none;
 }
 
@@ -81,8 +112,8 @@
 
 .terminal-replay-btn {
   background: transparent;
-  border: 1px solid #555;
-  color: #999;
+  border: 1px solid var(--t-replay-border);
+  color: var(--t-replay-text);
   padding: 0.25rem 0.75rem;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -92,8 +123,8 @@
 }
 
 .terminal-replay-btn:hover {
-  border-color: #7ec8e3;
-  color: #7ec8e3;
+  border-color: var(--t-replay-hover);
+  color: var(--t-replay-hover);
 }
 
 /* Scrollbar styling for terminal */
@@ -106,6 +137,6 @@
 }
 
 .terminal-body::-webkit-scrollbar-thumb {
-  background: #444;
+  background: var(--t-scrollbar);
   border-radius: 3px;
 }

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -63,6 +63,28 @@
 
 /* Phel Terminal (homepage REPL showcase) — styling mirrors animated-repl.css */
 .phel-terminal {
+  --t-chrome-bg: #e5e7eb;
+  --t-chrome-border: rgba(0, 0, 0, 0.06);
+  --t-title: #6b7280;
+  --t-tabs-bg: #e5e7eb;
+  --t-tab-text: #6b7280;
+  --t-tab-hover-bg: rgba(0, 0, 0, 0.04);
+  --t-tab-active-text: #111827;
+  --t-tab-active-bg: #ffffff;
+  --t-tab-active-border: #b45309;
+  --t-body-bg: #ffffff;
+  --t-comment: #6b7280;
+  --t-prompt: #b45309;
+  --t-prompt-cont: rgba(180, 83, 9, 0.4);
+  --t-input: #1f2937;
+  --t-output: #0369a1;
+  --t-focus: #b45309;
+  --t-copy-bg: rgba(255, 255, 255, 0.95);
+  --t-copy-border: #d1d5db;
+  --t-copy-text: #6b7280;
+  --t-copy-hover: #0369a1;
+  --t-scrollbar: #d1d5db;
+
   margin: var(--space-2xl) auto;
   max-width: 680px;
   border-radius: var(--radius-lg);
@@ -70,6 +92,31 @@
   overflow: hidden;
   font-family: 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
   font-size: 14px;
+  border: 1px solid var(--t-chrome-border);
+}
+
+.dark .phel-terminal {
+  --t-chrome-bg: #2d2d2d;
+  --t-chrome-border: rgba(255, 255, 255, 0.05);
+  --t-title: #999;
+  --t-tabs-bg: #2d2d2d;
+  --t-tab-text: #999;
+  --t-tab-hover-bg: rgba(126, 200, 227, 0.06);
+  --t-tab-active-text: #e0e0e0;
+  --t-tab-active-bg: #1a1a2e;
+  --t-tab-active-border: #ffbd2e;
+  --t-body-bg: #1a1a2e;
+  --t-comment: #888;
+  --t-prompt: #ffbd2e;
+  --t-prompt-cont: rgba(255, 189, 46, 0.45);
+  --t-input: #e0e0e0;
+  --t-output: #7ec8e3;
+  --t-focus: #ffbd2e;
+  --t-copy-bg: rgba(45, 45, 45, 0.9);
+  --t-copy-border: #555;
+  --t-copy-text: #999;
+  --t-copy-hover: #7ec8e3;
+  --t-scrollbar: #444;
 }
 
 .phel-terminal-chrome {
@@ -77,7 +124,7 @@
   align-items: center;
   gap: var(--space-md);
   padding: 0.625rem 1rem;
-  background: #2d2d2d;
+  background: var(--t-chrome-bg);
 }
 
 .phel-terminal-dots {
@@ -102,7 +149,7 @@
   text-align: center;
   font-size: 13px;
   font-weight: 500;
-  color: #999;
+  color: var(--t-title);
   user-select: none;
 }
 
@@ -115,8 +162,8 @@
   flex-wrap: wrap;
   gap: 0;
   padding: 0 0.5rem;
-  background: #2d2d2d;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--t-tabs-bg);
+  border-top: 1px solid var(--t-chrome-border);
   overflow-x: auto;
 }
 
@@ -133,31 +180,31 @@
   font-size: 13px;
   font-weight: 500;
   line-height: 1.4;
-  color: #999;
+  color: var(--t-tab-text);
   cursor: pointer;
   white-space: nowrap;
   transition: color 0.2s, border-color 0.2s, background 0.2s;
 }
 
 .phel-terminal-tab:hover {
-  color: #e0e0e0;
-  background: rgba(126, 200, 227, 0.06);
+  color: var(--t-tab-active-text);
+  background: var(--t-tab-hover-bg);
 }
 
 .phel-terminal-tab.is-active {
-  color: #e0e0e0;
-  background: #1a1a2e;
-  border-top-color: #ffbd2e;
+  color: var(--t-tab-active-text);
+  background: var(--t-tab-active-bg);
+  border-top-color: var(--t-tab-active-border);
 }
 
 .phel-terminal-tab:focus-visible {
-  outline: 2px solid #ffbd2e;
+  outline: 2px solid var(--t-focus);
   outline-offset: -2px;
 }
 
 .phel-terminal-body {
   position: relative;
-  background: #1a1a2e;
+  background: var(--t-body-bg);
 }
 
 .phel-terminal-session {
@@ -168,7 +215,7 @@
   border: none;
   border-radius: 0;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--t-input);
   font-family: inherit;
   font-size: 14px;
   line-height: 1.6;
@@ -194,37 +241,37 @@
 }
 
 .phel-terminal-body .copy-code-button {
-  color: #999;
-  background: rgba(45, 45, 45, 0.9);
-  border-color: #555;
+  color: var(--t-copy-text);
+  background: var(--t-copy-bg);
+  border-color: var(--t-copy-border);
 }
 
 .phel-terminal-body .copy-code-button:hover {
-  color: #7ec8e3;
-  border-color: #7ec8e3;
+  color: var(--t-copy-hover);
+  border-color: var(--t-copy-hover);
 }
 
 .phel-terminal-session .t-cmt {
-  color: #888;
+  color: var(--t-comment);
 }
 
 .phel-terminal-session .t-p {
-  color: #ffbd2e;
+  color: var(--t-prompt);
   font-weight: 500;
   user-select: none;
 }
 
 .phel-terminal-session .t-c {
-  color: rgba(255, 189, 46, 0.45);
+  color: var(--t-prompt-cont);
   user-select: none;
 }
 
 .phel-terminal-session .t-in {
-  color: #e0e0e0;
+  color: var(--t-input);
 }
 
 .phel-terminal-session .t-out {
-  color: #7ec8e3;
+  color: var(--t-output);
 }
 
 .phel-terminal-session::-webkit-scrollbar {
@@ -236,7 +283,7 @@
 }
 
 .phel-terminal-session::-webkit-scrollbar-thumb {
-  background: #444;
+  background: var(--t-scrollbar);
   border-radius: 3px;
 }
 

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -61,6 +61,91 @@
   margin-right: 0;
 }
 
+/* Homepage Tabs */
+.homepage-tabs {
+  margin-top: var(--space-2xl);
+  margin-bottom: var(--space-2xl);
+}
+
+.homepage-tabs-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  border-bottom: 1px solid var(--color-light-border);
+  margin-bottom: var(--space-md);
+}
+
+.homepage-tab-btn {
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--color-light-text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  transition: color var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}
+
+.homepage-tab-btn:hover {
+  color: var(--color-light-link);
+  background: rgba(108, 61, 197, 0.05);
+}
+
+.homepage-tab-btn.is-active {
+  color: var(--color-light-link);
+  border-bottom-color: var(--color-light-link);
+}
+
+.homepage-tab-btn:focus-visible {
+  outline: 2px solid var(--color-light-link);
+  outline-offset: 2px;
+}
+
+.homepage-tab-panel {
+  display: none;
+}
+
+.homepage-tab-panel.is-active {
+  display: block;
+}
+
+.homepage-tab-panel .code-block-wrapper,
+.homepage-tab-panel pre {
+  margin-top: 0;
+}
+
+.dark .homepage-tabs-nav {
+  border-bottom-color: var(--color-dark-border);
+}
+
+.dark .homepage-tab-btn {
+  color: var(--color-dark-text-secondary);
+}
+
+.dark .homepage-tab-btn:hover {
+  color: var(--color-dark-text-accent);
+  background: rgba(191, 164, 255, 0.08);
+}
+
+.dark .homepage-tab-btn.is-active {
+  color: var(--color-dark-text-accent);
+  border-bottom-color: var(--color-dark-text-accent);
+}
+
+.dark .homepage-tab-btn:focus-visible {
+  outline-color: var(--color-dark-text-accent);
+}
+
 /* Homepage Why Section */
 .homepage-why-section h2 {
   text-align: center;

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -61,141 +61,172 @@
   margin-right: 0;
 }
 
-/* Homepage Tabs */
-.homepage-tabs {
-  margin-top: var(--space-2xl);
-  margin-bottom: var(--space-2xl);
+/* Phel Terminal (homepage REPL showcase) */
+.phel-terminal {
+  margin: var(--space-2xl) auto;
+  max-width: 56rem;
+  background: #0b0d18;
+  color: #e5e7eb;
+  border: 1px solid rgba(191, 164, 255, 0.2);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.55),
+              0 0 0 1px rgba(108, 61, 197, 0.15);
+  overflow: hidden;
+  font-family: var(--font-mono);
 }
 
-.homepage-tabs-nav {
+.phel-terminal-chrome {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: linear-gradient(180deg, #1a1d2e 0%, #141627 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.phel-terminal-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.phel-terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: block;
+}
+
+.phel-terminal-dot--red    { background: #ff5f57; }
+.phel-terminal-dot--yellow { background: #febc2e; }
+.phel-terminal-dot--green  { background: #28c840; }
+
+.phel-terminal-title {
+  flex: 1;
+  text-align: center;
+  font-size: var(--text-xs);
+  color: rgba(229, 231, 235, 0.55);
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+
+.phel-terminal-chrome-spacer {
+  width: 42px;
+}
+
+.phel-terminal-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-xs);
-  border-bottom: 1px solid var(--color-light-border);
-  margin-bottom: var(--space-md);
+  gap: 2px;
+  padding: 0 var(--space-md);
+  background: #12142a;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  overflow-x: auto;
 }
 
-.homepage-tab-btn {
+.phel-terminal-tab {
   display: inline-flex;
   align-items: center;
   box-sizing: border-box;
   background: transparent;
   border: none;
-  border-bottom: 2px solid transparent;
+  border-top: 2px solid transparent;
   margin: 0;
   padding: var(--space-sm) var(--space-md);
-  font-family: inherit;
-  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   font-weight: 500;
-  line-height: 1.5;
-  color: var(--color-light-text-secondary);
+  line-height: 1.4;
+  color: rgba(229, 231, 235, 0.55);
   cursor: pointer;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  white-space: nowrap;
   transition: color var(--duration-fast) var(--ease-out),
               border-color var(--duration-fast) var(--ease-out),
               background var(--duration-fast) var(--ease-out);
 }
 
-.homepage-tab-btn:hover {
-  color: var(--color-light-link);
-  background: rgba(108, 61, 197, 0.05);
+.phel-terminal-tab:hover {
+  color: #e5e7eb;
+  background: rgba(191, 164, 255, 0.06);
 }
 
-.homepage-tab-btn.is-active {
-  color: var(--color-light-link);
-  border-bottom-color: var(--color-light-link);
+.phel-terminal-tab.is-active {
+  color: #ffffff;
+  background: #0b0d18;
+  border-top-color: var(--color-dark-text-accent, #bfa4ff);
 }
 
-.homepage-tab-btn:focus-visible {
-  outline: 2px solid var(--color-light-link);
-  outline-offset: 2px;
+.phel-terminal-tab:focus-visible {
+  outline: 2px solid var(--color-dark-text-accent, #bfa4ff);
+  outline-offset: -2px;
 }
 
-.homepage-tab-panel {
+.phel-terminal-body {
+  position: relative;
+}
+
+.phel-terminal-session {
   display: none;
+  margin: 0;
+  padding: var(--space-lg) var(--space-xl);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  color: #e5e7eb;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre;
+  max-width: none;
 }
 
-.homepage-tab-panel.is-active {
+.phel-terminal-session.is-active {
   display: block;
 }
 
-.homepage-tab-panel .code-block-wrapper,
-.homepage-tab-panel pre {
-  margin-top: 0;
+.phel-terminal-body .code-block-wrapper {
+  margin: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
 }
 
-.homepage-repl {
-  margin-top: var(--space-md);
-  margin-bottom: 0;
-  padding: var(--space-md) var(--space-lg);
-  background: #0f1220;
+.phel-terminal-body .code-block-wrapper::before {
+  display: none;
+}
+
+.phel-terminal-body .copy-code-button {
+  color: rgba(229, 231, 235, 0.6);
+}
+
+.phel-terminal-body .copy-code-button:hover {
   color: #e5e7eb;
-  border: 1px solid rgba(108, 61, 197, 0.35);
-  border-radius: var(--radius-md);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  line-height: 1.6;
-  overflow-x: auto;
-  white-space: pre;
 }
 
-.homepage-repl-prompt,
-.homepage-repl-cont {
-  color: var(--color-light-link);
-  font-weight: 600;
+.phel-terminal-session .t-cmt {
+  color: rgba(229, 231, 235, 0.4);
+  font-style: italic;
+}
+
+.phel-terminal-session .t-p {
+  color: var(--color-dark-text-accent, #bfa4ff);
+  font-weight: 700;
   user-select: none;
 }
 
-.homepage-repl-cont {
-  color: rgba(191, 164, 255, 0.55);
+.phel-terminal-session .t-c {
+  color: rgba(191, 164, 255, 0.4);
+  user-select: none;
 }
 
-.homepage-repl-input {
+.phel-terminal-session .t-in {
   color: #e5e7eb;
 }
 
-.homepage-repl-out {
-  color: #a5f3a5;
-  font-style: normal;
-}
-
-.dark .homepage-repl {
-  background: #0b0d18;
-  border-color: rgba(191, 164, 255, 0.25);
-}
-
-.dark .homepage-repl-prompt {
-  color: var(--color-dark-text-accent);
-}
-
-.dark .homepage-repl-cont {
-  color: rgba(191, 164, 255, 0.5);
-}
-
-.dark .homepage-repl-out {
+.phel-terminal-session .t-out {
   color: #86efac;
-}
-
-.dark .homepage-tabs-nav {
-  border-bottom-color: var(--color-dark-border);
-}
-
-.dark .homepage-tab-btn {
-  color: var(--color-dark-text-secondary);
-}
-
-.dark .homepage-tab-btn:hover {
-  color: var(--color-dark-text-accent);
-  background: rgba(191, 164, 255, 0.08);
-}
-
-.dark .homepage-tab-btn.is-active {
-  color: var(--color-dark-text-accent);
-  border-bottom-color: var(--color-dark-text-accent);
-}
-
-.dark .homepage-tab-btn:focus-visible {
-  outline-color: var(--color-dark-text-accent);
 }
 
 

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -124,6 +124,58 @@
   margin-top: 0;
 }
 
+.homepage-repl {
+  margin-top: var(--space-md);
+  margin-bottom: 0;
+  padding: var(--space-md) var(--space-lg);
+  background: #0f1220;
+  color: #e5e7eb;
+  border: 1px solid rgba(108, 61, 197, 0.35);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.homepage-repl-prompt,
+.homepage-repl-cont {
+  color: var(--color-light-link);
+  font-weight: 600;
+  user-select: none;
+}
+
+.homepage-repl-cont {
+  color: rgba(191, 164, 255, 0.55);
+}
+
+.homepage-repl-input {
+  color: #e5e7eb;
+}
+
+.homepage-repl-out {
+  color: #a5f3a5;
+  font-style: normal;
+}
+
+.dark .homepage-repl {
+  background: #0b0d18;
+  border-color: rgba(191, 164, 255, 0.25);
+}
+
+.dark .homepage-repl-prompt {
+  color: var(--color-dark-text-accent);
+}
+
+.dark .homepage-repl-cont {
+  color: rgba(191, 164, 255, 0.5);
+}
+
+.dark .homepage-repl-out {
+  color: #86efac;
+}
+
 .dark .homepage-tabs-nav {
   border-bottom-color: var(--color-dark-border);
 }
@@ -145,6 +197,7 @@
 .dark .homepage-tab-btn:focus-visible {
   outline-color: var(--color-dark-text-accent);
 }
+
 
 /* Homepage Why Section */
 .homepage-why-section h2 {

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -61,27 +61,23 @@
   margin-right: 0;
 }
 
-/* Phel Terminal (homepage REPL showcase) */
+/* Phel Terminal (homepage REPL showcase) — styling mirrors animated-repl.css */
 .phel-terminal {
   margin: var(--space-2xl) auto;
-  max-width: 56rem;
-  background: #262a3b;
-  color: #e5e7eb;
-  border: 1px solid rgba(191, 164, 255, 0.18);
+  max-width: 680px;
   border-radius: var(--radius-lg);
-  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.45),
-              0 0 0 1px rgba(108, 61, 197, 0.1);
+  box-shadow: var(--shadow-lg);
   overflow: hidden;
-  font-family: var(--font-mono);
+  font-family: 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
+  font-size: 14px;
 }
 
 .phel-terminal-chrome {
   display: flex;
   align-items: center;
   gap: var(--space-md);
-  padding: var(--space-sm) var(--space-md);
-  background: linear-gradient(180deg, #353a50 0%, #2c3043 100%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 0.625rem 1rem;
+  background: #2d2d2d;
 }
 
 .phel-terminal-dots {
@@ -93,19 +89,20 @@
   width: 12px;
   height: 12px;
   border-radius: 50%;
+  background: #555;
   display: block;
 }
 
 .phel-terminal-dot--red    { background: #ff5f57; }
-.phel-terminal-dot--yellow { background: #febc2e; }
+.phel-terminal-dot--yellow { background: #ffbd2e; }
 .phel-terminal-dot--green  { background: #28c840; }
 
 .phel-terminal-title {
   flex: 1;
   text-align: center;
-  font-size: var(--text-xs);
-  color: rgba(229, 231, 235, 0.55);
-  letter-spacing: 0.02em;
+  font-size: 13px;
+  font-weight: 500;
+  color: #999;
   user-select: none;
 }
 
@@ -116,10 +113,10 @@
 .phel-terminal-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 2px;
-  padding: 0 var(--space-md);
-  background: #2d3143;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  gap: 0;
+  padding: 0 0.5rem;
+  background: #242438;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   overflow-x: auto;
 }
 
@@ -131,51 +128,50 @@
   border: none;
   border-top: 2px solid transparent;
   margin: 0;
-  padding: var(--space-sm) var(--space-md);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
+  padding: 0.5rem 0.875rem;
+  font-family: inherit;
+  font-size: 13px;
   font-weight: 500;
   line-height: 1.4;
-  color: rgba(229, 231, 235, 0.55);
+  color: #999;
   cursor: pointer;
   white-space: nowrap;
-  transition: color var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out),
-              background var(--duration-fast) var(--ease-out);
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
 }
 
 .phel-terminal-tab:hover {
-  color: #e5e7eb;
-  background: rgba(191, 164, 255, 0.06);
+  color: #e0e0e0;
+  background: rgba(126, 200, 227, 0.06);
 }
 
 .phel-terminal-tab.is-active {
-  color: #ffffff;
-  background: #262a3b;
-  border-top-color: var(--color-dark-text-accent, #bfa4ff);
+  color: #e0e0e0;
+  background: #1a1a2e;
+  border-top-color: #ffbd2e;
 }
 
 .phel-terminal-tab:focus-visible {
-  outline: 2px solid var(--color-dark-text-accent, #bfa4ff);
+  outline: 2px solid #ffbd2e;
   outline-offset: -2px;
 }
 
 .phel-terminal-body {
   position: relative;
+  background: #1a1a2e;
 }
 
 .phel-terminal-session {
   display: none;
   margin: 0;
-  padding: var(--space-lg) var(--space-xl);
+  padding: 1rem 1.25rem;
   background: transparent;
   border: none;
   border-radius: 0;
   box-shadow: none;
-  color: #e5e7eb;
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  line-height: 1.65;
+  color: #e0e0e0;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.6;
   overflow-x: auto;
   white-space: pre;
   max-width: none;
@@ -198,35 +194,50 @@
 }
 
 .phel-terminal-body .copy-code-button {
-  color: rgba(229, 231, 235, 0.6);
+  color: #999;
+  background: rgba(45, 45, 45, 0.9);
+  border-color: #555;
 }
 
 .phel-terminal-body .copy-code-button:hover {
-  color: #e5e7eb;
+  color: #7ec8e3;
+  border-color: #7ec8e3;
 }
 
 .phel-terminal-session .t-cmt {
-  color: rgba(229, 231, 235, 0.4);
-  font-style: italic;
+  color: #888;
 }
 
 .phel-terminal-session .t-p {
-  color: var(--color-dark-text-accent, #bfa4ff);
-  font-weight: 700;
+  color: #ffbd2e;
+  font-weight: 500;
   user-select: none;
 }
 
 .phel-terminal-session .t-c {
-  color: rgba(191, 164, 255, 0.4);
+  color: rgba(255, 189, 46, 0.45);
   user-select: none;
 }
 
 .phel-terminal-session .t-in {
-  color: #e5e7eb;
+  color: #e0e0e0;
 }
 
 .phel-terminal-session .t-out {
-  color: #86efac;
+  color: #7ec8e3;
+}
+
+.phel-terminal-session::-webkit-scrollbar {
+  height: 6px;
+}
+
+.phel-terminal-session::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.phel-terminal-session::-webkit-scrollbar-thumb {
+  background: #444;
+  border-radius: 3px;
 }
 
 

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -65,12 +65,12 @@
 .phel-terminal {
   margin: var(--space-2xl) auto;
   max-width: 56rem;
-  background: #0b0d18;
+  background: #262a3b;
   color: #e5e7eb;
-  border: 1px solid rgba(191, 164, 255, 0.2);
+  border: 1px solid rgba(191, 164, 255, 0.18);
   border-radius: var(--radius-lg);
-  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.55),
-              0 0 0 1px rgba(108, 61, 197, 0.15);
+  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.45),
+              0 0 0 1px rgba(108, 61, 197, 0.1);
   overflow: hidden;
   font-family: var(--font-mono);
 }
@@ -80,8 +80,8 @@
   align-items: center;
   gap: var(--space-md);
   padding: var(--space-sm) var(--space-md);
-  background: linear-gradient(180deg, #1a1d2e 0%, #141627 100%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: linear-gradient(180deg, #353a50 0%, #2c3043 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .phel-terminal-dots {
@@ -118,8 +118,8 @@
   flex-wrap: wrap;
   gap: 2px;
   padding: 0 var(--space-md);
-  background: #12142a;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: #2d3143;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   overflow-x: auto;
 }
 
@@ -151,7 +151,7 @@
 
 .phel-terminal-tab.is-active {
   color: #ffffff;
-  background: #0b0d18;
+  background: #262a3b;
   border-top-color: var(--color-dark-text-accent, #bfa4ff);
 }
 

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -158,7 +158,6 @@
 .phel-terminal-body {
   position: relative;
   background: #1a1a2e;
-  min-height: 280px;
 }
 
 .phel-terminal-session {

--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -115,8 +115,8 @@
   flex-wrap: wrap;
   gap: 0;
   padding: 0 0.5rem;
-  background: #242438;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: #2d2d2d;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
   overflow-x: auto;
 }
 
@@ -158,6 +158,7 @@
 .phel-terminal-body {
   position: relative;
   background: #1a1a2e;
+  min-height: 280px;
 }
 
 .phel-terminal-session {

--- a/static/animated-repl.js
+++ b/static/animated-repl.js
@@ -9,11 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
     { type: 'prompt', text: '(+ 1 2 3)', delay: 60 },
     { type: 'result', text: '6', delay: 0 },
     { type: 'prompt', text: '(def name "World")', delay: 50 },
-    { type: 'result', text: 'name', delay: 0 },
+    { type: 'result', text: "#'user/name", delay: 0 },
     { type: 'prompt', text: '(str "Hello, " name "!")', delay: 45 },
     { type: 'result', text: '"Hello, World!"', delay: 0 },
     { type: 'prompt', text: '(defn greet [who] (str "Hi, " who "!"))', delay: 40 },
-    { type: 'result', text: 'greet', delay: 0 },
+    { type: 'result', text: "#'user/greet", delay: 0 },
     { type: 'prompt', text: '(greet "PHP developer")', delay: 50 },
     { type: 'result', text: '"Hi, PHP developer!"', delay: 0 },
     { type: 'prompt', text: '(->> (range 1 6) (map (fn [x] (* x x))) (reduce +))', delay: 35 },
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (type === 'shell') return '<span class="terminal-shell">$ </span>';
     if (type === 'prompt') {
       promptCounter += 1;
-      return `<span class="terminal-prompt">phel:${promptCounter}&gt; </span>`;
+      return `<span class="terminal-prompt">user:${promptCounter}&gt; </span>`;
     }
     return '';
   }

--- a/static/animated-repl.js
+++ b/static/animated-repl.js
@@ -5,15 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const lines = [
     { type: 'shell', text: 'docker run -it --rm phellang/repl', delay: 40 },
     { type: 'output', text: 'Welcome to the Phel Repl', delay: 0 },
-    { type: 'output', text: '------------------------------', delay: 0 },
+    { type: 'output', text: 'Type "exit" or press Ctrl-D to exit.', delay: 0 },
     { type: 'prompt', text: '(+ 1 2 3)', delay: 60 },
     { type: 'result', text: '6', delay: 0 },
     { type: 'prompt', text: '(def name "World")', delay: 50 },
-    { type: 'result', text: 'World', delay: 0 },
+    { type: 'result', text: 'name', delay: 0 },
     { type: 'prompt', text: '(str "Hello, " name "!")', delay: 45 },
     { type: 'result', text: '"Hello, World!"', delay: 0 },
     { type: 'prompt', text: '(defn greet [who] (str "Hi, " who "!"))', delay: 40 },
-    { type: 'result', text: '', delay: 0 },
+    { type: 'result', text: 'greet', delay: 0 },
     { type: 'prompt', text: '(greet "PHP developer")', delay: 50 },
     { type: 'result', text: '"Hi, PHP developer!"', delay: 0 },
     { type: 'prompt', text: '(->> (range 1 6) (map (fn [x] (* x x))) (reduce +))', delay: 35 },
@@ -44,9 +44,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const body = terminal.querySelector('#terminal-body');
   let isRunning = false;
 
+  let promptCounter = 0;
+
   function getPrefix(type) {
     if (type === 'shell') return '<span class="terminal-shell">$ </span>';
-    if (type === 'prompt') return '<span class="terminal-prompt">>>> </span>';
+    if (type === 'prompt') {
+      promptCounter += 1;
+      return `<span class="terminal-prompt">phel:${promptCounter}&gt; </span>`;
+    }
     return '';
   }
 
@@ -71,6 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (isRunning) return;
     isRunning = true;
     body.innerHTML = '';
+    promptCounter = 0;
 
     for (const line of lines) {
       const div = document.createElement('div');

--- a/static/copy-code.js
+++ b/static/copy-code.js
@@ -27,8 +27,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Handle copy
     copyButton.addEventListener('click', async () => {
-      const code = pre.querySelector('code');
-      const text = code ? code.textContent : pre.textContent;
+      let text;
+      if (pre.classList.contains('phel-terminal-session')) {
+        const inputs = pre.querySelectorAll('.t-in');
+        text = Array.from(inputs).map(el => el.textContent).join('\n');
+      } else {
+        const code = pre.querySelector('code');
+        text = code ? code.textContent : pre.textContent;
+      }
 
       try {
         await navigator.clipboard.writeText(text);

--- a/static/homepage-tabs.js
+++ b/static/homepage-tabs.js
@@ -2,8 +2,8 @@
   'use strict';
 
   function initTabs(container) {
-    var buttons = container.querySelectorAll('.homepage-tab-btn');
-    var panels = container.querySelectorAll('.homepage-tab-panel');
+    var buttons = container.querySelectorAll('.phel-terminal-tab, .homepage-tab-btn');
+    var panels = container.querySelectorAll('.phel-terminal-session, .homepage-tab-panel');
     if (!buttons.length || !panels.length) return;
 
     var tabIds = Array.prototype.map.call(buttons, function (b) {

--- a/static/homepage-tabs.js
+++ b/static/homepage-tabs.js
@@ -1,0 +1,56 @@
+(function () {
+  'use strict';
+
+  function initTabs(container) {
+    var buttons = container.querySelectorAll('.homepage-tab-btn');
+    var panels = container.querySelectorAll('.homepage-tab-panel');
+    if (!buttons.length || !panels.length) return;
+
+    function activate(tabId) {
+      buttons.forEach(function (btn) {
+        var isActive = btn.getAttribute('data-tab') === tabId;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        btn.setAttribute('tabindex', isActive ? '0' : '-1');
+      });
+      panels.forEach(function (panel) {
+        var isActive = panel.getAttribute('data-panel') === tabId;
+        panel.classList.toggle('is-active', isActive);
+        if (isActive) {
+          panel.removeAttribute('hidden');
+        } else {
+          panel.setAttribute('hidden', '');
+        }
+      });
+    }
+
+    buttons.forEach(function (btn, idx) {
+      btn.addEventListener('click', function () {
+        activate(btn.getAttribute('data-tab'));
+      });
+      btn.addEventListener('keydown', function (e) {
+        var key = e.key;
+        if (key !== 'ArrowLeft' && key !== 'ArrowRight' && key !== 'Home' && key !== 'End') return;
+        e.preventDefault();
+        var nextIdx = idx;
+        if (key === 'ArrowLeft') nextIdx = (idx - 1 + buttons.length) % buttons.length;
+        if (key === 'ArrowRight') nextIdx = (idx + 1) % buttons.length;
+        if (key === 'Home') nextIdx = 0;
+        if (key === 'End') nextIdx = buttons.length - 1;
+        var next = buttons[nextIdx];
+        activate(next.getAttribute('data-tab'));
+        next.focus();
+      });
+    });
+  }
+
+  function init() {
+    document.querySelectorAll('[data-homepage-tabs]').forEach(initTabs);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/homepage-tabs.js
+++ b/static/homepage-tabs.js
@@ -6,7 +6,12 @@
     var panels = container.querySelectorAll('.homepage-tab-panel');
     if (!buttons.length || !panels.length) return;
 
-    function activate(tabId) {
+    var tabIds = Array.prototype.map.call(buttons, function (b) {
+      return b.getAttribute('data-tab');
+    });
+
+    function activate(tabId, updateHash) {
+      if (tabIds.indexOf(tabId) === -1) return;
       buttons.forEach(function (btn) {
         var isActive = btn.getAttribute('data-tab') === tabId;
         btn.classList.toggle('is-active', isActive);
@@ -22,11 +27,21 @@
           panel.setAttribute('hidden', '');
         }
       });
+      if (updateHash && window.history && window.history.replaceState) {
+        window.history.replaceState(null, '', '#tab-' + tabId);
+      }
+    }
+
+    function tabIdFromHash() {
+      var h = window.location.hash || '';
+      if (h.indexOf('#tab-') !== 0) return null;
+      var id = h.slice(5);
+      return tabIds.indexOf(id) !== -1 ? id : null;
     }
 
     buttons.forEach(function (btn, idx) {
       btn.addEventListener('click', function () {
-        activate(btn.getAttribute('data-tab'));
+        activate(btn.getAttribute('data-tab'), true);
       });
       btn.addEventListener('keydown', function (e) {
         var key = e.key;
@@ -38,9 +53,17 @@
         if (key === 'Home') nextIdx = 0;
         if (key === 'End') nextIdx = buttons.length - 1;
         var next = buttons[nextIdx];
-        activate(next.getAttribute('data-tab'));
+        activate(next.getAttribute('data-tab'), true);
         next.focus();
       });
+    });
+
+    var initial = tabIdFromHash();
+    if (initial) activate(initial, false);
+
+    window.addEventListener('hashchange', function () {
+      var id = tabIdFromHash();
+      if (id) activate(id, false);
     });
   }
 

--- a/syntaxes/phel.sublime-syntax
+++ b/syntaxes/phel.sublime-syntax
@@ -6,19 +6,26 @@ scope: source.phel
 
 contexts:
   main:
+    - include: reader-skip
+    - include: regex-literal
+    - include: tagged-literal
     - include: comment
     - include: string
-    - include: paren
-    - include: bracket
-    - include: brace
     - include: keysym
     - include: literal
     - include: number
     - include: corelib
+    - include: anon-fn-paren
+    - include: set-brace
+    - include: paren
+    - include: bracket
+    - include: brace
+    - include: anon-fn-arg
+    - include: unquote
     #- include: symbol
 
   comment:
-    # Multiline block comments: start with #| and end with |#
+    # Multiline block comments: start with #| and end with |#  (deprecated, still supported)
     - match: '#\|'
       scope: punctuation.definition.comment.begin.phel
       push:
@@ -27,11 +34,35 @@ contexts:
           scope: punctuation.definition.comment.end.phel
           pop: true
 
-    # Single-line comments: ; ... or # ... (but not "#{")
-    - match: (;|#(?!\{)).*$
+    # Single-line comments: ; ... or (deprecated) bare # ...
+    # The `#` form must NOT swallow reader macros: #_  #{  #|  #(  #"  #?  ##  #A..#z  #'
+    - match: (;|#(?![_{\|(\"?#A-Za-z'])).*$
       scope: comment.line.hash-or-semicolon.phel
       captures:
         1: punctuation.definition.comment.phel
+
+  reader-skip:
+    # #_ reader-skip prefix (form-level comment). The following form is still
+    # tokenized normally; only the #_ prefix is muted.
+    - match: '#_'
+      scope: comment.line.reader-skip.phel
+
+  regex-literal:
+    # #"..."  regex literal -- highlight like a string, do NOT treat # as comment
+    - match: '#"'
+      scope: punctuation.definition.string.begin.phel
+      push:
+        - meta_scope: string.regexp.phel
+        - match: '"'
+          scope: punctuation.definition.string.end.phel
+          pop: true
+        - match: '\\.'
+          scope: constant.character.escape.phel
+
+  tagged-literal:
+    # #uuid, #inst, #cpp, ... tagged literal prefixes
+    - match: '#[A-Za-z][A-Za-z0-9_\-]*'
+      scope: storage.type.tagged-literal.phel
 
   string:
     - match: '"'
@@ -55,6 +86,28 @@ contexts:
       scope: constant.character.escape.unicodepoint.php
     - match: '\\[nrt\\\"]'
       scope: constant.character.escape.php
+
+  anon-fn-paren:
+    # #(...)  anonymous function literal -- NOT a comment
+    - match: '#\('
+      scope: punctuation.definition.group.begin.phel
+      push:
+        - meta_scope: meta.anon-fn.phel
+        - match: '\)'
+          scope: punctuation.definition.group.end.phel
+          pop: true
+        - include: main
+
+  set-brace:
+    # #{...}  set literal reader macro
+    - match: '#\{'
+      scope: punctuation.definition.group.begin.phel
+      push:
+        - meta_scope: meta.set.phel
+        - match: '\}'
+          scope: punctuation.definition.group.end.phel
+          pop: true
+        - include: main
 
   paren:
     - match: '@?\('
@@ -116,6 +169,9 @@ contexts:
         1: punctuation.definition.numeric.hexadecimal.phel
     - match: '[-+]?\b0[0-7]+(_[0-7]+)*\b'
       scope: constant.numeric.integer.octal.phel
+    # Ratio literals like 1/2, 22/7
+    - match: '[-+]?\b\d+/\d+\b'
+      scope: constant.numeric.ratio.phel
     - match: |-
         [-+]?(?x:
           (?:(\b\d+|\B)\.\d+|\b\d+\.\d*)(?:[eE][+-]?\d+)?\b
@@ -131,6 +187,18 @@ contexts:
       scope: keyword.control.phel
     - match: "(?<=\\(|\\{|\\[|\\s)(php\\/[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+)(?=\\s|\\)|\\]|\\})"
       scope: keyword.other.phel
+
+  anon-fn-arg:
+    # %, %1, %2, %& inside #(...)
+    - match: '%(&|\d+)?(?=\s|\)|\]|\})'
+      scope: variable.parameter.anon-fn.phel
+
+  unquote:
+    # ~@ / ,@ unquote-splicing, ~ / , unquote (, is deprecated but still supported)
+    - match: '~@|,@'
+      scope: keyword.operator.unquote-splicing.phel
+    - match: '~'
+      scope: keyword.operator.unquote.phel
 
   symbol:
     - match: "[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+"

--- a/syntaxes/phel.tmLanguage.json
+++ b/syntaxes/phel.tmLanguage.json
@@ -3,6 +3,9 @@
   "scopeName": "source.phel",
   "fileTypes": ["phel"],
   "patterns": [
+    { "include": "#reader-skip" },
+    { "include": "#regex-literal" },
+    { "include": "#tagged-literal" },
     { "include": "#comment" },
     { "include": "#string" },
     { "include": "#keyword" },
@@ -10,9 +13,13 @@
     { "include": "#keysym" },
     { "include": "#literal" },
     { "include": "#number" },
+    { "include": "#anon-fn-paren" },
+    { "include": "#set-brace" },
     { "include": "#paren" },
     { "include": "#bracket" },
-    { "include": "#brace" }
+    { "include": "#brace" },
+    { "include": "#anon-fn-arg" },
+    { "include": "#unquote" }
   ],
   "repository": {
     "comment": {
@@ -24,7 +31,40 @@
         },
         {
           "name": "comment.line.phel",
-          "match": "(;|#(?!\\{)).*$"
+          "match": "(?:;|#(?![_{\\|(\"?#A-Za-z']))[^\\n]*$"
+        }
+      ]
+    },
+    "reader-skip": {
+      "patterns": [
+        {
+          "name": "comment.line.reader-skip.phel",
+          "match": "#_"
+        }
+      ]
+    },
+    "regex-literal": {
+      "patterns": [
+        {
+          "name": "string.regexp.phel",
+          "begin": "#\"",
+          "end": "\"",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.phel" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.phel" } },
+          "patterns": [
+            {
+              "name": "constant.character.escape.phel",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "tagged-literal": {
+      "patterns": [
+        {
+          "name": "storage.type.tagged-literal.phel",
+          "match": "#[A-Za-z][A-Za-z0-9_\\-]*"
         }
       ]
     },
@@ -55,7 +95,7 @@
       "patterns": [
         {
           "name": "support.function.phel",
-          "match": "(?<=\\(|\\s)(php\\/[^\\s#(){}\\[\\]'\"`,]+)(?=[\\s)\\]\\}])"
+          "match": "(?<=\\(|\\s)php\\/[^\\s#(){}\\[\\]'\"`,]+"
         }
       ]
     },
@@ -90,12 +130,38 @@
           "match": "(?<![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])[-+]?0[0-7]+(_[0-7]+)*(?![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])"
         },
         {
+          "name": "constant.numeric.ratio.phel",
+          "match": "(?<![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])[-+]?\\d+/\\d+(?![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])"
+        },
+        {
           "name": "constant.numeric.float.phel",
           "match": "(?<![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])[-+]?(?:\\d+\\.\\d+|\\.\\d+)(?:[eE][+-]?\\d+)?(?![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])"
         },
         {
           "name": "constant.numeric.integer.phel",
           "match": "(?<![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])[-+]?\\d+(?![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])"
+        }
+      ]
+    },
+    "anon-fn-paren": {
+      "patterns": [
+        {
+          "begin": "#\\(",
+          "end": "\\)",
+          "beginCaptures": { "0": { "name": "punctuation.section.anon-fn.begin.phel" } },
+          "endCaptures": { "0": { "name": "punctuation.section.anon-fn.end.phel" } },
+          "patterns": [{ "include": "$self" }]
+        }
+      ]
+    },
+    "set-brace": {
+      "patterns": [
+        {
+          "begin": "#\\{",
+          "end": "\\}",
+          "beginCaptures": { "0": { "name": "punctuation.section.set.begin.phel" } },
+          "endCaptures": { "0": { "name": "punctuation.section.set.end.phel" } },
+          "patterns": [{ "include": "$self" }]
         }
       ]
     },
@@ -129,6 +195,26 @@
           "beginCaptures": { "0": { "name": "punctuation.brace.open.phel" } },
           "endCaptures": { "0": { "name": "punctuation.brace.close.phel" } },
           "patterns": [{ "include": "$self" }]
+        }
+      ]
+    },
+    "anon-fn-arg": {
+      "patterns": [
+        {
+          "name": "variable.parameter.anon-fn.phel",
+          "match": "%(?:&|\\d+)?(?![A-Za-z0-9_\\-?!$%&*+./:<=>@^~])"
+        }
+      ]
+    },
+    "unquote": {
+      "patterns": [
+        {
+          "name": "keyword.operator.unquote-splicing.phel",
+          "match": "~@|,@"
+        },
+        {
+          "name": "keyword.operator.unquote.phel",
+          "match": "~|,(?![A-Za-z0-9_])"
         }
       ]
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -118,6 +118,7 @@
   <script type="text/javascript" src="/progress-tracker.js" defer></script>
   <script type="text/javascript" src="/practice-overview.js" defer></script>
   <script type="text/javascript" src="/animated-repl.js" defer></script>
+  <script type="text/javascript" src="/homepage-tabs.js" defer></script>
   <script type="text/javascript" src="/easter-eggs.js" defer></script>
   <script type="text/javascript" src="/cheat-sheet-filter.js" defer></script>
   <script type="text/javascript" src="/keyboard-nav.js" defer></script>


### PR DESCRIPTION
## Summary

- Rework homepage intro + add tabbed "See Phel in Action" terminal emulating a real phel REPL (traffic-light chrome, `user:N>` prompts, `#'user/name` returns, multi-tab content, deep-linkable via URL hash).
- Match colors/width/min-height with the existing "Try Phel Instantly with Docker" animated REPL; both now support light and dark themes via CSS variables.
- Animated docker REPL uses the real `user:N>` prompt and var returns instead of generic `>>>`.
- Refresh cookbook + syntax highlighter for phel 0.33 (reader macros `#(...)`, `#_`, `#{}`, `#uuid`, ratio literals, `phel\\http-client`, `phel\\json`, `re-seq`, `(ClassName. args)`).
- Copy button on the tabbed terminal copies only the input forms — pasteable into a real REPL without prompt noise.

<img width="1068" height="647" alt="Screenshot 2026-04-19 at 19 29 36" src="https://github.com/user-attachments/assets/e6aee77c-9cfd-4c54-899c-7f7c0ebd1742" />

