### PR TITLE
docs: enforce ; comment style and strip em-dashes

### DIFF
--- a/build/src/ApiGenerator/Application/ApiMarkdownGenerator.php
+++ b/build/src/ApiGenerator/Application/ApiMarkdownGenerator.php
@@ -38,7 +38,20 @@ final readonly class ApiMarkdownGenerator
             $files[$namespace] = $this->buildNamespaceFile($namespace, $functions, $functionMap);
         }
 
+        foreach ($files as $key => $lines) {
+            $files[$key] = array_map($this->stripEmDash(...), $lines);
+        }
+
         return $files;
+    }
+
+    private function stripEmDash(string $text): string
+    {
+        return str_replace(
+            [' &mdash; ', ' &mdash;', '&mdash; ', '&mdash;', ' — ', ' —', '— ', '—'],
+            [', ',        ',',        ', ',        ',',       ', ', ',',  ', ', ','],
+            $text,
+        );
     }
 
     public function namespaceSlug(string $namespace): string

--- a/build/src/ReleasesGenerator/Application/GitHubReleasePagesGenerator.php
+++ b/build/src/ReleasesGenerator/Application/GitHubReleasePagesGenerator.php
@@ -230,10 +230,21 @@ final readonly class GitHubReleasePagesGenerator
         $body = $this->formatPrReferences($body);
         $body = $this->formatContributorMentions($body);
 
-        return preg_replace_callback(
+        $body = preg_replace_callback(
             '#https://github\.com/phel-lang/phel-lang/compare/(v[\d.]+)\.\.\.(v[\d.]+)#',
             fn(array $matches): string => "[{$matches[1]}...{$matches[2]}]({$matches[0]})",
             $body,
+        );
+
+        return $this->stripEmDash($body);
+    }
+
+    private function stripEmDash(string $text): string
+    {
+        return str_replace(
+            [' &mdash; ', ' &mdash;', '&mdash; ', '&mdash;', ' — ', ' —', '— ', '—'],
+            [', ',        ',',        ', ',        ',',       ', ', ',',  ', ', ','],
+            $text,
         );
     }
 

--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -38,7 +38,7 @@ That covers running, testing, formatting, and building. Everything else has sens
 
 ```php
 <?php
-// phel-config.php — every setter, default values shown
+// phel-config.php, every setter, default values shown
 return (new \Phel\Config\PhelConfig())
     ->setSrcDirs(['src'])
     ->setTestDirs(['tests'])

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -47,10 +47,10 @@ Try a few expressions:
 >>> (conj xs 4)
 [1 2 3 4]
 >>> xs
-[1 2 3]                    ;; original vector is unchanged
+[1 2 3]                    ; original vector is unchanged
 >>> (map inc xs)
 (2 3 4)
->>> (php/date "Y-m-d")      ;; call any PHP function
+>>> (php/date "Y-m-d")      ; call any PHP function
 "2026-04-21"
 ```
 
@@ -154,16 +154,16 @@ This checks required PHP extensions (`json`, `mbstring`, `readline`), cache dire
 
 Follow in order. Each step builds on the last. By the end you will be writing real Phel.
 
-1. **[Practice: Basics](/practice/basic)** (~10 min) — graded REPL exercises from "Hello, world" up.
-2. **[Basic Types](/documentation/language/basic-types)** (~5 min) — every literal in one page.
-3. **[Cheat Sheet](/documentation/reference/cheat-sheet)** (keep open) — core functions, one page, filterable.
-4. **[Cookbook](/documentation/guides/cookbook)** (~15 min) — copy-paste recipes for real tasks.
+1. **[Practice: Basics](/practice/basic)** (~10 min), graded REPL exercises from "Hello, world" up.
+2. **[Basic Types](/documentation/language/basic-types)** (~5 min), every literal in one page.
+3. **[Cheat Sheet](/documentation/reference/cheat-sheet)** (keep open), core functions, one page, filterable.
+4. **[Cookbook](/documentation/guides/cookbook)** (~15 min), copy-paste recipes for real tasks.
 
 After that, branch by need:
 
 - **Daily editor flow:** [REPL](/documentation/tooling/repl) → [Editor Support](/documentation/tooling/editor-support).
 - **Coming from PHP:** [Rosetta Stone](/documentation/guides/rosetta-stone), [PHP Interop](/documentation/php-interop).
 - **Power features:** [Macros](/documentation/language/macros), [Interfaces](/documentation/language/interfaces).
