### PR TITLE
Modernize documentation Phel examples

### DIFF
--- a/content/documentation/language/arithmetic.md
+++ b/content/documentation/language/arithmetic.md
@@ -32,7 +32,7 @@ Some operators support zero, one or multiple arguments.
 ```phel
 (+) ; Evaluates to 0
 (+ 1) ; Evaluates to 1
-(+ 1 2) ; Evalutaes to 3
+(+ 1 2) ; Evaluates to 3
 (+ 1 2 3 4 5 6 7 8 9) ; Evaluates to 45
 
 (-) ; Evaluates to 0
@@ -42,11 +42,11 @@ Some operators support zero, one or multiple arguments.
 
 (*) ; Evaluates to 1
 (* 2) ; Evaluates to 2
-(* 2 3 4) #Evaluates to 24
+(* 2 3 4) ; Evaluates to 24
 
 (/) ; Evaluates to 1
 (/ 2) ; Evaluates to 0.5 (reciprocal of 2)
-(/ 24 4 2) #Evaluates to 3
+(/ 24 4 2) ; Evaluates to 3
 ```
 
 {% php_note() %}
@@ -58,9 +58,9 @@ Phel's variadic operators are more flexible than PHP's:
 // Can't do this: +();  <- syntax error
 
 // Phel - supports 0, 1, or many operands
-(+)                     # 0 (identity)
-(+ 1)                   # 1 (identity)
-(+ 1 2 3 4 5)          # 15 (sum of all)
+(+)                     ; 0 (identity)
+(+ 1)                   ; 1 (identity)
+(+ 1 2 3 4 5)          ; 15 (sum of all)
 ```
 
 **Useful patterns:**
@@ -90,9 +90,9 @@ is_nan(log(-1));     // true
 is_nan(NAN);         // true
 
 // Phel
-(nan? 1)             # false
-(nan? (php/log -1))  # true
-(nan? NAN)           # true
+(nan? 1)             ; false
+(nan? (php/log -1))  ; true
+(nan? NAN)           ; true
 ```
 
 The `%` operator for remainder and `**` for exponentiation work like PHP's `%` and `**` operators.
@@ -158,4 +158,3 @@ Phel provides named functions for bitwise operations instead of PHP's operators:
 
 Phel also provides additional bit manipulation functions not available in PHP: `bit-set`, `bit-clear`, `bit-flip`, and `bit-test`.
 {% end %}
-

--- a/content/documentation/language/control-flow.md
+++ b/content/documentation/language/control-flow.md
@@ -262,7 +262,7 @@ function countdown($n) {
 (loop [n 1000000]
   (if (= n 0)
     0
-    (recur (dec n))))  # No stack overflow!
+    (recur (dec n))))  ; No stack overflow!
 ```
 
 This is critical for functional programming patterns in PHP.
@@ -375,7 +375,7 @@ foreach (range(1, 3) as $x) {
 }
 
 // Phel - declarative comprehension
-(for [x :in [1 2 3]] (inc x))  # [2 3 4]
+(for [x :in [1 2 3]] (inc x))  ; [2 3 4]
 ```
 
 Phel's `for` combines iteration, filtering (`:when`), early termination (`:while`), reduction (`:reduce`), and nested loops in one elegant expression-much more powerful than PHP's `for`/`foreach`.
@@ -385,7 +385,7 @@ Phel's `for` combines iteration, filtering (`:when`), early termination (`:while
 `for` works similarly to Clojure's `for`-list comprehensions with `:let`, `:when`, and nested bindings. The `:reduce` modifier is a Phel extension.
 {% end %}
 
-# Do
+## Do
 
 ```phel
 (do expr*)
@@ -398,7 +398,7 @@ Evaluates the expressions in order and returns the value of the last expression.
 (do (print 1) (print 2) (print 3)) ; Print 1, 2, and 3
 ```
 
-# Dofor
+## Dofor
 
 ```phel
 (dofor [x :in [1 2 3]] (print x)) ; Prints 1, 2, 3 and returns nil
@@ -428,9 +428,9 @@ Takes an expression and a set of test/form pairs. Threads the expression through
 
 (defn maybe-transform [data opts]
   (cond-> data
-    (:uppercase opts) (str/upper-case)
-    (:trim opts)      (str/trim)
-    (:prefix opts)    (str (:prefix opts))))
+    (:uppercase opts) (phel\string/upper-case)
+    (:trim opts)      (phel\string/trim)
+    (:prefix opts)    (#(str (:prefix opts) %))))
 ```
 
 ### cond->>
@@ -450,7 +450,7 @@ Like `cond->` but threads as the last argument (thread-last style).
 ;; Only applies (map inc) and (take 3), skips (filter odd?)
 ```
 
-# Exceptions
+## Exceptions
 
 ```phel
 (throw expr)
