### PR TITLE
docs: optimize onboarding, add agentic-coding reference, polish 404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE / Editor
 .cache/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .omc/
 .idea/
 .vscode/
@@ -24,6 +25,7 @@ Thumbs.db
 .phel-repl-history
 .phpunit.result.cache
 cache/
+/static/wasm-repl/
 
 # API / Search (generated)
 /static/api.json

--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -3,11 +3,7 @@ title = "Configuration"
 weight = 60
 +++
 
-Phel comes with some configuration options. They are stored in the `phel-config.php` file in the root directory of every project.
-
-## Quick Start with `forProject()`
-
-For most projects, the `forProject()` factory method provides sensible defaults with minimal configuration:
+Phel reads `phel-config.php` from the project root. For most projects you only need the factory:
 
 ```php
 <?php
@@ -15,15 +11,34 @@ For most projects, the `forProject()` factory method provides sensible defaults 
 return \Phel\Config\PhelConfig::forProject('your-ns\main');
 ```
 
-This configures the project with conventional directory layout (`src/phel/`, `tests/phel/`) and sets the main namespace for building. Override any setting by chaining setters after `forProject()`.
+This sets a conventional layout (`src/phel/`, `tests/phel/`) and the build entry namespace. Override anything by chaining setters.
 
-## Structure
+## Common Tweaks
 
-These are all Phel specific configuration options available, along with the values that are set by default.
+The five settings most projects touch:
 
 ```php
 <?php
-// phel-config.php
+return \Phel\Config\PhelConfig::forProject('your-ns\main')
+    ->setSrcDirs(['src'])                      // Phel source roots
+    ->setTestDirs(['tests'])                   // test roots, picked up by `phel test`
+    ->setFormatDirs(['src', 'tests'])          // dirs `phel format` rewrites
+    ->setBuildConfig((new \Phel\Config\PhelBuildConfig())
+        ->setMainPhelNamespace('your-ns\index')   // entry ns for `phel build`
+        ->setMainPhpPath('out/index.php'))        // generated PHP entry
+;
+```
+
+That covers running, testing, formatting, and building. Everything else has sensible defaults.
+
+## Full Reference
+
+<details>
+<summary><strong>All available options</strong></summary>
+
+```php
+<?php
+// phel-config.php — every setter, default values shown
 return (new \Phel\Config\PhelConfig())
     ->setSrcDirs(['src'])
     ->setTestDirs(['tests'])
@@ -47,192 +62,21 @@ return (new \Phel\Config\PhelConfig())
 ;
 ```
 