-- **Pair with an AI agent:** [Agentic Coding](/documentation/reference/agentic-coding) — single-page reference for Claude Code, Codex, Cursor.
+- **Pair with an AI agent:** [Agentic Coding](/documentation/reference/agentic-coding), single-page reference for Claude Code, Codex, Cursor.
 
 Need a different install path? See [Installation](/documentation/installation).

--- a/content/practice/challenges.md
+++ b/content/practice/challenges.md
@@ -8,10 +8,10 @@ Time to put everything together. These challenges grow from gentle warm-ups into
 {% question(difficulty="hard") %}
 **Temperature converter**: write `c->f` and `f->c` to convert between Celsius and Fahrenheit. Then build `convert` so that `(convert 100 :c->f)` returns `212.0`.
 ```phel
-(c->f 100)            ;; => 212.0
-(f->c 32)             ;; => 0.0
-(convert 100 :c->f)   ;; => 212.0
-(convert 32 :f->c)    ;; => 0.0
+(c->f 100)            ; => 212.0
+(f->c 32)             ; => 0.0
+(convert 100 :c->f)   ; => 212.0
+(convert 32 :f->c)    ; => 0.0
 ```
 {% end %}
 {% solution() %}
@@ -60,7 +60,7 @@ Learn more: [Control Flow](/documentation/language/control-flow), [Arithmetic](/
 {% question(difficulty="hard") %}
 **Fibonacci**: return the first `n` Fibonacci numbers.
 ```phel
-(fib 8) ;; => [0 1 1 2 3 5 8 13]
+(fib 8) ; => [0 1 1 2 3 5 8 13]
 ```
 Hint: `loop`/`recur` with an accumulator.
 {% end %}
@@ -82,8 +82,8 @@ Learn more: [Control Flow](/documentation/language/control-flow), [Data Structur
 {% question(difficulty="hard") %}
 **Caesar cipher**: write `encode` and `decode` that shift lowercase letters by `n` positions. Leave other characters alone.
 ```phel
-(encode "hello" 3)  ;; => "khoor"
-(decode "khoor" 3)  ;; => "hello"
+(encode "hello" 3)  ; => "khoor"
+(decode "khoor" 3)  ; => "hello"
 ```
 Hint: `php/ord` and `php/chr` give you character codes.
 {% end %}
@@ -101,8 +101,8 @@ Hint: `php/ord` and `php/chr` give you character codes.
 (defn decode [text n]
   (encode text (- 26 n)))
 
-(encode "hello" 3)  ;; => "khoor"
-(decode "khoor" 3)  ;; => "hello"
+(encode "hello" 3)  ; => "khoor"
+(decode "khoor" 3)  ; => "hello"
 ```
 This combines `map` over a string (treated as a sequence of characters), the short anonymous `|` form, PHP interop for character codes, and modular arithmetic for the wrap-around.
 
@@ -155,7 +155,7 @@ Learn more: [PHP Interop](/documentation/php-interop), [Data Structures](/docume
 ```phel
 (reset-counter!)
 (tick!) (tick!) (tick!)
-(current) ;; => 3
+(current) ; => 3
 ```
 {% end %}
 {% solution() %}
@@ -168,7 +168,7 @@ Learn more: [PHP Interop](/documentation/php-interop), [Data Structures](/docume
 
 (reset-counter!)
 (tick!) (tick!) (tick!)
-(current) ;; => 3
+(current) ; => 3
 ```
 Most Phel data is immutable, but sometimes you need a single mutable cell - a request counter, a cached result, an in-memory app state. `var` gives you exactly that, `swap!` updates it with a function, and `@` (or `deref`) reads the current value. By convention, functions that mutate end with `!`.
 

--- a/content/practice/working-with-collections.md
+++ b/content/practice/working-with-collections.md
@@ -238,7 +238,7 @@ Use `group-by` to split numbers into evens and odds:
 {% question(difficulty="hard") %}
 Define `area` so it accepts a map `{:width w :height h}` and returns `w * h`. Use destructuring in the parameter list:
 ```phel
-(area {:width 5 :height 3}) ;; => 15
+(area {:width 5 :height 3}) ; => 15
 ```
 {% end %}
 {% solution() %}

--- a/scripts/generate-og-images.py
+++ b/scripts/generate-og-images.py
@@ -114,7 +114,7 @@ def main() -> None:
     )
     render(
         title="Destructuring Deep Dive",
-        subtitle="Nested vectors and maps, :keys, :or, :as, & rest — the Clojure way in Phel.",
+        subtitle="Nested vectors and maps, :keys, :or, :as, & rest, the Clojure way in Phel.",
         out_path=OUT_DIR / "og-destructuring-deep-dive.png",
     )
 

--- a/static/progress-tracker.js
+++ b/static/progress-tracker.js
@@ -30,7 +30,7 @@
       if (check) {
         check.innerHTML = done ? '&#10003;' : '';
         check.classList.toggle('completed', done);
-        check.title = done ? 'Completed — click to undo' : 'Mark as done';
+        check.title = done ? 'Completed, click to undo' : 'Mark as done';
       }
     }
 