@@ -535,4 +535,3 @@ Use `ex-data`, `ex-message`, and `ex-cause` to extract information from structur
         404 (println "Not found:" (ex-message e))
         403 (println "Forbidden:" (ex-message e))))))
 ```
-

--- a/content/documentation/language/data-structures.md
+++ b/content/documentation/language/data-structures.md
@@ -534,7 +534,7 @@ Use `update-keys` and `update-vals` to apply a function to all keys or all value
 (update-vals {:a 1 :b 2 :c 3} inc)
 ; => {:a 2 :b 3 :c 4}
 
-(update-vals {:x "hello" :y "world"} str/upper-case)
+(update-vals {:x "hello" :y "world"} phel\string/upper-case)
 ; => {:x "HELLO" :y "WORLD"}
 ```
 

--- a/content/documentation/language/functions-and-recursion.md
+++ b/content/documentation/language/functions-and-recursion.md
@@ -251,8 +251,9 @@ Calls the function with the given arguments. The last argument must be a list of
 ```phel
 (apply + [1 2 3]) ; Evaluates to 6
 (apply + 1 2 [3]) ; Evaluates to 6
-(apply + 1 2 3) ; BAD! Last element must be a list
 ```
+
+Calling `(apply + 1 2 3)` is invalid because the last argument must be a list.
 
 ## Passing by reference
 

--- a/content/documentation/language/interfaces.md
+++ b/content/documentation/language/interfaces.md
@@ -130,7 +130,7 @@ Interfaces shine when you have different types that share behavior:
                 (image "/logo.png" "Phel logo")]]
   (->> elements
        (map render)
-       (str/join "\n")))
+       (phel\string/join "\n")))
 ;; => "<h1>Welcome</h1>\n<p>Hello from Phel!</p>\n<img src=\"/logo.png\" alt=\"Phel logo\">"
 ```
 
@@ -252,18 +252,13 @@ Use `underive` to remove a parent-child relationship:
 (isa? :square :rectangle)     ; => false
 ```
 
-### Custom hierarchies
+### Empty hierarchy maps
 
-By default, `derive` and friends use a global hierarchy. Use `make-hierarchy` to create an isolated hierarchy and pass it explicitly:
+Use `make-hierarchy` to create the empty hierarchy map shape used by hierarchy-aware code. The public `derive`, `underive`, `isa?`, `parents`, `ancestors`, and `descendants` helpers operate on the global hierarchy.
 
 ```phel
-(def animal-h (make-hierarchy))
-(def animal-h (derive animal-h :dog :animal))
-(def animal-h (derive animal-h :cat :animal))
-(def animal-h (derive animal-h :poodle :dog))
-
-(isa? animal-h :poodle :animal)  ; => true
-(descendants animal-h :animal)   ; => #{:dog :cat :poodle}
+(make-hierarchy)
+; => {:parents {} :descendants {} :ancestors {}}
 ```
 
 ### Hierarchy-aware multimethod dispatch

--- a/content/documentation/language/macros.md
+++ b/content/documentation/language/macros.md
@@ -24,13 +24,14 @@ Macros are **not** like PHP functions. They run at compile-time and transform co
 ```php
 // PHP - No macro system
 // You'd need to use code generation or eval()
+```
 
-// Phel - Macros transform code at compile time
+```phel
 (defmacro unless [test then else]
   `(if (not ,test) ,then ,else))
 
-(unless false "yes" "no")  # => "yes"
-# Expands to: (if (not false) "yes" "no") at compile time
+(unless false "yes" "no")  ; => "yes"
+; Expands to: (if (not false) "yes" "no") at compile time
 ```
 
 This is more powerful and safer than PHP's `eval()` or code generation.

--- a/content/documentation/language/truth-and-boolean-operations.md
+++ b/content/documentation/language/truth-and-boolean-operations.md
@@ -38,9 +38,9 @@ if ("") { }       // false - won't execute
 if ([]) { }       // false - won't execute
 
 // Phel
-(if 0 "yes" "no")   # => "yes" - 0 is truthy!
-(if "" "yes" "no")  # => "yes" - "" is truthy!
-(if [] "yes" "no")  # => "yes" - [] is truthy!
+(if 0 "yes" "no")   ; => "yes" - 0 is truthy!
+(if "" "yes" "no")  ; => "yes" - "" is truthy!
+(if [] "yes" "no")  ; => "yes" - [] is truthy!
 ```
 {% end %}
 

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -289,7 +289,7 @@ $arr[5] ?? null;  // Returns null
 // Phel
 (php/aget arr 0)
 (php/aget arr 1)
-(php/aget arr 5)  # Returns nil
+(php/aget arr 5)  ; Returns nil
 ```
 
 **Important distinction:**
@@ -338,7 +338,7 @@ $data['meta']['missing'] ?? null;
 // Phel - clean path-based access
 (php/aget-in users ["users" 1 "name"])
 (php/aget-in data ["meta" "status"])
-(php/aget-in data ["meta" "missing"])  # Returns nil safely
+(php/aget-in data ["meta" "missing"])  ; Returns nil safely
 ```
 
 This is similar to Phel's `get-in` for immutable data structures, but specifically for PHP arrays.