-## Options in detail
+| Setter | Purpose |
+|--------|---------|
+| `setSrcDirs` | Source directories scanned by the compiler. |
+| `setTestDirs` | Directories `phel test` walks. |
+| `setVendorDir` | Composer vendor directory name. |
+| `setErrorLogFile` | Path of the `error.log` file. |
+| `setIgnoreWhenBuilding` | Phel files skipped by `phel build`. |
+| `setNoCacheWhenBuilding` | Files always retranspiled, regardless of `--cache` / `--no-cache`. |
+| `setFormatDirs` | Directories rewritten by `phel format`. |
+| `setKeepGeneratedTempFiles` | Keep generated temp files after `phel run`. Default `false`. |
+| `setTempDir` | Absolute path for temporary files. Throws if not writable. |
+| `setCacheDir` | Directory for namespace + compiled-code caches. |
+| `setEnableNamespaceCache` | Persistent namespace cache for warm runs. Default `true`. |
+| `setEnableCompiledCodeCache` | Compiled-code cache for tests/builds. Default `true`. |
+| `setBuildConfig` | `setMainPhelNamespace` (entry ns) + `setMainPhpPath` (generated PHP entry). |
+| `setExportConfig` | `setFromDirectories`, `setNamespacePrefix`, `setTargetDirectory` for `phel export`. See [PHP Interop](/documentation/php-interop/#calling-phel-functions-from-php). |
 
-This chapter contains all configuration options explained in detail.
-
-### SrcDirs
-
-Set a list of directories in which the source files for the project are located.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setSrcDirs(['src'])
-    # ...
-;
-```
-
-### TestDirs
-
-Set a list of directories in which the test files are located.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setTestDirs(['tests'])
-    # ...
-;
-```
-
-### VendorDir
-
-Set the name of the composer vendor directory.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setVendorDir('vendor')
-    # ...
-;
-```
-
-### ErrorLogFile
-
-Set the path to the `error.log` file
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setErrorLogFile('data/error.log')
-    # ...
-;
-```
-
-### IgnoreWhenBuilding
-
-Set a list of Phel files that should be ignored when building the code.
-
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setIgnoreWhenBuilding(['ignore-when-building.phel'])
-    # ...
-;
-```
-
-### NoCacheWhenBuilding
-
-Set a list of Phel files that should be not cached when building the code. This means, they will be transpiled all the time; regardless when you use the `--cache` or `--no-cache` flag.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setNoCacheWhenBuilding([])
-    # ...
-;
-```
-
-### FormatDirs
-
-Set a list of directories whose files will be formatted when running the format command.
-
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setFormatDirs(['src', 'tests'])
-    # ...
-;
-```
-
-### KeepGeneratedTempFiles
-
-A flag that automatically removes all generated temporal files once the command `phel run` has been executed. Default is `false`.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setKeepGeneratedTempFiles(false)
-    # ...
-;
-```
-
-### TempDir
-
-Allows setting a custom absolute path for temporary files.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setTempDir('/tmp/phel')
-    # ...
-;
-```
-
-If the path does not exist and cannot be created or written to, an exception is thrown.
-
-### BuildConfig
-
-The configuration when running the `phel build` command.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setBuildConfig((new \Phel\Config\PhelBuildConfig())
-        ->setMainPhelNamespace('your-ns\index')
-        ->setMainPhpPath('out/index.php'))
-    # ...
-;
-```
-
-- `setMainPhelNamespace`: the main phel namespace to start transpiling the Phel code.
-- `setMainPhpPath`: the entry point of the build PHP result.
-
-### ExportConfig
-
-Set configuration options that are being used for the `phel export` command that is described in the [PHP Interop](/documentation/php-interop/#calling-phel-functions-from-php) chapter.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setExportConfig((new \Phel\Config\PhelExportConfig())
-        ->setFromDirectories(['src'])
-        ->setNamespacePrefix('PhelGenerated')
-        ->setTargetDirectory('src/PhelGenerated'))
-    # ...
-;
-```
-
-Currently, the export command requires three options:
-
-- `setFromDirectories`: Sets a list of directories in which the export command should search for export functions.
-- `setNamespacePrefix`: Sets a namespace prefix for all generated PHP classes.
-- `setTargetDirectory`: Sets the directory where the generated PHP classes are stored.
-
-### CacheDir
-
-Set the directory for namespace and compiled code caches. Defaults to a subdirectory of the temp directory.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setCacheDir('/tmp/phel/cache')
-    # ...
-;
-```
-
-### EnableNamespaceCache
-
-Enable or disable the persistent namespace cache for faster warm runs. Default is `true`.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setEnableNamespaceCache(true)
-    # ...
-;
-```
-
-### EnableCompiledCodeCache
-
-Enable or disable the compiled code cache for faster test execution and builds. Default is `true`.
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->setEnableCompiledCodeCache(true)
-    # ...
-;
-```
+</details>

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -150,22 +150,20 @@ vendor/bin/phel doctor
 
 This checks required PHP extensions (`json`, `mbstring`, `readline`), cache directory permissions, and source layout. Run it any time the tooling misbehaves.
 
-## Where to Go Next
+## Your First 30 Minutes
 
-**Build intuition**
-- [Practice exercises](/practice/basic): graded challenges from "Hello, world" to real programs.
-- [Basic Types](/documentation/language/basic-types): the full set of literals.
-- [Cheat Sheet](/documentation/reference/cheat-sheet): one-page core functions.
+Follow in order. Each step builds on the last. By the end you will be writing real Phel.
 
-**Tooling**
-- [REPL guide](/documentation/tooling/repl): history, reloading, helpers.
-- [Editor Support](/documentation/tooling/editor-support): nREPL, LSP, syntax highlighting.
-- [CLI Commands](/documentation/tooling/cli-commands): every command explained.
+1. **[Practice: Basics](/practice/basic)** (~10 min) — graded REPL exercises from "Hello, world" up.
+2. **[Basic Types](/documentation/language/basic-types)** (~5 min) — every literal in one page.
+3. **[Cheat Sheet](/documentation/reference/cheat-sheet)** (keep open) — core functions, one page, filterable.
+4. **[Cookbook](/documentation/guides/cookbook)** (~15 min) — copy-paste recipes for real tasks.
 
-**Going deeper**
-- [Rosetta Stone: PHP → Phel](/documentation/guides/rosetta-stone): side-by-side patterns.
-- [Cookbook](/documentation/guides/cookbook): real-world snippets.
-- [PHP Interop](/documentation/php-interop): calling PHP code from Phel.
-- [Macros](/documentation/language/macros): the superpower.
+After that, branch by need:
+
+- **Daily editor flow:** [REPL](/documentation/tooling/repl) → [Editor Support](/documentation/tooling/editor-support).
+- **Coming from PHP:** [Rosetta Stone](/documentation/guides/rosetta-stone), [PHP Interop](/documentation/php-interop).
+- **Power features:** [Macros](/documentation/language/macros), [Interfaces](/documentation/language/interfaces).
+- **Pair with an AI agent:** [Agentic Coding](/documentation/reference/agentic-coding) — single-page reference for Claude Code, Codex, Cursor.
 
 Need a different install path? See [Installation](/documentation/installation).

--- a/content/documentation/reference/agentic-coding.md
+++ b/content/documentation/reference/agentic-coding.md
@@ -1,0 +1,274 @@
++++
+title = "Agentic Coding"
+weight = 50
+description = "Single-page Phel reference for AI coding agents (Claude Code, Codex, Cursor, Copilot, Aider, Gemini). Self-contained syntax, idioms, interop, gotchas."
+aliases = ["/documentation/llms", "/documentation/ai-agents"]
++++
+
+A single page designed for AI coding agents (Claude Code, Codex, Cursor, Copilot, Aider, Gemini) to learn Phel without crawling the rest of the docs. Humans pairing with an agent will also find it useful.
+
+If you only have time to load one doc into an agent's context, load this one.
+
+## What Phel Is
+
+Phel is a functional Lisp that compiles to PHP. It runs on any PHP 8.4+ runtime, ships through Composer, and interops fully with PHP libraries.
+
+- Immutable persistent data structures by default.
+- Macros, homoiconicity, REPL-driven development.
+- Compiles to plain PHP. No separate runtime, no JVM.
+- Source files: `.phel`. Project config: `phel-config.php`.
+
+## Verify Before You Generate
+
+Before suggesting code, verify against the running install:
+
+```bash
+vendor/bin/phel doc <fn>          # function signature + docstring
+vendor/bin/phel eval '<expr>'      # one-shot eval
+vendor/bin/phel repl               # full REPL
+vendor/bin/phel test [path]        # run tests
+vendor/bin/phel run <file>         # run a script
+vendor/bin/phel build              # compile to PHP
+vendor/bin/phel format <file>      # rewrite formatting
+vendor/bin/phel doctor             # env + extension check
+```
+
+If a function name is uncertain, run `phel doc` or grep `vendor/phel-lang/phel-lang/src/php/Lang/` and `vendor/phel-lang/phel-lang/src/phel/core/`. Do not invent function names.
+
+## Installed Agent Skills
+
+The Phel package ships skill adapters in `vendor/phel-lang/phel-lang/.agents/`. Install for the active agent:
+
+```bash
+vendor/bin/phel agent-install claude    # or codex, cursor, copilot, aider, gemini
+vendor/bin/phel agent-install --all     # every adapter
+```
+
+The `.agents/` tree contains: `RULES.md`, `index.md` (intent map), `tasks/*.md` (recipes for HTTP apps, CLI tools, tests, REPL flow, validation, etc.), and `examples/`. Prefer it over guessing.
+
+## Syntax in 60 Seconds
+
+```phel
+;; Inline comment uses one semicolon.
+;; Standalone comment uses two.
+
+;; Atoms: nil true false
+;; Numbers: 42 -3 1.5 3.14e2 0xFF 0b1010 0o17
+;; Strings: "hello" "line\nbreak"
+;; Keywords: :status :user/email
+;; Symbols: my-var my-ns/fn
+;; Regex literal: #"^\d+$"
+
+;; Calls: (function arg1 arg2 ...). First element is the operator.
+(+ 1 2 3)                          ; => 6
+(str "Hello, " name)
+
+;; Data structures (all immutable):
+[1 2 3]                            ; vector
+{:a 1 :b 2}                        ; map
+#{1 2 3}                           ; set
+'(1 2 3)                           ; list (data, not a call)
+
+;; PHP assoc array literal (when interop needs one):
+#php {"k" "v"}
+```
+
+## Core Forms
+
+```phel
+(def x 42)                         ; global binding
+(def- secret 7)                    ; private binding
+
+(defn greet [name]                 ; public function
+  (str "Hello, " name))
+
+(defn- helper [x] (* x 2))         ; private function
+
+(let [x 1, y 2] (+ x y))           ; local bindings (commas optional)
+
+(if cond then else)
+(when cond expr ...)
+(cond  pred-1 expr-1
+       pred-2 expr-2
+       :else  fallback)
+(case x 1 "one" 2 "two" "default")
+(condp = x 1 "one" 2 "two" "other")
+
+(do expr1 expr2 ... last)          ; sequence; returns last
+
+(loop [acc 0 n 10]
+  (if (zero? n) acc (recur (+ acc n) (dec n))))
+
+(for   [x :in xs :when (odd? x)] (* x x))   ; lazy comprehension
+(doseq [x :in xs] (println x))              ; side effects, returns nil
+(dotimes [i 5] (println i))
+
+(fn [x] (* x 2))                   ; anonymous fn
+#(* % 2)                           ; reader shorthand (single arg)
+#(+ %1 %2)                         ; multi-arg shorthand
+#(apply + %&)                      ; variadic shorthand
+
+(-> x (f a) (g b))                 ; thread first
+(->> x (f a) (g b))                ; thread last
+(some-> x .a .b)                   ; nil-safe thread first
+(cond-> x pred (f y))              ; conditional thread
+
+(try expr (catch php\Exception e (handle e)) (finally cleanup))
+```
+
+## Namespaces
+
+```phel
+;; src/my-app/users.phel
+(ns my-app\users
+  (:require phel\string :as str)
+  (:require phel\html :as h)
+  (:use \DateTimeImmutable))
+
+(defn full-name [{:first f :last l}]
+  (str/join " " [f l]))
+```
+
+Rules:
+
+- Two or more segments required (`my-app\main`, not `main`).
+- File path mirrors namespace under `src/`. Source uses dashes, compiled PHP uses studly case (`my-app\users` ↔ `MyApp\Users`).
+
+## PHP Interop
+
+```phel
+(php/strlen "hi")                          ; call PHP function
+(php/new \DateTimeImmutable "2024-01-15")  ; construct
+(php/-> obj (method arg))                  ; instance method
+(php/:: \DateTimeImmutable ATOM)           ; static / constant
+
+;; Shorthands also accepted:
+(.method obj arg)
+(.-prop obj)
+(Class/method args)
+Class/CONST
+
+;; Convert Phel collection to PHP array (when handing off to PHP):
+(to-php-array ["a" "b" "c"])
+
+;; Convert PHP array back to Phel collection:
+(vec (php/explode "," "a,b,c"))            ; => ["a" "b" "c"]
+
+;; Catch PHP exceptions:
+(try (risky)
+  (catch \RuntimeException e (handle e)))
+```
+
+## Records, Protocols, Multimethods
+
+```phel
+(defrecord Point [x y])
+(def p (->Point 1 2))
+(get p :x)                         ; => 1     (use get, not .-x)
+(map->Point {:x 1 :y 2})           ; => (point 1 2)
+
+(defprotocol Drawable
+  (draw [this]))
+
+(extend-type :string Drawable
+  (draw [s] (println s)))
+
+(defmulti area :shape)
+(defmethod area :circle [{:radius r}] (* 3.14 r r))
+(defmethod area :rect   [{:w w :h h}] (* w h))
+```
+
+## Truthiness, Equality, Comments
+
+- Only `false` and `nil` are falsy. `0`, `""`, `[]`, `{}` are all truthy.
+- `=` is value equality across all types. `identical?` is reference equality.
+- Comments: `;` inline, `;;` standalone, `#_` discards the next form, `(comment ...)` ignores its body.
+
+```phel
+(if 0 "truthy" "falsy")            ; => "truthy"
+(= [1 2] [1 2])                    ; => true
+#_(this-form-is-skipped)
+```
+
+## Tests
+
+```phel
+(ns my-app\users-test
+  (:require phel\test :refer [deftest is])
+  (:require my-app\users :as users))
+
+(deftest full-name-joins
+  (is (= "Ada Lovelace"
+         (users/full-name {:first "Ada" :last "Lovelace"}))))
+```
+
+Run with `vendor/bin/phel test`.
+
+## Common Gotchas
+
+Read these once. They cover most failure modes agents hit.
+
+1. **CLI args**: use `*argv*` (vector of strings, post-script-path), not `php/$argv` (which is `null` under `phel run`).
+2. **`for` vs `doseq`**: `for` builds a lazy sequence. Use `doseq` for side effects (logging, printing, IO).
+3. **`transduce` with `max`/`min`**: they have no zero-arity, so wrap and pass init: `(transduce xf (fn [a b] (max a b)) 0 coll)`.
+4. **Top-level side effects break `phel build`**: guard with `(when-not *build-mode* ...)`.
+5. **Records access by keyword**: `(get p :x)`, not `(.-x p)`.
+6. **PHP arrays are not Phel collections**: convert with `vec` or `to-php-array`. There is no `to-vec` or `to-list`.
+7. **Namespace must have at least two segments**: `(ns app\main)`, not `(ns main)`.
+8. **String module is `phel\string`** (renamed from `phel\str`).
+9. **PHP assoc literal**: `#php {"k" "v"}`, not `{:k "v"}`. Phel maps are not PHP arrays.
+10. **`recur` only in tail position** of `loop` or `fn`.
+
+## Project Layout
+
+```
+my-app/
+  composer.json         # PHP deps + composer scripts (repl, dev, test, build)
+  phel-config.php       # Phel config; usually one line via forProject()
+  src/
+    main.phel           # entry namespace
+    modules/...
+  tests/
+    modules/...
+```
+
+Minimal `phel-config.php`:
+
+```php
+<?php
+return \Phel\Config\PhelConfig::forProject('my-app\main');
+```
+
+Full options in [Configuration](/documentation/configuration).
+
+## Authoring Guidelines for Agents
+
+When generating Phel code:
+
+1. **Verify, don't invent.** Run `phel doc <fn>` or grep `src/phel/core/` before using a function name you are unsure about.
+2. **Prefer pure functions.** Push side effects to the edge. Use `atom` only when you genuinely need shared mutable state.
+3. **Thread, don't nest.** `(->> xs (filter f) (map g) (reduce h 0))` beats nested calls four levels deep.
+4. **Reach for the right comprehension.** `for` returns data, `doseq` runs effects, `dotimes` repeats, `loop`/`recur` accumulates.
+5. **Stay immutable.** `(conj v x)` returns a new vector; rebind it. Do not expect in-place mutation.
+6. **Match comment style.** `;` inline, `;;` standalone. The `#` line comment form is deprecated.
+7. **Avoid em-dashes** in any Phel docstrings or generated docs for this site. Prefer commas, colons, periods, or parentheses.
+8. **Conventional commits.** `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`. No mention of AI / LLM authorship in commit messages.
+
+## Where to Look Next
+
+Inside the Phel install:
+
+- `vendor/phel-lang/phel-lang/.agents/index.md`: intent → recipe map.
+- `vendor/phel-lang/phel-lang/.agents/RULES.md`: canonical rule set + CLI map.
+- `vendor/phel-lang/phel-lang/.agents/tasks/`: recipes for HTTP, CLI, tests, debugging, validation, pattern matching.
+- `vendor/phel-lang/phel-lang/src/phel/core/`: source of every core function.
+
+On this site:
+
+- [Cheat Sheet](/documentation/reference/cheat-sheet): full filterable list of core forms and functions.
+- [Language section](/documentation/language/): one page per concept (types, functions, control flow, macros, interfaces, namespaces, destructuring, recursion).
+- [PHP Interop](/documentation/php-interop): every interop form in detail.
+- [Cookbook](/documentation/guides/cookbook): copy-paste recipes for real tasks.
+- [Rosetta Stone](/documentation/guides/rosetta-stone): PHP → Phel patterns side by side.
+- [REPL guide](/documentation/tooling/repl): development loop.
+- [CLI Commands](/documentation/tooling/cli-commands): every subcommand.

--- a/content/documentation/reference/in-the-wild.md
+++ b/content/documentation/reference/in-the-wild.md
@@ -27,4 +27,5 @@ This page contains a list of libraries and projects that use Phel. If you want t
 * [smeghead/phel-saraudon](https://github.com/smeghead/phel-saraudon): A command to visualize result of `git log --stat`.
 * [smeghead/phel-cellular-automaton](https://github.com/smeghead/phel-cellular-automaton): The cellular automaton using the CLI terminal written in phel.
 * [smeghead/phel-mml2wav](https://github.com/smeghead/phel-mml2wav): Generate WAV format files from MML (Music Macro Language).
+* [Lacsw/phelgeon](https://github.com/Lacsw/phelgeon): A Phel project by Lacsw.
 

--- a/content/documentation/why-phel.md
+++ b/content/documentation/why-phel.md
@@ -3,132 +3,98 @@ title = "Why Phel?"
 weight = 3
 +++
 
-You already know PHP. It pays the bills, it runs half the web, and PHP 8.x is genuinely good. So why would you bother learning a Lisp that compiles to the same runtime?
+You already know PHP. So why learn a Lisp that compiles to the same runtime?
 
-This page gives honest answers. No marketing fluff, no hand-waving. If Phel isn't right for you, that's fine too.
+Honest answers below. No marketing. If Phel isn't right for you, that's fine.
 
----
+## Do I need to know Lisp?
 
-## "Why not just use modern PHP?"
+No. The whole syntax is one rule: the first element inside parentheses is the function, everything after it is an argument.
 
-Modern PHP is great. Union types, match expressions, fibers, enums -- the language has improved dramatically. But some things are not on PHP's roadmap:
-
-- **Immutable data structures by default.** In Phel, data never changes in place. You transform it into new values. This eliminates entire categories of bugs (stale state, unexpected mutations, order-dependent side effects).
-- **A real macro system.** Phel macros operate on the code itself as data, letting you extend the language with new syntax. PHP attributes and code generation are not the same thing.
-- **Homoiconicity.** Phel code is Phel data. This means programs can inspect, generate, and transform other programs trivially.
-- **REPL-driven development.** Evaluate expressions interactively, test ideas instantly, build programs incrementally. See the [REPL guide](/documentation/tooling/repl).
-- **Functional-first design.** Phel is built around pure functions, pipelines, and data transformation. PHP can do functional programming, but its standard library, conventions, and tooling all push you toward OOP.
-
-None of this makes PHP bad. It means Phel and PHP optimize for different things, even though they share a runtime.
-
-## "Isn't adding a compilation step a hassle?"
-
-Phel compiles to PHP transparently. You run `vendor/bin/phel run` or use the REPL. There is no separate build pipeline to configure, no watcher to set up, no output directory to manage.
-
-This is no different from TypeScript compiling to JavaScript, or Sass compiling to CSS. Your deployment is still just PHP files running on your existing infrastructure.
-
-See [CLI Commands](/documentation/tooling/cli-commands) for the full list of available commands.
-
-## "Can I use existing PHP libraries?"
-
-Yes, 100%. Phel has full PHP interop through the `php/` prefix:
+```php
+// PHP
+array_map($fn, $arr);
+str_contains($haystack, $needle);
+```
 
 ```phel
-;; Call any PHP function
-(php/strlen "hello")  ; => 5
-(php/array_map #(* % 2) (php/array 1 2 3))
-
-;; Create objects
-(php/new \DateTimeImmutable "2024-01-15")
-
-;; Call methods
-(php/-> date (format "Y-m-d"))
-
-;; Access static methods and constants
-(php/:: \DateTimeImmutable ATOM)
+;; Phel
+(map fn arr)
+(php/str_contains haystack needle)
 ```
 
-Composer packages work. You can call any PHP function, instantiate any class, use traits, and access constants. See [PHP Interop](/documentation/php-interop) for the full reference.
+No operator precedence, no special cases, no ambiguity. The [Practice exercises](/practice/basic) get you comfortable in an hour.
 
-## "What about performance?"
+## Why Lisp syntax specifically?
 
-Phel compiles to standard PHP, so runtime performance is comparable to handwritten PHP. The persistent (immutable) data structures carry some overhead compared to plain PHP arrays because every "modification" creates a new structure. For most applications -- web requests, CLI tools, data processing -- this overhead is negligible.
+1. **Homoiconicity.** Phel code is Phel data (lists, vectors, maps). Macros manipulate code with the same functions you use on data.
+2. **Macros.** Extend the language with new syntax that looks built-in. See [Macros](/documentation/language/macros).
+3. **Regularity.** One pattern: `(function arg1 arg2 ...)`. Once internalized, you can read any Phel code.
 
-The trade-off is explicit: you give up a bit of micro-performance in exchange for correctness guarantees and a better developer experience. If you are writing a tight inner loop that processes millions of array mutations per second, plain PHP arrays are the right tool. For everything else, immutable data structures make your code easier to reason about and harder to break.
+The unfamiliar feeling fades faster than expected, usually within a few days of actual use.
 
-## "Can I use Phel in an existing PHP project?"
+## Why not just modern PHP?
 
-Yes. Phel is a Composer package. Add it to any existing PHP project:
+Modern PHP is great. Some things are not on its roadmap:
 
-```bash
-composer require phel-lang/phel-lang
+- **Immutable data structures by default.** Data never changes in place. Eliminates whole classes of bugs (stale state, unexpected mutations, order-dependent side effects).
+- **A real macro system.** Operates on code as data. PHP attributes and codegen are not the same.
+- **REPL-driven development.** Evaluate expressions interactively, build programs incrementally. See [REPL](/documentation/tooling/repl).
+- **Functional-first design.** Pure functions, pipelines, data transformation. PHP can do FP, but its stdlib and conventions push toward OOP.
+
+PHP is not bad. Phel and PHP optimize for different things on the same runtime.
+
+## Can I use existing PHP libraries?
+
+Yes, fully. Phel has full PHP interop through the `php/` prefix:
+
+```phel
+(php/strlen "hello")                          ; => 5
+(php/new \DateTimeImmutable "2024-01-15")     ; create object
+(php/-> date (format "Y-m-d"))                ; call method
+(php/:: \DateTimeImmutable ATOM)              ; static / constant
 ```
 
-You can call Phel functions from PHP and PHP functions from Phel. This means you can adopt Phel gradually -- write one module in Phel, keep everything else in PHP, and expand as it makes sense. See the [PHP Interop](/documentation/php-interop) section on calling Phel from PHP for details.
+Composer packages work. Any class, trait, function, constant. See [PHP Interop](/documentation/php-interop).
 
-## "What about debugging?"
+## Isn't a compilation step a hassle?
 
-Phel compiles to PHP, so PHP's debugging ecosystem works:
+No. `vendor/bin/phel run` or the REPL compiles transparently. No build pipeline, no watcher, no output dir to manage. Same as TypeScript → JavaScript or Sass → CSS. Deployment is plain PHP files on existing infra.
 
-- **Phel's built-in helpers** -- `tap>`, `add-tap`, and `pprint` for quick inspection during development.
-- **PHP native tools** -- `var_dump`, `print_r`, and Symfony's `dump()` all work since Phel values are PHP objects under the hood.
-- **XDebug** -- Full step-through debugging with breakpoints, call stacks, and variable inspection. Works in PhpStorm and VS Code.
+## What about performance?
 
-See the [Debug helpers](/documentation/tooling/phel-helpers/) and [XDebug setup](/documentation/tooling/xdebug-setup/) guides for examples.
+Phel compiles to standard PHP. Runtime performance is comparable to handwritten PHP. Persistent data structures carry some overhead vs plain arrays since "modification" creates a new structure. Negligible for web requests, CLI tools, data processing.
 
-## "Is Phel production-ready?"
+The trade-off is explicit: trade micro-performance for correctness and DX. For tight inner loops over millions of mutations, plain PHP arrays win. For everything else, immutability wins.
 
-Honest answer: Phel is a growing project. The core language is stable and well-tested. It is a great fit for:
+## What about debugging?
+
+PHP's full debugging ecosystem works:
+
+- **Phel helpers**: `tap>`, `add-tap`, `pprint` for inline inspection.
+- **PHP native**: `var_dump`, `print_r`, Symfony `dump()` all work since Phel values are PHP objects.
+- **XDebug**: full step-through with breakpoints, call stacks, variable inspection. PhpStorm and VS Code.
+
+See [Debug helpers](/documentation/tooling/phel-helpers/) and [XDebug setup](/documentation/tooling/xdebug-setup/).
+
+## What about IDE support?
+
+Editor support exists for the major editors:
+
+- **VS Code**, **PhpStorm**, **Emacs**, **Vim**: syntax highlighting, REPL/nREPL integration, formatting.
+
+See [Editor Support](/documentation/tooling/editor-support).
+
+## Is Phel production-ready?
+
+The core language is stable and well-tested. Great fit for:
 
 - Side projects and personal tools
 - CLI applications
 - Internal tools and scripts
 - Learning functional programming on a runtime you already know
-- Prototyping ideas with REPL-driven development
+- Prototyping with REPL-driven development
 
-The community is small but active. If you need battle-tested, enterprise-grade stability with long-term support guarantees, Phel is not there yet. If you want a productive, expressive language that runs anywhere PHP does and you are comfortable being an early adopter, Phel delivers.
+The community is small but active. Need battle-tested enterprise stability with LTS guarantees? Phel is not there yet. Want a productive, expressive language on PHP and OK being an early adopter? Phel delivers.
 
-Check out [In the Wild](/documentation/reference/in-the-wild) to see what people are building.
-
-## "Do I need to know Lisp?"
-
-No. Phel's syntax is minimal -- it is just parentheses wrapping function calls. If you can read this PHP:
-
-```php
-array_map($fn, $arr);
-str_contains($haystack, $needle);
-```
-
-You can read this Phel:
-
-```phel
-(map fn arr)
-(php/str_contains haystack needle)
-```
-
-The rule is simple: the first element inside the parentheses is the function, everything after it is an argument. That is the entire syntax. No operator precedence rules, no special cases, no ambiguity.
-
-The [Practice exercises](/practice/basic) will get you comfortable in an hour. If you already know PHP, [Phel for PHP Developers](/documentation/guides/phel-for-php-developers) maps familiar patterns to their Phel equivalents.
-
-## "What about IDE support?"
-
-Editor support exists for the major editors:
-
-- **VS Code** -- Syntax highlighting, snippets, and inline evaluation.
-- **PhpStorm** -- Plugin with syntax highlighting, structural editing, and REPL actions.
-- **Emacs** -- Editing helpers and REPL integration.
-- **Vim** -- Syntax highlighting, filetype detection, and indentation.
-
-See [Editor Support](/documentation/tooling/editor-support) for installation links and details.
-
-## "Why Lisp syntax specifically?"
-
-Three reasons:
-
-1. **Homoiconicity.** Because Phel code is Phel data (lists, vectors, maps), the macro system can manipulate code with the same functions you use to manipulate data. This is not possible with PHP's syntax.
-
-2. **The macro system.** Macros let you extend the language itself. You can create new control structures, DSLs, and abstractions that look and feel like built-in language features. See [Macros](/documentation/language/macros) for examples.
-
-3. **Regularity.** There is one syntactic pattern: `(function arg1 arg2 ...)`. No operator precedence, no special forms for different constructs, no syntax to memorize beyond parentheses. Once you internalize the pattern, you can read any Phel code.
-
-The trade-off is that Lisp syntax looks unfamiliar at first. That feeling goes away faster than you expect -- most developers report being comfortable within a few days of actual use.
+See [In the Wild](/documentation/reference/in-the-wild) for what people are building.

--- a/css/base.css
+++ b/css/base.css
@@ -495,42 +495,222 @@ scroll-margin-top: calc(var(--header-height) + 2rem);
 }
 
 .error-page {
-  max-width: 640px;
-  margin: 2rem auto;
+  max-width: 920px;
+  margin: 2rem auto 4rem;
+  padding: 0 1rem;
+  text-align: center;
 }
 
-.error-page__links {
+.error-page__hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 2.5rem;
+  padding-top: 1rem;
+}
+
+.error-page .error-page__tag {
+  font-family: var(--font-mono);
+  font-size: clamp(5rem, 16vw, 9rem);
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  margin: 0 0 0.25rem;
+  background: linear-gradient(
+    135deg,
+    var(--color-light-text-accent) 0%,
+    var(--color-light-link) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+}
+
+.dark .error-page .error-page__tag {
+  background: linear-gradient(
+    135deg,
+    var(--color-dark-text-accent) 0%,
+    var(--color-dark-link) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.error-page .error-page__title {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  margin: 0 0 0.875rem;
+  line-height: 1.2;
+}
+
+.error-page .error-page__lead {
+  max-width: 52ch;
+  margin: 0 auto 1.75rem;
+  color: var(--color-light-text-secondary);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+
+.dark .error-page .error-page__lead {
+  color: var(--color-dark-text-secondary);
+}
+
+.error-page .error-page__repl {
+  display: inline-block;
+  text-align: left;
+  margin: 0 auto;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  background: var(--color-light-code-bg);
+  border: 1px solid var(--color-light-border-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  max-width: 100%;
+  box-shadow: var(--shadow-xs);
+}
+
+.dark .error-page .error-page__repl {
+  background: var(--color-dark-code-bg);
+  border-color: var(--color-dark-border-subtle);
+}
+
+.error-page .error-page__repl code {
+  background: none;
+  padding: 0;
+  border: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+.error-page .error-page__repl-string {
+  color: var(--color-light-text-accent);
+}
+
+.dark .error-page .error-page__repl-string {
+  color: var(--color-dark-text-accent);
+}
+
+.error-page .error-page__repl-comment {
+  color: var(--color-light-text-muted);
+  font-style: italic;
+}
+
+.dark .error-page .error-page__repl-comment {
+  color: var(--color-dark-text-muted);
+}
+
+.error-page .error-page__groups {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 0 auto 2.25rem;
+  padding: 0;
+  text-align: left;
+}
+
+.error-page .error-page__group {
+  border: 1px solid var(--color-light-border);
+  border-radius: var(--radius-lg);
+  padding: 1.125rem 1.25rem 1rem;
+  background: var(--color-light-surface);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+}
+
+.error-page .error-page__group:hover {
+  border-color: var(--color-light-text-accent);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.dark .error-page .error-page__group {
+  border-color: var(--color-dark-border);
+  background: var(--color-dark-surface);
+}
+
+.dark .error-page .error-page__group:hover {
+  border-color: var(--color-dark-text-accent);
+}
+
+.error-page .error-page__group-title {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-light-text-muted);
+  margin: 0 0 0.625rem;
+  font-weight: 700;
+  border: 0;
+  padding: 0;
+}
+
+.dark .error-page .error-page__group-title {
+  color: var(--color-dark-text-muted);
+}
+
+.error-page .error-page__links {
   list-style: none;
   padding: 0;
-  margin-top: 1.25rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 0.5rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
-.error-page__links li {
+.error-page .error-page__links li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.error-page .error-page__links li::before,
+.error-page .error-page__links li::marker {
+  content: none;
+  display: none;
+}
+
+.error-page .error-page__links a {
+  display: block;
+  padding: 0.5rem 0.625rem;
+  margin: 0 -0.625rem;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--color-light-link);
+  font-weight: 500;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.error-page .error-page__links a:hover,
+.error-page .error-page__links a:focus-visible {
+  background: var(--color-light-surface-hover);
+  color: var(--color-light-text-accent);
+}
+
+.dark .error-page .error-page__links a {
+  color: var(--color-dark-link);
+}
+
+.dark .error-page .error-page__links a:hover,
+.dark .error-page .error-page__links a:focus-visible {
+  background: var(--color-dark-surface-hover);
+  color: var(--color-dark-text-accent);
+}
+
+.error-page .error-page__hint {
+  font-size: 0.9375rem;
+  color: var(--color-light-text-muted);
   margin: 0;
 }
 
-.error-page__links a {
-  display: block;
-  padding: 0.625rem 0.875rem;
-  border: 1px solid var(--color-light-border);
-  border-radius: var(--radius-md);
-  text-decoration: none;
-  transition: background var(--duration-fast) var(--ease-out), border-color var(--duration-fast) var(--ease-out);
-}
-
-.error-page__links a:hover {
-  background: var(--color-light-surface);
-  border-color: var(--color-light-primary);
-}
-
-.dark .error-page__links a {
-  border-color: var(--color-dark-border);
-}
-
-.dark .error-page__links a:hover {
-  background: var(--color-dark-surface);
-  border-color: var(--color-dark-primary);
+.dark .error-page .error-page__hint {
+  color: var(--color-dark-text-muted);
 }

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,59 @@
+# Phel Lang
+
+> Phel is a functional Lisp that compiles to PHP. Persistent immutable data structures,
+> macros, REPL-driven development, full PHP interop. Runs on PHP 8.4+.
+
+If you only fetch one URL, fetch the agent reference:
+
+- [Agentic Coding (single-page reference)](https://phel-lang.org/documentation/reference/agentic-coding/)
+
+## Onboarding
+
+- [Getting Started](https://phel-lang.org/documentation/getting-started/): zero to REPL in 60 seconds.
+- [Installation](https://phel-lang.org/documentation/installation/): Composer, PHAR, Docker, Nix.
+- [Why Phel?](https://phel-lang.org/documentation/why-phel/): honest FAQ.
+
+## Language
+
+- [Cheat Sheet](https://phel-lang.org/documentation/reference/cheat-sheet/): full filterable core surface.
+- [Basic Types](https://phel-lang.org/documentation/language/basic-types/)
+- [Data Structures](https://phel-lang.org/documentation/language/data-structures/)
+- [Functions and Recursion](https://phel-lang.org/documentation/language/functions-and-recursion/)
+- [Control Flow](https://phel-lang.org/documentation/language/control-flow/)
+- [Destructuring](https://phel-lang.org/documentation/language/destructuring/)
+- [Global and Local Bindings](https://phel-lang.org/documentation/language/global-and-local-bindings/)
+- [Namespaces](https://phel-lang.org/documentation/language/namespaces/)
+- [Macros](https://phel-lang.org/documentation/language/macros/)
+- [Interfaces](https://phel-lang.org/documentation/language/interfaces/)
+- [Truth and Boolean](https://phel-lang.org/documentation/language/truth-and-boolean-operations/)
+- [Arithmetic](https://phel-lang.org/documentation/language/arithmetic/)
+
+## Interop and Tooling
+
+- [PHP Interop](https://phel-lang.org/documentation/php-interop/)
+- [CLI Commands](https://phel-lang.org/documentation/tooling/cli-commands/)
+- [REPL](https://phel-lang.org/documentation/tooling/repl/)
+- [Editor Support](https://phel-lang.org/documentation/tooling/editor-support/)
+- [Phel Helpers](https://phel-lang.org/documentation/tooling/phel-helpers/)
+- [XDebug Setup](https://phel-lang.org/documentation/tooling/xdebug-setup/)
+- [Authoring Libraries](https://phel-lang.org/documentation/tooling/authoring-libraries/)
+- [Configuration](https://phel-lang.org/documentation/configuration/)
+- [Testing](https://phel-lang.org/documentation/testing/)
+
+## Guides
+
+- [Cookbook](https://phel-lang.org/documentation/guides/cookbook/)
+- [Rosetta Stone (PHP to Phel)](https://phel-lang.org/documentation/guides/rosetta-stone/)
+- [Coming from Clojure](https://phel-lang.org/documentation/guides/coming-from-clojure/)
+- [Phel for PHP Developers](https://phel-lang.org/documentation/guides/phel-for-php-developers/)
+
+## Web
+
+- [HTML Rendering](https://phel-lang.org/documentation/web/html-rendering/)
+- [HTTP Request and Response](https://phel-lang.org/documentation/web/http-request-and-response/)
+
+## Source of Truth
+
+- Compiler + core: <https://github.com/phel-lang/phel-lang>
+- Agent skill adapters: `vendor/phel-lang/phel-lang/.agents/` after `composer require phel-lang/phel-lang`.
+- Install adapter for active agent: `vendor/bin/phel agent-install <claude|codex|cursor|copilot|aider|gemini|--all>`.

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,18 +1,48 @@
 {% extends "layouts/one-column-layout.html" %}
 
 {% block content %}
-    <div class="error-page">
-        <h1>404 — Page Not Found</h1>
-        <p>The page you were looking for has moved, was renamed, or never existed.</p>
-        <p>Try one of these instead, or open search from the top of the page.</p>
-        <ul class="error-page__links">
-            <li><a href="/">Home</a></li>
-            <li><a href="/documentation/getting-started/">Getting started</a></li>
-            <li><a href="/documentation/reference/api/">API reference</a></li>
-            <li><a href="/documentation/reference/cheat-sheet/">Cheat sheet</a></li>
-            <li><a href="/practice/">Practice</a></li>
-            <li><a href="/blog/">Blog</a></li>
-        </ul>
-    </div>
-{% endblock content %}
+<section class="error-page" aria-labelledby="error-title">
+  <header class="error-page__hero">
+    <p class="error-page__tag" aria-hidden="true">404</p>
+    <h1 id="error-title" class="error-page__title">Page not found</h1>
+    <p class="error-page__lead">
+      The page you were looking for has moved, was renamed, or never existed.
+    </p>
+    <pre class="error-page__repl" aria-hidden="true"><code>&gt;&gt;&gt; (find-page <span class="error-page__repl-string">"requested-url"</span>)
+nil  <span class="error-page__repl-comment">;; not in this namespace</span></code></pre>
+  </header>
 
+  <div class="error-page__groups">
+    <section class="error-page__group">
+      <h2 class="error-page__group-title">Learn</h2>
+      <ul class="error-page__links">
+        <li><a href="/documentation/getting-started/">Getting started</a></li>
+        <li><a href="/practice/">Practice exercises</a></li>
+        <li><a href="/documentation/guides/cookbook/">Cookbook</a></li>
+      </ul>
+    </section>
+
+    <section class="error-page__group">
+      <h2 class="error-page__group-title">Reference</h2>
+      <ul class="error-page__links">
+        <li><a href="/documentation/reference/cheat-sheet/">Cheat sheet</a></li>
+        <li><a href="/documentation/reference/api/">API reference</a></li>
+        <li><a href="/documentation/reference/agentic-coding/">Agentic coding</a></li>
+      </ul>
+    </section>
+
+    <section class="error-page__group">
+      <h2 class="error-page__group-title">Explore</h2>
+      <ul class="error-page__links">
+        <li><a href="/">Home</a></li>
+        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/documentation/">All documentation</a></li>
+      </ul>
+    </section>
+  </div>
+
+  <p class="error-page__hint">
+    Or open search from the top of any page to find what you need.
+  </p>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Summary

- Trim and reorder `why-phel.md` so the "do I need to know Lisp?" answer leads; restructure `configuration.md` around `forProject()` with a five-setting common-tweaks block and the full reference collapsed; replace the three-bucket "Where to Go Next" in `getting-started.md` with a linear "Your First 30 Minutes" path.
- Add `content/documentation/reference/agentic-coding.md`, a single self-contained Phel reference for AI coding agents (Claude Code, Codex, Cursor, Copilot, Aider, Gemini) covering syntax, core forms, PHP interop, common gotchas, and pointers to the vendored `.agents/` skill set. Add `static/llms.txt` following the llms.txt convention so AI fetchers can discover this page without crawling the rest of the docs.
- Redesign the 404 page: gradient 404 tag, REPL-style `(find-page ...) ;; not in this namespace` hint, three grouped destination cards (Learn, Reference, Explore), search hint at the bottom. CSS rules use `.error-page` ancestor specificity so the documentation H2 and ul styles do not cascade through.
- Add `Lacsw/phelgeon` to the In the Wild project list.