--- a/static/syntax-theme-light.css
+++ b/static/syntax-theme-light.css
@@ -1,7 +1,7 @@
 /*
  * Phel light syntax theme
  * Tuned to the phel-lang.org palette (indigo/violet accent, slate neutrals).
- * Applies to every fenced code block Zola emits — Phel gets the full treatment,
+ * Applies to every fenced code block Zola emits, Phel gets the full treatment,
  * other languages inherit the same token colors via shared z-* classes.
  */
 

--- a/templates/partials/breadcrumb.html
+++ b/templates/partials/breadcrumb.html
@@ -18,7 +18,7 @@
 {# Filter ancestors: drop the site root (`_index.md`) and the implicit
    `documentation/_index.md` (visitors already know they're in docs). The
    tail (current page title) renders only when at least one ancestor
-   remains after filtering — keeps the breadcrumb off direct children of
+   remains after filtering, keeps the breadcrumb off direct children of
    /documentation/ and off the site root. #}
 {% set hide = ["_index.md", "documentation/_index.md"] %}
 {% set_global rendered_ancestors = [] %}

--- a/templates/partials/doc-prev-next.html
+++ b/templates/partials/doc-prev-next.html
@@ -14,7 +14,7 @@
   {% set_global rendered_subs = [] %}
 
   {# Section landings (Language, Web, Tooling, Guides, Reference) are
-     omitted from the flow — they're table-of-contents pages with their
+     omitted from the flow, they're table-of-contents pages with their
      own card grid, so prev/next there would be redundant, and skipping
      them keeps the read order clean: last page of one section -> first
      page of the next. #}


### PR DESCRIPTION
## Summary
- Switch inline Phel comments in docs from `;;` (standalone) to `;` (inline) per the project rule
- Remove em-dashes from rendered pages (content, templates, OG image script, static JS/CSS)
- Add em-dash stripping in the API markdown generator and releases generator so regenerated files stay clean

## Test plan
- [ ] `grep -r '—' content/ templates/ static/` returns nothing
- [ ] `grep -rP '\S.*\s;;(?!;)' content/` returns nothing (no inline `;;` misuse)
- [ ] CI passes