--- a/content/documentation/reference/cheat-sheet.md
+++ b/content/documentation/reference/cheat-sheet.md
@@ -153,7 +153,6 @@ See [Global and Local Bindings](/documentation/language/global-and-local-binding
 #(* % 2)                           ; short form (single param)
 #(+ %1 %2)                        ; short form (multiple params)
 #(apply + %&)                     ; short form (variadic)
-|(* $ 2)                           ; legacy short form (deprecated)
 
 (defn greet                        ; multi-arity
   ([] "Hi")
@@ -470,10 +469,7 @@ Derive ad-hoc hierarchies for use with multimethods and `isa?` checks.
 (ancestors :filled-square)         ; => #{:square :shape}
 (descendants :shape)               ; => #{:square :circle :filled-square}
 
-;; Use a custom hierarchy
-(def h (make-hierarchy))
-(def h (derive h :dog :animal))
-(isa? h :dog :animal)              ; => true
+(make-hierarchy)                   ; => {:parents {} :descendants {} :ancestors {}}
 ```
 
 ## Transducers

--- a/content/documentation/reference/one-liners.md
+++ b/content/documentation/reference/one-liners.md
@@ -43,7 +43,7 @@ Check if a number is prime:
 ```phel
 (let [n 17]
   (and (> n 1)
-       (every? #(not= 0 (% n %))
+       (every? (fn [d] (not= 0 (% n d)))
                (range 2 (php/intval (+ 1 (php/sqrt n)))))))
 ;; => true
 ```
@@ -74,7 +74,7 @@ Multiplies the base by itself `exp` times.
 Reverse a string:
 
 ```phel
-(str/reverse "hello")
+(phel\string/reverse "hello")
 ;; => "olleh"
 ```
 
@@ -83,7 +83,7 @@ Uses Phel's string library to reverse characters.
 Palindrome check:
 
 ```phel
-(let [s "racecar"] (= s (str/reverse s)))
+(let [s "racecar"] (= s (phel\string/reverse s)))
 ;; => true
 ```
 
@@ -103,9 +103,9 @@ Converts the string to a sequence of characters, filters vowels, and counts them
 Title case a string:
 
 ```phel
-(->> (str/split "hello world of phel" "/ /")
-     (map str/capitalize)
-     (str/join " "))
+(->> (phel\string/split "hello world of phel" "/ /")
+     (map phel\string/capitalize)
+     (phel\string/join " "))
 ;; => "Hello World Of Phel"
 ```
 
@@ -132,7 +132,7 @@ Shifts each letter by 13 positions, wrapping around the alphabet.
 Repeat string pattern:
 
 ```phel
-(str/join "" (map #(if (even? %) "*" "-") (range 0 10)))
+(phel\string/join "" (map #(if (even? %) "*" "-") (range 0 10)))
 ;; => "*-*-*-*-*-"
 ```
 
@@ -267,6 +267,7 @@ Build a frequency-sorted leaderboard:
 
 ```phel
 (->> (frequencies [:alice :bob :alice :carol :bob :alice])
+     pairs
      (sort-by second)
      reverse)
 ;; => ([:alice 3] [:bob 2] [:carol 1])
@@ -312,10 +313,10 @@ Shifts each letter forward by 3 positions in the alphabet.
 Simple slug generator:
 
 ```phel
-(->> "Hello World, This is Phel!"
-     (str/lower-case)
-     (str/replace " " "-")
-     (str/replace "/[^a-z0-9-]/" ""))
+(-> "Hello World, This is Phel!"
+     (phel\string/lower-case)
+     (phel\string/replace " " "-")
+     (phel\string/replace #"[^a-z0-9-]" ""))
 ;; => "hello-world-this-is-phel"
 ```
 
@@ -338,10 +339,10 @@ Diamond pattern (width 5):
 
 ```phel
 (->> (concat (range 1 6 2) (range 3 0 -2))
-     (map #(str/join ""
-             [(str/repeat " " (/ (- 5 %) 2))
-              (str/repeat "*" %)]))
-     (str/join "\n"))
+     (map #(phel\string/join ""
+             [(phel\string/repeat " " (/ (- 5 %) 2))
+              (phel\string/repeat "*" %)]))
+     (phel\string/join "\n"))
 ;; => "  *\n ***\n*****\n ***\n  *"
 ```
 


### PR DESCRIPTION
## Summary
- update documentation examples to avoid deprecated Phel comment and anonymous function syntax in runnable snippets
- fully qualify standalone string-library examples so they work without hidden namespace aliases
- fix invalid examples found by CLI validation, including `apply`, prime checking, frequency sorting, slug generation, and hierarchy usage

## Validation
- Ran targeted `./vendor/bin/phel eval` checks for the updated arithmetic, apply, hierarchy, string, slug, and one-liner examples.
- Ran a temporary-file `./vendor/bin/phel run` check for the macro example because macros must be available at compile time.
- Ran `zola build` successfully.

Notes: the broader sweep classified non-standalone snippets separately, including placeholders, REPL transcripts, examples that depend on surrounding app context, and PHP/shell command blocks.
