### PR TITLE
docs: simplify and tighten all documentation pages

### DIFF
--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Documentation"
-description = "Comprehensive guides and references for Phel: installation, language features, tooling, web development, and more."
+description = "Phel docs: install, language, tooling, web, reference."
 sort_by = "weight"
 insert_anchor_links = "right"
 paginate_by = 5
@@ -8,10 +8,8 @@ paginate_by = 5
 
 # Documentation
 
-Welcome to the Phel documentation. Here you'll find comprehensive guides and references for using Phel.
-
 <div class="redirect-notice">
-    <p><strong>Notice:</strong> You will be automatically redirected to the <a href="/documentation/getting-started/">Getting Started</a> guide in a few seconds.</p>
+    <p><strong>Redirecting to <a href="/documentation/getting-started/">Getting Started</a>...</strong></p>
 </div>
 
 <script>

--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -3,7 +3,7 @@ title = "Configuration"
 weight = 60
 +++
 
-Phel reads `phel-config.php` from the project root. For most projects you only need the factory:
+Phel reads `phel-config.php` from the project root. Most projects only need the factory:
 
 ```php
 <?php
@@ -11,11 +11,9 @@ Phel reads `phel-config.php` from the project root. For most projects you only n
 return \Phel\Config\PhelConfig::forProject('your-ns\main');
 ```
 
-This sets a conventional layout (`src/phel/`, `tests/phel/`) and the build entry namespace. Override anything by chaining setters.
+Sets `src/phel/`, `tests/phel/`, and the build entry namespace. Chain setters to override.
 
-## Common Tweaks
-
-The five settings most projects touch:
+## Common tweaks
 
 ```php
 <?php
@@ -29,9 +27,9 @@ return \Phel\Config\PhelConfig::forProject('your-ns\main')
 ;
 ```
 
-That covers running, testing, formatting, and building. Everything else has sensible defaults.
+Covers running, testing, formatting, building. Defaults handle the rest.
 
-## Full Reference
+## Full reference
 
 <details>
 <summary><strong>All available options</strong></summary>

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -3,26 +3,26 @@ title = "Getting Started"
 weight = 1
 +++
 
-Phel is a Lisp that compiles to PHP. You get persistent data structures, immutability by default, and macros. All running on the PHP runtime you already have.
+Phel is a Lisp that compiles to PHP. Persistent data structures, immutability by default, macros. Runs on your existing PHP runtime.
 
-This page gets you from zero to a live REPL in under a minute.
+Zero to live REPL in under a minute.
 
 ## Requirements
 
-- **PHP 8.4+**, check with `php -v`
-- **[Composer](https://getcomposer.org/)**, check with `composer --version`
+- **PHP 8.4+** (`php -v`)
+- **[Composer](https://getcomposer.org/)** (`composer --version`)
 
-That is all you need. No extra runtime, no JVM.
+No extra runtime. No JVM.
 
-> **No PHP installed?** Skip to the one-line Docker REPL:
+> **No PHP installed?** One-line Docker REPL:
 >
 > ```bash
 > docker run --rm -it php:8.4-cli sh -c "curl -sL https://phel-lang.org/phar -o /tmp/phel.phar && php /tmp/phel.phar repl"
 > ```
 >
-> See [Installation → Docker](/documentation/installation#docker-no-php-required) for a `phel` alias and Composer-based workflows.
+> See [Installation, Docker](/documentation/installation#docker-no-php-required) for a `phel` alias and Composer workflows.
 
-## 60-Second Quick Start
+## 60-second quick start
 
 ```bash
 composer create-project --stability dev phel-lang/cli-skeleton example-app
@@ -60,9 +60,9 @@ Exit with `Ctrl+D` or `exit`. Run the entry script:
 composer dev
 ```
 
-Done. You have a working Phel project.
+Done. Working Phel project.
 
-## Which Background Do You Come From?
+## Which background do you come from?
 
 <details class="dev-note dev-note--clojure">
 <summary>
@@ -72,18 +72,18 @@ Done. You have a working Phel project.
 </summary>
 <div class="dev-note__content">
 
-**Most of your intuition transfers unchanged.** `def`, `defn`, `let`, `fn`, `if`, `when`, `cond`, `case`, `loop`/`recur`, `->`, `->>`, `as->`, destructuring, `conj`, `assoc`, `map`, `filter`, `reduce`, transducers, protocols: all work as you expect.
+**Most intuition transfers.** `def`, `defn`, `let`, `fn`, `if`, `when`, `cond`, `case`, `loop`/`recur`, `->`, `->>`, `as->`, destructuring, `conj`, `assoc`, `map`, `filter`, `reduce`, transducers, protocols: work as expected.
 
-**Key differences at a glance:**
+**Key differences:**
 
-- Runtime is PHP, not the JVM. `println`, files, HTTP all go through PHP.
-- Namespaces use dashes in source but map to PHP classes under the hood (`my-app\core` ↔ `MyApp\Core`).
+- Runtime is PHP, not JVM. `println`, files, HTTP go through PHP.
+- Namespaces use dashes in source, map to PHP classes (`my-app\core` ↔ `MyApp\Core`).
 - Interop: `(php/date "Y-m-d")`, `(php/new DateTime)`, `(php/-> obj (method arg))`.
-- No agents/refs. Use PHP features for concurrency, or Phel's fiber-based `async` (amphp).
-- `nil` is the only falsy value other than `false`. Strings, `0`, `[]` are all truthy.
-- Comments: `;` inline, `;;` standalone. `#_` reader discard and `(comment ...)` both work.
+- No agents/refs. Use PHP for concurrency, or Phel's fiber-based `async` (amphp).
+- Only `nil` and `false` are falsy. Strings, `0`, `[]` truthy.
+- Comments: `;` inline, `;;` standalone. `#_` reader discard and `(comment ...)` work.
 
-**Start here:** [Coming from Clojure](/documentation/guides/coming-from-clojure) for the full diff guide.
+**Start:** [Coming from Clojure](/documentation/guides/coming-from-clojure).
 
 </div>
 </details>
@@ -96,42 +96,42 @@ Done. You have a working Phel project.
 </summary>
 <div class="dev-note__content">
 
-**Your PHP ecosystem stays.** Phel compiles to PHP, ships via Composer, runs with your PHP binary, and can call any PHP function or class directly.
+**PHP ecosystem stays.** Compiles to PHP, ships via Composer, runs with your PHP binary, calls any PHP function/class directly.
 
-**What is different:**
+**Differences:**
 
-- Immutable by default. Instead of `$x = $x + 1`, you bind a new value: `(let [x (+ x 1)] ...)`.
-- Prefix notation: `add(1, 2)` becomes `(+ 1 2)`. The function is always the first element.
-- Persistent vectors/maps/sets instead of PHP arrays (structural sharing, O(log32 n) updates).
-- Everything is an expression. No statements, no `return` keyword.
-- Interop is one-liner: `(php/date "Y-m-d")`, `(php/new DateTime "2024-01-01")`, `(php/-> obj (method arg))`.
-- REPL-first workflow. You write code by evaluating forms, not by running scripts repeatedly.
+- Immutable by default. Bind new values: `(let [x (+ x 1)] ...)` instead of `$x = $x + 1`.
+- Prefix notation: `add(1, 2)` becomes `(+ 1 2)`. Function is always first.
+- Persistent vectors/maps/sets, not PHP arrays (structural sharing, O(log32 n) updates).
+- Everything an expression. No statements, no `return`.
+- One-liner interop: `(php/date "Y-m-d")`, `(php/new DateTime "2024-01-01")`, `(php/-> obj (method arg))`.
+- REPL-first. Evaluate forms, don't re-run scripts.
 
-**Start here:** [Phel for PHP Developers](/documentation/guides/phel-for-php-developers). Maps every common PHP pattern to Phel.
+**Start:** [Phel for PHP Developers](/documentation/guides/phel-for-php-developers). Maps PHP patterns to Phel.
 
 </div>
 </details>
 
-## Project Layout
+## Project layout
 
-The skeleton gives you this:
+Skeleton gives you:
 
 ```
 example-app/
-├── composer.json       # PHP dependencies + phel scripts
-├── phel-config.php     # project config (source/test dirs, build)
+├── composer.json       ; PHP deps + phel scripts
+├── phel-config.php     ; project config (src/test dirs, build)
 ├── src/
-│   ├── main.phel       # entry namespace
-│   └── modules/        # your code, organized by namespace
+│   ├── main.phel       ; entry namespace
+│   └── modules/        ; your code by namespace
 └── tests/
     └── modules/
 ```
 
-All commands are available as `vendor/bin/phel <cmd>` (for example `vendor/bin/phel repl`). The skeleton also wires `composer repl`, `composer dev`, `composer test`, and `composer build` as shortcuts.
+All commands as `vendor/bin/phel <cmd>` (e.g. `vendor/bin/phel repl`). Skeleton wires `composer repl`, `composer dev`, `composer test`, `composer build` as shortcuts.
 
-## Initialize Without the Skeleton
+## Initialize without the skeleton
 
-Prefer a minimal setup? Add Phel to any Composer project:
+Minimal setup? Add Phel to any Composer project:
 
 ```bash
 mkdir my-app && cd my-app
@@ -140,30 +140,30 @@ vendor/bin/phel init my-app
 vendor/bin/phel repl
 ```
 
-`phel init` creates `phel-config.php`, a `src/` namespace, and a matching test file.
+`phel init` creates `phel-config.php`, a `src/` namespace, matching test file.
 
-## Verify Your Setup
+## Verify setup
 
 ```bash
 vendor/bin/phel doctor
 ```
 
-This checks required PHP extensions (`json`, `mbstring`, `readline`), cache directory permissions, and source layout. Run it any time the tooling misbehaves.
+Checks PHP extensions (`json`, `mbstring`, `readline`), cache dir permissions, source layout. Run when tooling misbehaves.
 
-## Your First 30 Minutes
+## Your first 30 minutes
 
-Follow in order. Each step builds on the last. By the end you will be writing real Phel.
+In order:
 
-1. **[Practice: Basics](/practice/basic)** (~10 min), graded REPL exercises from "Hello, world" up.
-2. **[Basic Types](/documentation/language/basic-types)** (~5 min), every literal in one page.
-3. **[Cheat Sheet](/documentation/reference/cheat-sheet)** (keep open), core functions, one page, filterable.
-4. **[Cookbook](/documentation/guides/cookbook)** (~15 min), copy-paste recipes for real tasks.
+1. **[Practice: Basics](/practice/basic)** (~10 min), graded REPL exercises.
+2. **[Basic Types](/documentation/language/basic-types)** (~5 min), every literal.
+3. **[Cheat Sheet](/documentation/reference/cheat-sheet)** (keep open), core functions, filterable.
+4. **[Cookbook](/documentation/guides/cookbook)** (~15 min), copy-paste recipes.
 
-After that, branch by need:
+Branch by need:
 
-- **Daily editor flow:** [REPL](/documentation/tooling/repl) → [Editor Support](/documentation/tooling/editor-support).
-- **Coming from PHP:** [Rosetta Stone](/documentation/guides/rosetta-stone), [PHP Interop](/documentation/php-interop).
+- **Editor flow:** [REPL](/documentation/tooling/repl), [Editor Support](/documentation/tooling/editor-support).
+- **From PHP:** [Rosetta Stone](/documentation/guides/rosetta-stone), [PHP Interop](/documentation/php-interop).
 - **Power features:** [Macros](/documentation/language/macros), [Interfaces](/documentation/language/interfaces).
-- **Pair with an AI agent:** [Agentic Coding](/documentation/reference/agentic-coding), single-page reference for Claude Code, Codex, Cursor.
+- **AI agent pairing:** [Agentic Coding](/documentation/reference/agentic-coding) for Claude Code, Codex, Cursor.
 
-Need a different install path? See [Installation](/documentation/installation).
+Different install path? See [Installation](/documentation/installation).

--- a/content/documentation/guides/_index.md
+++ b/content/documentation/guides/_index.md
@@ -6,4 +6,4 @@ insert_anchor_links = "right"
 template = "section-page.html"
 +++
 
-Transition guides and practical recipes for developers coming from other languages or looking for real-world patterns.
+Transition guides and recipes for developers from other languages or looking for real-world patterns.

--- a/content/documentation/guides/coming-from-clojure.md
+++ b/content/documentation/guides/coming-from-clojure.md
@@ -4,17 +4,17 @@ weight = 2
 aliases = ["/documentation/coming-from-clojure"]
 +++
 
-If you already know Clojure, you will feel right at home in Phel. Phel is a functional Lisp that compiles to PHP, directly inspired by Clojure (and Janet). It brings persistent data structures, immutability by default, and a functional-first philosophy to the PHP ecosystem. This guide highlights what transfers directly, what differs, and where Phel adds capabilities unique to its PHP target.
+Phel is a functional Lisp on PHP, inspired by Clojure (and Janet). Persistent data structures, immutability by default, functional-first. This guide: what transfers, what differs, what Phel adds.
 
-Phel ships with protocols, transducers, reader conditionals (`#?()`), regex literals, structured exceptions via `ex-info`/`ex-data`, and a hierarchy system with `derive`/`isa?`/`parents`/`ancestors`/`descendants`, plus core.match-style `match`, `schema` validation, fiber-based `async`, and an nREPL/LSP toolchain.
+Ships with: protocols, transducers, reader conditionals (`#?()`), regex literals, `ex-info`/`ex-data`, hierarchies (`derive`, `isa?`, `parents`, `ancestors`, `descendants`), core.match-style `match`, `schema`, fiber-based `async`, nREPL/LSP toolchain.
 
-## What Feels Familiar
+## What feels familiar
 
-Most of your Clojure intuition carries over unchanged.
+Clojure intuition carries over.
 
-**Core forms** -- `def`, `defn`, `let`, `fn`, `if`, `when`, `cond`, `case`, `do`, `loop`/`recur` all work the way you expect.
+**Core forms:** `def`, `defn`, `let`, `fn`, `if`, `when`, `cond`, `case`, `do`, `loop`/`recur`.
 
-**Persistent data structures** -- Vectors, maps, and sets use the same algorithms (HAMTs and similar structures) and the same core functions:
+**Persistent data structures:** vectors, maps, sets. Same algorithms (HAMTs etc.), same core functions:
 
 ```phel
 (def v [1 2 3])
@@ -29,7 +29,7 @@ Most of your Clojure intuition carries over unchanged.
 (conj s 4)              ; => #{1 2 3 4}
 ```
 
-**Threading macros** -- `->`, `->>`, and `as->` work exactly as in Clojure:
+**Threading macros:** `->`, `->>`, `as->` work as in Clojure:
 
 ```phel
 (->> users
@@ -38,7 +38,7 @@ Most of your Clojure intuition carries over unchanged.
      (into #{}))
 ```
 
-**Destructuring** -- Both sequential and associative destructuring work in `let`, `fn`, `defn`, and `loop`:
+**Destructuring:** sequential and associative work in `let`, `fn`, `defn`, `loop`:
 
 ```phel
 (let [[a b & rest] [1 2 3 4 5]]
@@ -48,7 +48,7 @@ Most of your Clojure intuition carries over unchanged.
   (str name " is " age)) ; => "Alice is 30"
 ```
 
-**Higher-order functions** -- `map`, `filter`, `reduce`, `some`, `every?`, `comp`, `partial`, `apply`, and friends are all present:
+**Higher-order functions:** `map`, `filter`, `reduce`, `some`, `every?`, `comp`, `partial`, `apply`, etc.:
 
 ```phel
 (map inc [1 2 3])          ; => (2 3 4)
@@ -56,7 +56,7 @@ Most of your Clojure intuition carries over unchanged.
 (reduce + 0 [1 2 3 4 5])   ; => 15
 ```
 
-**Lazy sequences** -- Phel has full lazy sequence support. Core functions like `map`, `filter`, `take`, `drop`, `concat`, `mapcat`, `interleave`, and `partition` all return lazy sequences. Infinite sequences work too:
+**Lazy sequences:** full support. `map`, `filter`, `take`, `drop`, `concat`, `mapcat`, `interleave`, `partition` return lazy seqs. Infinite seqs work:
 
 ```phel
 (take 5 (iterate inc 0))       ; => (0 1 2 3 4)
@@ -65,23 +65,23 @@ Most of your Clojure intuition carries over unchanged.
 (->> (range) (filter even?) (take 5)) ; => (0 2 4 6 8)
 ```
 
-Phel also provides `lazy-seq` and `lazy-cat` macros for building custom lazy sequences, plus `doall`, `dorun`, and `realized?` for controlling realization. Lazy file I/O is available through `line-seq`, `file-seq`, `read-file-lazy`, and `csv-seq`.
+`lazy-seq`, `lazy-cat` build custom lazy seqs. `doall`, `dorun`, `realized?` control realization. Lazy file I/O via `line-seq`, `file-seq`, `read-file-lazy`, `csv-seq`.
 
-**Namespaces with `:require`** -- The module system uses `:require` for Phel modules and supports `:as` and `:refer`, just like Clojure.
+**Namespaces:** `:require` for Phel modules, `:as` and `:refer` like Clojure.
 
-**REPL-driven development** -- Phel ships with a REPL that supports `doc`, inline `require`, and multiline expressions. See the [REPL](/documentation/tooling/repl) page.
+**REPL:** supports `doc`, inline `require`, multiline. See [REPL](/documentation/tooling/repl).
 
-**Macros** -- `defmacro`, quote, syntax-quote, unquote, and unquote-splicing are all available. `defn` is itself a macro, just like in Clojure. See [Macros](/documentation/language/macros).
+**Macros:** `defmacro`, quote, syntax-quote, unquote, unquote-splicing. `defn` is a macro. See [Macros](/documentation/language/macros).
 
-For full reference on data structures, see [Data Structures](/documentation/language/data-structures). For function definitions and recursion, see [Functions and Recursion](/documentation/language/functions-and-recursion).
+Reference: [Data Structures](/documentation/language/data-structures), [Functions and Recursion](/documentation/language/functions-and-recursion).
 
-## Key Differences
+## Key differences
 
-These are the conceptual differences that matter most day-to-day.
+Day-to-day differences.
 
-### No JVM -- PHP is the runtime
+### No JVM, PHP runtime
 
-Phel compiles to PHP and runs on the PHP interpreter. There is no JVM, no classpath, no JAR files. Your dependency manager is Composer, not deps.edn or Leiningen.
+Compiles to PHP, runs on PHP. No JVM, classpath, JARs. Dependency manager is Composer (not deps.edn or Leiningen).
 
 ### Protocols
 
@@ -110,9 +110,9 @@ Phel supports Clojure-style `defmulti` / `defmethod` with hierarchy-aware dispat
 (defmethod area :rectangle [{:width w :height h}] (* w h))
 ```
 
-### Atoms -- no agents, refs, or STM
+### Atoms only, no agents/refs/STM
 
-Phel provides a single mutable state primitive: `atom`. It works like a Clojure atom:
+`atom` is the only mutable primitive. Works like Clojure's:
 
 ```phel
 (def counter (atom 0))
@@ -122,19 +122,19 @@ Phel provides a single mutable state primitive: `atom`. It works like a Clojure 
 (reset! counter 42)   ; direct reset
 ```
 
-There are no agents, refs, or STM. See [Global and Local Bindings](/documentation/language/global-and-local-bindings) for details.
+No agents, refs, STM. See [Global and Local Bindings](/documentation/language/global-and-local-bindings).
 
 ### No spec
 
-There is no built-in spec or schema system. Validate data with predicates and `cond` or reach for a PHP validation library through interop.
+No built-in spec/schema. Validate with predicates + `cond`, or use a PHP validation library via interop.
 
 ### Truthiness
 
-This is the same as Clojure -- only `false` and `nil` are falsy. `0`, `""`, and `[]` are all truthy. If you have been writing Clojure this is exactly what you expect, but it differs from PHP's truthiness rules. See [Truth and Boolean Operations](/documentation/language/truth-and-boolean-operations).
+Same as Clojure: only `false` and `nil` falsy. `0`, `""`, `[]` truthy. Differs from PHP. See [Truth and Boolean Operations](/documentation/language/truth-and-boolean-operations).
 
 ### Reader conditionals
 
-Phel now supports reader conditionals with `#?()` and splicing reader conditionals with `#?@()`, using `:phel` and `:default` as platform keys. This enables writing cross-platform `.cljc` files:
+`#?()` and splicing `#?@()`, using `:phel` and `:default` as platform keys. Enables cross-platform `.cljc` files:
 
 ```phel
 (def host
@@ -142,15 +142,15 @@ Phel now supports reader conditionals with `#?()` and splicing reader conditiona
      :default "Unknown"))
 ```
 
-Custom reader macros are not supported, but generic tagged literals (`#uuid`, `#inst`, `#cpp`, ...) are read as tagged-literal nodes. The Clojure-style `#(...)` anonymous function shorthand with `%` / `%1` / `%&` placeholders works as expected; the Phel-only `|(...)` with `$` placeholders is also accepted but deprecated. The `#_` form for commenting out expressions is supported.
+No custom reader macros. Generic tagged literals (`#uuid`, `#inst`, `#cpp`, etc.) read as tagged-literal nodes. Clojure-style `#(...)` with `%`/`%1`/`%&` works. Phel-only `|(...)` with `$` accepted but deprecated. `#_` to skip a form.
 
-## Syntax Differences
+## Syntax differences
 
-This section shows Clojure and Phel side by side for the constructs that differ syntactically.
+Clojure and Phel side by side for syntactically different constructs.
 
 ### Namespace declaration
 
-Namespaces use `\` as the separator (following PHP conventions) instead of `.`:
+Use `\` separator (PHP convention) instead of `.`:
 
 ```clojure
 ;; Clojure
@@ -165,17 +165,17 @@ Namespaces use `\` as the separator (following PHP conventions) instead of `.`:
   (:require myapp\db :as db))
 ```
 
-Key differences:
-- `\` instead of `.` as separator
-- No vector wrapping around each require clause
-- `:use` imports PHP classes (separate from `:require` for Phel modules)
-- `:refer` works the same way: `(:require myapp\db :refer [query])`
+Differences:
+- `\` instead of `.`
+- No vector wrap per require clause
+- `:use` for PHP classes; `:require` for Phel modules
+- `:refer` same: `(:require myapp\db :refer [query])`
 
-See [Namespaces](/documentation/language/namespaces) for the full reference.
+See [Namespaces](/documentation/language/namespaces).
 
 ### Keywords
 
-Keywords look the same:
+Same:
 
 ```clojure
 ;; Clojure
@@ -191,11 +191,11 @@ Keywords look the same:
 ::namespaced-key
 ```
 
-Keywords work as functions on maps in both languages: `(:name user)`.
+Keywords act as functions on maps in both: `(:name user)`.
 
 ### String concatenation and formatting
 
-Phel uses `str` for concatenation (same as Clojure) and `format` for sprintf-style formatting:
+`str` for concat, `format` for sprintf-style:
 
 ```clojure
 ;; Clojure
@@ -211,7 +211,7 @@ Phel uses `str` for concatenation (same as Clojure) and `format` for sprintf-sty
 
 ### Anonymous functions
 
-The full `fn` form works identically. The Clojure `#(...)` shorthand with `%` placeholders works the same way in Phel:
+`fn` and `#(...)` with `%` work the same:
 
 ```clojure
 ;; Clojure
@@ -227,13 +227,13 @@ The full `fn` form works identically. The Clojure `#(...)` shorthand with `%` pl
 #(+ %1 %2)
 ```
 
-Phel also accepts `|(...)` with `$` placeholders as a legacy shorthand, but `#(...)` is preferred.
+Phel accepts legacy `|(...)` with `$`, but `#(...)` is preferred.
 
-See [Functions and Recursion](/documentation/language/functions-and-recursion) for multi-arity functions, variadic parameters, and `recur`.
+See [Functions and Recursion](/documentation/language/functions-and-recursion) for multi-arity, variadic, `recur`.
 
 ### Maps
 
-Maps use `{}` in both languages. Keyword keys are idiomatic:
+Both use `{}`. Keyword keys idiomatic:
 
 ```clojure
 ;; Clojure
@@ -251,11 +251,11 @@ Maps use `{}` in both languages. Keyword keys are idiomatic:
 (assoc user :role :admin)
 ```
 
-The syntax and functions are the same. Phel maps also support any hashable type as keys, including vectors and other maps.
+Same syntax and functions. Phel maps also accept any hashable type as keys.
 
 ### PHP interop (replaces Java interop)
 
-Where Clojure has Java interop, Phel has PHP interop using the `php/` prefix:
+Use `php/` prefix:
 
 ```clojure
 ;; Clojure (Java interop)
@@ -271,11 +271,11 @@ Where Clojure has Java interop, Phel has PHP interop using the `php/` prefix:
 (php/pow 2 10)
 ```
 
-Any PHP function is callable by adding the `php/` prefix. See [PHP Interop](/documentation/php-interop) for the full reference.
+Any PHP function via `php/` prefix. See [PHP Interop](/documentation/php-interop).
 
 ### Printing
 
-Use `println` for output with a newline, `print` without:
+`println` adds newline, `print` doesn't:
 
 ```clojure
 ;; Clojure
@@ -291,7 +291,7 @@ Use `println` for output with a newline, `print` without:
 
 ### Comments
 
-Phel uses `;` and `;;` for line comments. The legacy `#` line comment and `#| ... |#` block comment syntax still read but are deprecated. Use `#_` to skip a single form:
+Use `;` and `;;`. Legacy `#` line and `#| ... |#` block comments still read but deprecated. `#_` skips a form:
 
 ```clojure
 ;; Clojure
@@ -307,9 +307,9 @@ Phel uses `;` and `;;` for line comments. The legacy `#` line comment and `#| ..
 (comment (+ 1 2))
 ```
 
-## PHP Interop (Your New Superpower)
+## PHP interop
 
-PHP interop is Phel's equivalent of Clojure's Java interop. The `php/` prefix gives you access to the entire PHP ecosystem.
+Phel's equivalent of Clojure's Java interop. `php/` prefix unlocks the PHP ecosystem.
 
 ### Calling PHP functions
 
@@ -352,7 +352,7 @@ PHP interop is Phel's equivalent of Clojure's Java interop. The `php/` prefix gi
 
 ### PHP array access
 
-When working with PHP arrays (not Phel data structures), use `php/aget` and `php/aset`:
+For PHP arrays (not Phel data structures), use `php/aget`, `php/aset`:
 
 ```phel
 (def config (php/json_decode (php/file_get_contents "config.json") true))
@@ -360,25 +360,25 @@ When working with PHP arrays (not Phel data structures), use `php/aget` and `php
 (php/aget-in config ["database" "host"])
 ```
 
-For the complete interop reference, see [PHP Interop](/documentation/php-interop).
+Full interop reference: [PHP Interop](/documentation/php-interop).
 
-## What You Will Miss (And Workarounds)
+## What you'll miss (and workarounds)
 
 ### Protocols
 
-Phel supports `defprotocol` and `extend-type`, bringing it close to Clojure's protocol system. You can also use `definterface` + `defstruct` for simpler patterns. See [Interfaces](/documentation/language/interfaces).
+`defprotocol` and `extend-type` work like Clojure's. `definterface` + `defstruct` for simpler patterns. See [Interfaces](/documentation/language/interfaces).
 
 ### CIDER / Calva / nREPL
 
-Editor tooling covers [VS Code, PhpStorm, Emacs, and Vim](/documentation/tooling/editor-support), with syntax highlighting and REPL integration. Phel also ships an [nREPL server](/documentation/tooling/cli-commands#nrepl) and an [LSP server](/documentation/tooling/cli-commands#lsp) for deeper editor integration, plus structured stack frames in `EvalError` and stdout capture in `EvalResult`.
+Editor tooling covers [VS Code, PhpStorm, Emacs, Vim](/documentation/tooling/editor-support). Phel ships [nREPL](/documentation/tooling/cli-commands#nrepl) and [LSP](/documentation/tooling/cli-commands#lsp) servers, structured stack frames in `EvalError`, stdout capture in `EvalResult`.
 
 ### ClojureScript
 
-Phel targets PHP only. There is no browser/JavaScript target.
+PHP only. No browser/JavaScript target.
 
 ### deps.edn / Leiningen
 
-Use Composer for dependency management. Your `composer.json` replaces `deps.edn`:
+Use Composer. `composer.json` replaces `deps.edn`:
 
 ```json
 {
@@ -390,50 +390,50 @@ Use Composer for dependency management. Your `composer.json` replaces `deps.edn`
 
 ### core.async / concurrency primitives
 
-PHP's execution model is request-based, not long-running. There is no `core.async`, no channels, no CSP. For concurrent work, use PHP's queue systems or process managers through interop.
+PHP is request-based, not long-running. No `core.async`, channels, CSP. Use PHP queues or process managers via interop.
 
-## What You Will Gain
+## What you'll gain
 
 ### Cheap, ubiquitous hosting
 
-PHP runs on virtually every web host, including shared hosting plans that cost a few dollars per month. No need for a JVM-capable server.
+PHP runs on virtually any web host, including shared hosting at a few dollars/month. No JVM-capable server.
 
 ### Simpler deployment
 
-No JVM startup, no heap tuning, no GC configuration. Deploy Phel the same way you deploy any PHP application -- upload files or `composer install` on the server.
+No JVM startup, heap tuning, GC config. Deploy like any PHP app: upload files or `composer install`.
 
-### Fast startup time
+### Fast startup
 
-PHP processes start in milliseconds, not seconds. No JVM warmup. This makes CLI tools and short-lived scripts practical.
+PHP processes start in milliseconds. No JVM warmup. CLI tools and short-lived scripts are practical.
 
-### The PHP ecosystem
+### PHP ecosystem
 
-Decades of battle-tested libraries are one `composer require` away: WordPress, Laravel, Symfony components, Guzzle for HTTP, PHPUnit, Doctrine for database access, and thousands more. All of these are callable from Phel through `php/` interop.
+Decades of battle-tested libraries via `composer require`: WordPress, Laravel, Symfony, Guzzle, PHPUnit, Doctrine, thousands more. All callable via `php/`.
 
-### Easy shared hosting
+### Shared hosting
 
-Many organizations already run PHP infrastructure. Phel lets you bring functional programming and Lisp into environments where deploying a JVM is not an option.
+Many orgs already run PHP. Bring FP/Lisp into environments where the JVM isn't an option.
 
-## Quick Reference: Clojure to Phel
+## Quick reference: Clojure to Phel
 
 | Clojure | Phel | Notes |
 |---------|------|-------|
 | `(ns foo.bar)` | `(ns foo\bar)` | `\` separator instead of `.` |
 | `(:require [foo.bar :as b])` | `(:require foo\bar :as b)` | No vector wrapping required |
-| `#(* % 2)` | `#(* % 2)` | Same -- `|(* $ 2)` also works (legacy) |
-| `(atom 0)` | `(atom 0)` | Same -- `(var 0)` is the deprecated alias |
+| `#(* % 2)` | `#(* % 2)` | Same. `|(* $ 2)` legacy |
+| `(atom 0)` | `(atom 0)` | Same. `(var 0)` deprecated |
 | `@my-atom` | `@my-atom` | Same |
-| `(reset! a v)` | `(reset! a v)` | Same -- `(set! a v)` is the deprecated alias |
+| `(reset! a v)` | `(reset! a v)` | Same. `(set! a v)` deprecated |
 | `(swap! a f)` | `(swap! a f)` | Same |
-| `(.method obj)` | `(php/-> obj (method))` | Instance method call |
-| `(Class/static)` | `(php/:: Class (static))` | Static method call |
+| `(.method obj)` | `(php/-> obj (method))` | Instance method |
+| `(Class/static)` | `(php/:: Class (static))` | Static method |
 | `(new Class)` | `(php/new Class)` | Instantiation |
-| `(defprotocol P)` | `(defprotocol P)` | Same -- available since v0.31 |
-| `(defrecord R)` | `(defrecord R)` or `(defstruct R)` | `defrecord` available since v0.32 |
-| `(lazy-seq ...)` | `(lazy-seq ...)` | Same -- available since v0.25 |
-| `#?(:clj x :default y)` | `#?(:phel x :default y)` | Reader conditionals -- since v0.31 |
-| `(ex-info msg data)` | `(ex-info msg data)` | Same -- available since v0.31 |
-| `(transduce xf f coll)` | `(transduce xf f coll)` | Same -- available since v0.31 |
-| `;; comment` | `;; comment` | `;` and `;;` are the standard |
+| `(defprotocol P)` | `(defprotocol P)` | Same |
+| `(defrecord R)` | `(defrecord R)` or `(defstruct R)` | Both available |
+| `(lazy-seq ...)` | `(lazy-seq ...)` | Same |
+| `#?(:clj x :default y)` | `#?(:phel x :default y)` | Reader conditionals |
+| `(ex-info msg data)` | `(ex-info msg data)` | Same |
+| `(transduce xf f coll)` | `(transduce xf f coll)` | Same |
+| `;; comment` | `;; comment` | `;` and `;;` standard |
 
 Welcome to the PHP side of Lisp. The parentheses are the same -- the runtime just happens to be PHP.

--- a/content/documentation/guides/cookbook.md
+++ b/content/documentation/guides/cookbook.md
@@ -4,11 +4,11 @@ weight = 4
 aliases = ["/documentation/cookbook"]
 +++
 
-Practical recipes for common tasks in Phel. Each example is self-contained and ready to use.
+Recipes for common tasks. Each example self-contained.
 
-## Read and Process a CSV File
+## Read and process a CSV file
 
-Read a CSV file and parse it into a vector of maps, where each map represents a row with column headers as keys.
+Read CSV into a vector of maps, headers as keys.
 
 ```phel
 (ns cookbook\csv-reader)
@@ -54,9 +54,9 @@ Read a CSV file and parse it into a vector of maps, where each map represents a 
 
 **See also:** [PHP Interop](/documentation/php-interop), [Data Structures](/documentation/language/data-structures)
 
-## Build a Simple CLI Tool
+## Build a simple CLI tool
 
-A command-line script that reads arguments, parses simple flags, and produces output.
+CLI script that reads args, parses flags, produces output.
 
 ```phel
 (ns cookbook\cli-tool)
@@ -101,9 +101,9 @@ A command-line script that reads arguments, parses simple flags, and produces ou
 
 **See also:** [PHP Interop](/documentation/php-interop), [Control Flow](/documentation/language/control-flow)
 
-## HTTP Request with cURL
+## HTTP request with cURL
 
-Make an HTTP GET request using the built-in `phel\http-client` module and parse a JSON response with `phel\json`.
+GET request via `phel\http-client`. Parse JSON via `phel\json`.
 
 ```phel
 (ns cookbook\http-client
@@ -157,7 +157,7 @@ Make an HTTP GET request using the built-in `phel\http-client` module and parse 
 
 ## Generate HTML
 
-Use Phel's `html` module to generate HTML markup with nested elements, attributes, and dynamic content.
+`html` module: nested elements, attributes, dynamic content.
 
 ```phel
 (ns cookbook\html-generator
@@ -221,9 +221,9 @@ Use Phel's `html` module to generate HTML markup with nested elements, attribute
 
 **See also:** [HTML Rendering](/documentation/web/html-rendering)
 
-## Working with Dates
+## Working with dates
 
-Use PHP's DateTime classes via Phel interop to create, format, and compare dates.
+PHP DateTime via interop: create, format, compare.
 
 ```phel
 (ns cookbook\dates
@@ -297,9 +297,9 @@ Use PHP's DateTime classes via Phel interop to create, format, and compare dates
 
 **See also:** [PHP Interop](/documentation/php-interop)
 
-## File System Operations
+## Filesystem operations
 
-Read files, write files, list directories, and check file existence using PHP interop.
+Read, write, list, exist checks via PHP interop.
 
 ```phel
 (ns cookbook\filesystem)
@@ -392,9 +392,9 @@ Read files, write files, list directories, and check file existence using PHP in
 
 **See also:** [PHP Interop](/documentation/php-interop)
 
-## Data Transformation Pipeline
+## Data transformation pipeline
 
-Take raw data, filter it, transform it, and group it using Phel's threading macros and collection functions.
+Filter, transform, group via threading macros and collection functions.
 
 ```phel
 (ns cookbook\data-pipeline)
@@ -464,9 +464,9 @@ Take raw data, filter it, transform it, and group it using Phel's threading macr
 
 **See also:** [Data Structures](/documentation/language/data-structures), [Control Flow](/documentation/language/control-flow)
 
-## Simple Key-Value Store
+## Simple key-value store
 
-Build a persistent key-value store backed by a JSON file, with functions for get, put, delete, and listing keys.
+Persistent KV store backed by JSON. Get, put, delete, list keys.
 
 ```phel
 (ns cookbook\kv-store
@@ -556,9 +556,9 @@ Build a persistent key-value store backed by a JSON file, with functions for get
 
 **See also:** [Data Structures](/documentation/language/data-structures), [PHP Interop](/documentation/php-interop)
 
-## Defining and Using Protocols
+## Defining and using protocols
 
-Protocols let you define polymorphic behavior that can be extended to any type -- even types you didn't create. This is similar to PHP interfaces but more flexible.
+Protocols define polymorphic behavior, extendable to any type. More flexible than PHP interfaces.
 
 ```phel
 (ns cookbook\protocols)
@@ -611,9 +611,9 @@ Protocols let you define polymorphic behavior that can be extended to any type -
 
 **See also:** [Cheat Sheet -- Protocols](/documentation/reference/cheat-sheet#protocols)
 
-## Data Processing with Transducers
+## Data processing with transducers
 
-Transducers let you compose data transformation pipelines without creating intermediate collections. They are faster and more memory-efficient than chaining `map`, `filter`, etc.
+Compose pipelines without intermediate collections. Faster, less memory than chaining `map`/`filter`.
 
 ```phel
 (ns cookbook\transducers)
@@ -680,9 +680,9 @@ Transducers let you compose data transformation pipelines without creating inter
 
 **See also:** [Cheat Sheet -- Transducers](/documentation/reference/cheat-sheet#transducers)
 
-## Reader Conditionals for Cross-Platform Code
+## Reader conditionals for cross-platform code
 
-Reader conditionals allow you to write `.cljc` files that can target different platforms. Use `:phel` for Phel-specific code and `:default` as a fallback.
+Write `.cljc` targeting multiple platforms. `:phel` for Phel-specific, `:default` as fallback.
 
 ```phel
 (ns cookbook\conditionals)
@@ -710,9 +710,9 @@ Reader conditionals allow you to write `.cljc` files that can target different p
 ;; On Phel: => [:core :macros :php-interop :composer]
 ```
 
-## Regex Matching and Validation
+## Regex matching and validation
 
-Phel provides regex literals (`#"..."`) and matching functions for working with PCRE patterns.
+Regex literals (`#"..."`) and matching functions for PCRE patterns.
 
 ```phel
 (ns cookbook\regex)
@@ -751,9 +751,9 @@ Phel provides regex literals (`#"..."`) and matching functions for working with 
 
 **See also:** [Cheat Sheet -- Regular Expressions](/documentation/reference/cheat-sheet#regular-expressions)
 
-## Structured Exceptions with ex-info
+## Structured exceptions with ex-info
 
-Use `ex-info` to create exceptions that carry structured data, making error handling more informative than plain string messages.
+`ex-info` carries structured data with exceptions. More informative than plain messages.
 
 ```phel
 (ns cookbook\exceptions
@@ -810,9 +810,9 @@ Use `ex-info` to create exceptions that carry structured data, making error hand
 
 **See also:** [Cheat Sheet -- Error Handling](/documentation/reference/cheat-sheet#error-handling)
 
-## Pattern Matching with `phel\match`
+## Pattern matching with `phel\match`
 
-The `phel\match` module provides a `match` macro with literal, vector, map, wildcard, `:as`, `:guard`, `:or`, and rest-binding patterns.
+`match` macro: literal, vector, map, wildcard, `:as`, `:guard`, `:or`, rest-binding patterns.
 
 ```phel
 (ns cookbook\match
@@ -836,7 +836,7 @@ The `phel\match` module provides a `match` macro with literal, vector, map, wild
 
 ## Schemas with `phel\schema`
 
-Validate, coerce, and generate data from declarative schemas. Kinds include `:vector`, `:set`, `:map`, `:map-of`, `:tuple`, `:enum`, `:and`, `:or`, `:maybe`, `:re`, `:fn`, `:ref`, and function schemas `[:=> args ret]`.
+Validate, coerce, generate data from declarative schemas. Kinds: `:vector`, `:set`, `:map`, `:map-of`, `:tuple`, `:enum`, `:and`, `:or`, `:maybe`, `:re`, `:fn`, `:ref`, function schemas `[:=> args ret]`.
 
 ```phel
 (ns cookbook\schema
@@ -860,6 +860,7 @@ Validate, coerce, and generate data from declarative schemas. Kinds include `:ve
 ```
 
 Instrument a function to check args/return at call sites:
+
 
 ```phel
 (defn greet [u] (str "Hi " (:name u)))

--- a/content/documentation/guides/phel-for-php-developers.md
+++ b/content/documentation/guides/phel-for-php-developers.md
@@ -4,11 +4,11 @@ weight = 1
 aliases = ["/documentation/phel-for-php-developers"]
 +++
 
-This guide maps common PHP patterns to their Phel equivalents. If you already know PHP, you can use this page as a quick reference to start writing Phel productively. Each section shows familiar PHP code alongside the idiomatic Phel way of doing the same thing.
+PHP patterns mapped to Phel. Quick reference for PHP devs. Each section: PHP code, then idiomatic Phel.
 
-## Variables and Constants
+## Variables and constants
 
-In PHP, variables are mutable by default. In Phel, bindings are immutable -- you create new values instead of changing existing ones.
+PHP variables are mutable. Phel bindings are immutable: create new values, don't change existing ones.
 
 ```php
 // PHP
@@ -38,9 +38,9 @@ function example() {
 ;; local and other do not exist outside the let block
 ```
 
-Key difference: `def` and `let` bindings are immutable. You don't modify a value -- you create a new one. See [Global and Local Bindings](/documentation/language/global-and-local-bindings) for more details.
+Key: `def` and `let` are immutable. Create a new value, don't modify. See [Global and Local Bindings](/documentation/language/global-and-local-bindings).
 
-If you need mutable state, Phel provides explicit variables:
+For mutable state, use atoms:
 
 ```phel
 (def counter (atom 0))
@@ -50,7 +50,7 @@ If you need mutable state, Phel provides explicit variables:
 
 ## Functions
 
-PHP functions map naturally to Phel's `defn`. The last expression in a Phel function is its return value -- no `return` statement needed.
+`defn` defines a function. Last expression is the return value. No `return`.
 
 ```php
 // PHP
@@ -91,20 +91,20 @@ function sum(...$numbers): int {
 (sum 1 2 3 4)    ; => 10
 ```
 
-The short anonymous function syntax `#(...)` replaces PHP's arrow functions. Use `%` for a single parameter, or `%1`, `%2`, etc. for multiple parameters:
+`#(...)` replaces PHP arrow functions. `%` for one param, `%1`, `%2` for multiple:
 
 ```phel
 #(+ %1 %2)          ; Same as fn($a, $b) => $a + $b
 #(str "Hi " %)      ; Same as fn($x) => "Hi " . $x
 ```
 
-See [Functions and Recursion](/documentation/language/functions-and-recursion) for the full reference.
+Full reference: [Functions and Recursion](/documentation/language/functions-and-recursion).
 
-## Arrays to Vectors and Maps
+## Arrays to vectors and maps
 
-PHP uses a single `array` type for both indexed and associative arrays. Phel separates these into distinct immutable data structures.
+PHP arrays are both indexed and associative. Phel splits these into distinct immutable data structures.
 
-### Indexed arrays become vectors
+### Indexed arrays, vectors
 
 ```php
 // PHP
@@ -121,7 +121,7 @@ $first = $numbers[0];         // Access by index
 (first numbers)                 ; => 1
 ```
 
-### Associative arrays become maps
+### Associative arrays, maps
 
 ```php
 // PHP
@@ -152,9 +152,9 @@ unset($user['age']);                     // Remove key
 | `in_array($v, $arr)` | `(some #(= % v) coll)` | |
 | `array_key_exists` | `(contains? map :k)` | |
 
-The critical difference: all operations return **new** collections. The original is never modified. See [Data Structures](/documentation/language/data-structures) for the full reference.
+All operations return **new** collections. Originals never change. See [Data Structures](/documentation/language/data-structures).
 
-## Control Flow
+## Control flow
 
 ### if / else
 
@@ -189,9 +189,9 @@ if ($debug) {
   (log "enabled"))
 ```
 
-`when` returns `nil` when the condition is false. Use it for side-effects or when you do not need an else branch.
+`when` returns `nil` if condition is false. For side-effects or no else.
 
-### switch becomes case
+### switch, case
 
 ```php
 // PHP
@@ -210,7 +210,7 @@ switch ($code) {
     404 "Not Found"))  ; Returns nil if no match
 ```
 
-### match becomes cond
+### match, cond
 
 ```php
 // PHP
@@ -234,7 +234,7 @@ $label = match(true) {
 
 ### Truthiness difference
 
-This is a common gotcha for PHP developers:
+Common PHP-dev gotcha:
 
 ```php
 // PHP falsy values: false, null, 0, "", "0", [], 0.0
@@ -250,11 +250,11 @@ if ([]) { /* NOT reached */ }
 (if [] "truthy" "falsy")   ; => "truthy"
 ```
 
-See [Control Flow](/documentation/language/control-flow) and [Truth and Boolean Operations](/documentation/language/truth-and-boolean-operations) for more.
+See [Control Flow](/documentation/language/control-flow), [Truth and Boolean Operations](/documentation/language/truth-and-boolean-operations).
 
 ## Loops
 
-Phel favors higher-order functions over explicit loops. Most PHP loops translate into `map`, `filter`, or `reduce`.
+Phel prefers higher-order functions. Most PHP loops become `map`, `filter`, `reduce`.
 
 ### foreach
 
@@ -316,7 +316,7 @@ $sum = array_reduce($numbers, fn($carry, $x) => $carry + $x, 0);
 (def sum (reduce + 0 numbers))
 ```
 
-Notice how Phel's argument order differs from PHP: the function comes before the collection. This makes composition and threading natural.
+Phel's arg order: function first, collection last. Makes composition and threading natural.
 
 ## Strings
 
@@ -338,11 +338,11 @@ $contains = str_contains($haystack, $needle);
 (def contains (php/str_contains haystack needle))
 ```
 
-Any PHP string function can be called with the `php/` prefix. Phel provides `str` for concatenation and `format` for sprintf-style formatting. See [PHP Interop](/documentation/php-interop) for the full interop reference.
+Any PHP string function via `php/` prefix. `str` concatenates, `format` for sprintf-style. See [PHP Interop](/documentation/php-interop).
 
-## Classes and Objects
+## Classes and objects
 
-Phel is not object-oriented, but it provides full interop with PHP's object system.
+Phel isn't OO, but has full interop with PHP's object system.
 
 ### Creating objects
 
@@ -403,7 +403,7 @@ $parsed = DateTimeImmutable::createFromFormat('Y-m-d', '2024-03-22');
 (def parsed (php/:: DateTimeImmutable (createFromFormat "Y-m-d" "2024-03-22")))
 ```
 
-For data modeling, Phel uses structs and maps instead of classes:
+For data modeling, Phel uses structs and maps:
 
 ```phel
 (defstruct user [name email role])
@@ -413,11 +413,11 @@ For data modeling, Phel uses structs and maps instead of classes:
 (assoc alice :role :editor)  ; => new struct with role changed
 ```
 
-See [PHP Interop](/documentation/php-interop) for the complete reference.
+See [PHP Interop](/documentation/php-interop) for the full reference.
 
-## Protocols vs PHP Interfaces
+## Protocols vs PHP interfaces
 
-PHP interfaces define contracts that classes must implement at class definition time. Phel protocols are similar in purpose but more flexible -- you can extend a protocol to a type **after** it was defined, without touching the original code.
+PHP interfaces require implementation at class definition. Phel protocols extend to types **after** they're defined, without modifying the original code.
 
 ```php
 // PHP -- interface must be declared at class definition
@@ -468,11 +468,11 @@ class Order implements Loggable {
 (satisfies? Loggable (order 1 0)) ; => true
 ```
 
-The key advantage: you can make **any** type satisfy a protocol at any time, even types from external libraries. In PHP, you would need a wrapper class, an adapter, or inheritance.
+Advantage: any type can satisfy a protocol at any time, even external library types. PHP would need a wrapper, adapter, or inheritance.
 
-## Regex: Literals vs preg_match
+## Regex: literals vs preg_match
 
-PHP uses `preg_match` with pattern strings. Phel provides regex literals (`#"..."`) and dedicated matching functions.
+PHP uses `preg_match` with pattern strings. Phel has regex literals (`#"..."`) and matching functions.
 
 ```php
 // PHP
@@ -505,9 +505,9 @@ preg_match_all('/\d+/', 'a1b2c3', $all);
 (re-find #"\d+" "abc123def")       ; => "123"
 ```
 
-`re-matches` requires the entire string to match (like wrapping PHP's pattern with `^...$`). `re-find` returns the first match anywhere in the string (like `preg_match` without anchors).
+`re-matches` requires full-string match (like wrapping with `^...$`). `re-find` returns first match anywhere (like `preg_match` without anchors).
 
-## Error Handling
+## Error handling
 
 ```php
 // PHP
@@ -539,11 +539,11 @@ throw new RuntimeException("Something went wrong");
 (throw (php/new \RuntimeException "Something went wrong"))
 ```
 
-The structure is similar to PHP's try/catch but expressed as a single form. See the exceptions section in [Control Flow](/documentation/language/control-flow) for more details.
+Single form, similar structure to PHP try/catch. See [Control Flow](/documentation/language/control-flow) exceptions section.
 
 ### Structured exceptions with ex-info
 
-PHP exceptions carry a string message, an integer code, and an optional previous exception. Phel's `ex-info` adds a **data map**, making exceptions much more informative without creating custom exception classes.
+PHP exceptions: message string, integer code, optional previous. Phel's `ex-info` adds a **data map**: more informative without custom exception classes.
 
 ```php
 // PHP -- custom exception to carry context
@@ -575,11 +575,11 @@ try {
     (println (ex-cause e))))       ; => nil
 ```
 
-With `ex-info` you get structured context attached to any exception without defining new classes. Use `ex-message`, `ex-data`, and `ex-cause` to inspect the exception.
+`ex-info` attaches context without new classes. `ex-message`, `ex-data`, `ex-cause` inspect.
 
-## Common Patterns
+## Common patterns
 
-Here are practical examples of real PHP code converted to idiomatic Phel.
+Real PHP converted to idiomatic Phel.
 
 ### Processing a list of users
 
@@ -681,9 +681,9 @@ $dbPort = $config['database']['port'] ?? 3306;
 (def db-port (or (php/aget-in config ["database" "port"]) 3306))
 ```
 
-## Transducers vs Array Pipelines
+## Transducers vs array pipelines
 
-PHP developers often chain `array_filter`, `array_map`, and `array_reduce` to process data. Each step creates a new intermediate array. Phel's transducers compose these operations into a single pass with no intermediate collections.
+Chaining `array_filter`, `array_map`, `array_reduce` creates intermediate arrays per step. Transducers compose into a single pass, no intermediate collections.
 
 ```php
 // PHP -- each step creates a new array
@@ -720,9 +720,9 @@ $result = array_reduce(
 
 | Approach | When to use |
 |----------|-------------|
-| `->>` threading | Most of the time -- readable, uses lazy seqs, good enough for typical data |
-| `transduce` | Performance-critical paths, very large collections, or when you want to reuse a transformation |
-| `into` with xf | When you want the transducer result as a specific collection type |
+| `->>` threading | Default. Readable, lazy seqs, good for typical data |
+| `transduce` | Hot paths, large collections, or reusable transforms |
+| `into` with xf | Want a specific collection type as result |
 
 ```phel
 ; Reusable transducer: define once, apply to any data source
@@ -738,17 +738,17 @@ $result = array_reduce(
 (transduce process-events str "" log-stream-c)
 ```
 
-Transducers are especially useful when the same transformation needs to be applied to different data sources (vectors, lazy sequences, channels, etc.) since they are decoupled from the input/output type.
+Transducers shine when the same transform applies to different sources (vectors, lazy seqs, channels). Decoupled from input/output type.
 
-## Key Mindset Shifts
+## Key mindset shifts
 
-Moving from PHP to Phel involves a few conceptual shifts:
+PHP to Phel:
 
-- **Data is immutable** -- you do not modify data in place, you transform it into new values. The original is always preserved.
-- **Functions are values** -- pass them as arguments, return them from other functions, store them in collections.
-- **Prefix notation** -- the operator always comes first: `(+ 1 2)` not `1 + 2`. This is consistent for everything, including function calls.
-- **No return statement** -- the last expression in a function body is its return value.
-- **No semicolons, no curly braces** -- just parentheses. Indentation conveys structure visually; parentheses convey it to the compiler.
-- **Truthiness** -- only `false` and `nil` are falsy. `0`, `""`, and `[]` are all truthy. This catches many PHP developers off guard at first.
-- **Everything is an expression** -- `if`, `let`, `case`, and `cond` all return values. There are no statements.
-- **Thread-last (`->>`) replaces method chaining** -- instead of `$arr->filter()->map()->sort()`, use `(->> coll (filter pred) (map f) (sort))`.
+- **Immutable data:** transform to new values, originals stay intact.
+- **Functions are values:** pass them, return them, store them.
+- **Prefix notation:** operator first. `(+ 1 2)` not `1 + 2`. Consistent across all calls.
+- **No return:** last expression is the return value.
+- **No semicolons or braces:** just parens. Indentation for humans, parens for the compiler.
+- **Truthiness:** only `false` and `nil` falsy. `0`, `""`, `[]` truthy. Catches PHP devs off guard.
+- **Everything is an expression:** `if`, `let`, `case`, `cond` all return values. No statements.
+- **Thread-last (`->>`) replaces method chaining:** instead of `$arr->filter()->map()->sort()`, write `(->> coll (filter pred) (map f) (sort))`.

--- a/content/documentation/installation.md
+++ b/content/documentation/installation.md
@@ -3,24 +3,24 @@ title = "Installation"
 weight = 2
 +++
 
-Phel requires **PHP 8.4+**. Pick the install method that matches how you want to work.
+Requires **PHP 8.4+**. Pick the method matching your workflow.
 
-## Which Method Should I Use?
+## Which method?
 
 | Goal                                        | Use                                                  |
 | ------------------------------------------- | ---------------------------------------------------- |
-| Start a new project with tests + scripts    | [**Composer skeleton**](#new-project-from-skeleton)  |
-| Add Phel to an existing Composer project    | [**Composer require**](#add-to-an-existing-project)  |
-| Run a single file or play around (no setup) | [**PHAR**](#phar-no-project-setup)                   |
-| **No PHP installed** (just Docker)          | [**Docker**](#docker-no-php-required)                |
-| Reproducible dev shells across machines     | [**Nix**](#nix)                                      |
-| Just looking for the fastest path           | [Getting Started](/documentation/getting-started) →  |
+| New project with tests + scripts            | [**Composer skeleton**](#new-project-from-skeleton)  |
+| Add to existing Composer project            | [**Composer require**](#add-to-an-existing-project)  |
+| Run a single file, no setup                 | [**PHAR**](#phar-no-project-setup)                   |
+| **No PHP installed** (Docker only)          | [**Docker**](#docker-no-php-required)                |
+| Reproducible dev shells                     | [**Nix**](#nix)                                      |
+| Fastest path                                | [Getting Started](/documentation/getting-started) →  |
 
-## Composer (Recommended)
+## Composer (recommended)
 
 ### New project from skeleton
 
-The skeleton comes with tests, build config, and ready-to-use `composer` scripts (`repl`, `dev`, `test`, `build`, `format`).
+Ships with tests, build config, ready-to-use `composer` scripts (`repl`, `dev`, `test`, `build`, `format`).
 
 ```bash
 composer create-project --stability dev phel-lang/cli-skeleton example-app
@@ -35,7 +35,7 @@ composer require phel-lang/phel-lang
 vendor/bin/phel init my-app    # scaffold phel-config.php + src/
 ```
 
-All commands are then available via `vendor/bin/phel <cmd>` (for example `vendor/bin/phel repl`).
+All commands then via `vendor/bin/phel <cmd>` (e.g. `vendor/bin/phel repl`).
 
 <details class="dev-note dev-note--php">
 <summary>
@@ -45,21 +45,21 @@ All commands are then available via `vendor/bin/phel <cmd>` (for example `vendor
 </summary>
 <div class="dev-note__content">
 
-No. Phel lives alongside your PHP code. You can `require 'vendor/autoload.php'` and call compiled Phel namespaces from PHP, or call PHP classes from Phel. Add it to any Composer project (Laravel, Symfony, WordPress plugin, framework-less) and use it where Lisp is a better fit.
+No. Phel lives alongside PHP. `require 'vendor/autoload.php'` and call compiled Phel namespaces from PHP, or call PHP from Phel. Drop into any Composer project (Laravel, Symfony, WordPress plugin) and use where Lisp fits better.
 
 </div>
 </details>
 
-## PHAR (No Project Setup)
+## PHAR (no project setup)
 
-Run Phel without Composer. Good for quick experiments, CI one-shots, or when you just want to try the language.
+Run without Composer. Good for quick experiments, CI one-shots, trying the language.
 
 ```bash
 curl -L https://phel-lang.org/phar -o phel.phar
 php phel.phar --version
 ```
 
-Every command works the same way:
+Every command works the same:
 
 ```bash
 php phel.phar repl
@@ -75,33 +75,33 @@ sudo mv phel.phar /usr/local/bin/phel
 phel repl
 ```
 
-## Docker (No PHP Required)
+## Docker (no PHP required)
 
-Don't have PHP installed (or don't want to)? If you have Docker, you can run Phel in one command.
+No PHP installed? With Docker, run Phel in one command.
 
 ### Zero-setup REPL
 
-Paste this and you are in a live Phel REPL. No files, no install. Just Docker.
+Paste and you're in a live Phel REPL. No files, no install:
 
 ```bash
 docker run --rm -it php:8.4-cli sh -c \
   "curl -sL https://phel-lang.org/phar -o /tmp/phel.phar && php /tmp/phel.phar repl"
 ```
 
-The container downloads the PHAR fresh each run. Fine for experimenting, wasteful for daily use (see below).
+Container downloads PHAR fresh each run. Fine for experimenting, wasteful for daily use (see below).
 
 ### Run a Phel file from your host
 
-Mount the current directory and run any Phel script:
+Mount cwd, run any Phel script:
 
 ```bash
 docker run --rm -it -v "$PWD":/app -w /app php:8.4-cli sh -c \
   "curl -sL https://phel-lang.org/phar -o /tmp/phel.phar && php /tmp/phel.phar run src/main.phel"
 ```
 
-### Persistent: a `phel` alias backed by Docker
+### Persistent `phel` alias backed by Docker
 
-Download the PHAR once, then make `phel` feel native:
+Download PHAR once, make `phel` feel native:
 
 ```bash
 curl -L https://phel-lang.org/phar -o phel.phar
@@ -114,9 +114,9 @@ phel run src/main.phel
 phel test
 ```
 
-### Create a Composer project with no local PHP
+### Composer project with no local PHP
 
-Use the official `composer` image (ships with PHP + Composer):
+Use official `composer` image (ships PHP + Composer):
 
 ```bash
 docker run --rm -it -v "$PWD":/app -w /app composer \
@@ -128,7 +128,7 @@ cd example-app
 docker run --rm -it -v "$PWD":/app -w /app -p 2345:2345 composer composer repl
 ```
 
-Make it an alias for daily use:
+Alias for daily use:
 
 ```bash
 alias dcomposer='docker run --rm -it -v "$PWD":/app -w /app composer'
@@ -137,13 +137,13 @@ dcomposer composer test
 dcomposer composer dev
 ```
 
-> The `-p 2345:2345` exposes the default nREPL port if you want editor integration from your host. Omit it if you don't need it.
+> `-p 2345:2345` exposes default nREPL port for host editor integration. Omit if not needed.
 
 ## Nix
 
-For reproducible dev environments. Phel is packaged in nixpkgs: see [phel on search.nixos.org](https://search.nixos.org/packages?channel=unstable&show=phel) or the [package source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ph/phel/package.nix).
+Reproducible dev environments. Phel is in nixpkgs: see [phel on search.nixos.org](https://search.nixos.org/packages?channel=unstable&show=phel) or the [package source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ph/phel/package.nix).
 
-If you don't have Nix yet, install via the [Determinate Systems installer](https://determinate.systems/nix-installer/) or the [official installer](https://nixos.org/download).
+No Nix yet? Install via [Determinate Systems installer](https://determinate.systems/nix-installer/) or [official installer](https://nixos.org/download).
 
 ### Ad-hoc shell
 
@@ -152,11 +152,11 @@ nix shell nixpkgs#phel
 phel repl
 ```
 
-> Nixpkgs can lag behind the latest release. Check with `nix eval nixpkgs#phel.version`. If you need the newest version, use Composer or the PHAR.
+> Nixpkgs may lag latest. Check `nix eval nixpkgs#phel.version`. For newest, use Composer or PHAR.
 
 ### Project `shell.nix`
 
-Pin PHP + Composer for the whole team:
+Pin PHP + Composer for the team:
 
 ```nix
 { pkgs ? import <nixpkgs> { } }:
@@ -171,17 +171,17 @@ pkgs.mkShell {
 
 Then `nix-shell` and use Composer as normal.
 
-## Verify Your Install
+## Verify install
 
-Whichever method you picked, run the doctor:
+Run the doctor:
 
 ```bash
-vendor/bin/phel doctor    # Composer install
-php phel.phar doctor      # PHAR
-phel doctor               # Nix / global
+vendor/bin/phel doctor    ; Composer
+php phel.phar doctor      ; PHAR
+phel doctor               ; Nix / global
 ```
 
-It checks PHP extensions (`json`, `mbstring`, `readline`), writable cache directory, and source layout. If anything is missing, it tells you exactly what to install.
+Checks PHP extensions (`json`, `mbstring`, `readline`), writable cache dir, source layout. Tells you exactly what's missing.
 
 <details class="dev-note dev-note--clojure">
 <summary>
@@ -191,7 +191,7 @@ It checks PHP extensions (`json`, `mbstring`, `readline`), writable cache direct
 </summary>
 <div class="dev-note__content">
 
-Rough mapping for folks coming from `lein`/`deps.edn`:
+Mapping from `lein`/`deps.edn`:
 
 | Clojure                       | Phel                                |
 | ----------------------------- | ----------------------------------- |
@@ -202,14 +202,14 @@ Rough mapping for folks coming from `lein`/`deps.edn`:
 | `uberjar`                     | `phel build` (compiles to PHP)     |
 | nREPL                         | `phel nrepl` (bencode over TCP)    |
 
-Editor integration works the same way you're used to: nREPL + LSP. See [Editor Support](/documentation/tooling/editor-support).
+Editor integration: nREPL + LSP. See [Editor Support](/documentation/tooling/editor-support).
 
 </div>
 </details>
 
-## Next Steps
+## Next steps
 
-- [Getting Started](/documentation/getting-started): first REPL session and project tour.
+- [Getting Started](/documentation/getting-started): first REPL session, project tour.
 - [Editor Support](/documentation/tooling/editor-support): Emacs, VS Code, IntelliJ, Vim.
 - [CLI Commands](/documentation/tooling/cli-commands): every subcommand.
 - [Configuration](/documentation/configuration): `phel-config.php` options.

--- a/content/documentation/language/_index.md
+++ b/content/documentation/language/_index.md
@@ -9,6 +9,6 @@ template = "section-page.html"
 insert_after = "Why Phel?"
 +++
 
-Phel is a functional Lisp that compiles to PHP. This section covers the core language features - from basic types and arithmetic through to macros and interfaces.
+Functional Lisp that compiles to PHP. Core language features: basic types, arithmetic, macros, interfaces.
 
-Work through these pages in order for a guided introduction, or jump to any topic as a reference.
+Read in order, or jump to any topic.

--- a/content/documentation/language/arithmetic.md
+++ b/content/documentation/language/arithmetic.md
@@ -4,17 +4,17 @@ weight = 2
 aliases = ["/documentation/arithmetic"]
 +++
 
-## Arithmetic Operators
+## Arithmetic operators
 
-All arithmetic operators are entered in prefix notation.
+Prefix notation:
 
 ```phel
-;; (1 + (2*2) + (10/5) + 3 + 4 + (5 - 6))
-(+ 1 (* 2 2) (/ 10 5) 3 4 (- 5 6)) ; Evaluates to 13
+;; 1 + (2*2) + (10/5) + 3 + 4 + (5 - 6)
+(+ 1 (* 2 2) (/ 10 5) 3 4 (- 5 6)) ; => 13
 ```
 
 {% php_note() %}
-Phel uses prefix notation (operator comes first) instead of PHP's infix notation:
+Prefix notation (operator first) instead of PHP's infix:
 
 ```php
 // PHP - infix notation
@@ -24,33 +24,33 @@ Phel uses prefix notation (operator comes first) instead of PHP's infix notation
 (+ 1 (* 2 2) (/ 10 5) 3 4 (- 5 6))
 ```
 
-This allows operators to accept any number of arguments and eliminates operator precedence concerns.
+Operators take any number of args, no precedence concerns.
 {% end %}
 
-Some operators support zero, one or multiple arguments.
+Operators take zero, one, or many args:
 
 ```phel
-(+) ; Evaluates to 0
-(+ 1) ; Evaluates to 1
-(+ 1 2) ; Evaluates to 3
-(+ 1 2 3 4 5 6 7 8 9) ; Evaluates to 45
+(+) ; => 0
+(+ 1) ; => 1
+(+ 1 2) ; => 3
+(+ 1 2 3 4 5 6 7 8 9) ; => 45
 
-(-) ; Evaluates to 0
-(- 1) ; Evaluates to -1
-(- 2 1) ; Evaluates to 1
-(- 3 2 1) ; Evaluates to 0
+(-) ; => 0
+(- 1) ; => -1
+(- 2 1) ; => 1
+(- 3 2 1) ; => 0
 
-(*) ; Evaluates to 1
-(* 2) ; Evaluates to 2
-(* 2 3 4) ; Evaluates to 24
+(*) ; => 1
+(* 2) ; => 2
+(* 2 3 4) ; => 24
 
-(/) ; Evaluates to 1
-(/ 2) ; Evaluates to 0.5 (reciprocal of 2)
-(/ 24 4 2) ; Evaluates to 3
+(/) ; => 1
+(/ 2) ; => 0.5 (reciprocal)
+(/ 24 4 2) ; => 3
 ```
 
 {% php_note() %}
-Phel's variadic operators are more flexible than PHP's:
+Variadic operators more flexible than PHP:
 
 ```php
 // PHP - requires at least two operands
@@ -63,16 +63,16 @@ Phel's variadic operators are more flexible than PHP's:
 (+ 1 2 3 4 5)          ; 15 (sum of all)
 ```
 
-**Useful patterns:**
-- `(+)` returns the additive identity (0)
-- `(*)` returns the multiplicative identity (1)
-- `(- x)` negates a number
-- `(/ x)` computes the reciprocal
+**Patterns:**
+- `(+)` additive identity (0)
+- `(*)` multiplicative identity (1)
+- `(- x)` negate
+- `(/ x)` reciprocal
 {% end %}
 
-Further numeric operations are `%` to compute the remainder of two values and `**` to raise a number to the power. All numeric operations can be found in the API documentation.
+Other numerics: `%` (remainder), `**` (power). Full list in the API docs.
 
-Some numeric operations can result in an undefined or unrepresentable value. These values are called _Not a Number_ (NaN). Phel represents these values by the constant `NAN`. You can check if a result is NaN by using the `nan?` function.
+Some operations yield NaN. Phel uses `NAN` constant. Check with `nan?`:
 
 ```phel
 (nan? 1) ; false
@@ -81,7 +81,7 @@ Some numeric operations can result in an undefined or unrepresentable value. The
 ```
 
 {% php_note() %}
-NaN handling is similar to PHP:
+NaN handling matches PHP:
 
 ```php
 // PHP
@@ -95,12 +95,12 @@ is_nan(NAN);         // true
 (nan? NAN)           ; true
 ```
 
-The `%` operator for remainder and `**` for exponentiation work like PHP's `%` and `**` operators.
+`%` remainder and `**` exponent match PHP's.
 {% end %}
 
-## Bitwise Operators
+## Bitwise operators
 
-Phel allows the evaluation and manipulation of specific bits within an integer.
+Manipulate bits in integers.
 
 ```phel
 ;; Bitwise and
@@ -136,7 +136,7 @@ Phel allows the evaluation and manipulation of specific bits within an integer.
 ```
 
 {% php_note() %}
-Phel provides named functions for bitwise operations instead of PHP's operators:
+Named functions instead of PHP operators:
 
 ```php
 // PHP bitwise operators
@@ -156,5 +156,5 @@ Phel provides named functions for bitwise operations instead of PHP's operators:
 (bit-shift-right 0b1101 1)
 ```
 
-Phel also provides additional bit manipulation functions not available in PHP: `bit-set`, `bit-clear`, `bit-flip`, and `bit-test`.
+Adds extra functions not in PHP: `bit-set`, `bit-clear`, `bit-flip`, `bit-test`.
 {% end %}

--- a/content/documentation/language/basic-types.md
+++ b/content/documentation/language/basic-types.md
@@ -4,9 +4,9 @@ weight = 1
 aliases = ["/documentation/basic-types"]
 +++
 
-## Nil, True, False
+## Nil, true, false
 
-Nil, true and false are literal constants.
+Literal constants:
 
 ```phel
 nil
@@ -14,7 +14,7 @@ true
 false
 ```
 
-In Phel, only `false` and `nil` are falsy. Everything else is truthy-including `0`, `""`, and `[]`.
+Only `false` and `nil` are falsy. `0`, `""`, `[]` truthy.
 
 ```phel
 ;; Truthiness examples
@@ -26,17 +26,17 @@ In Phel, only `false` and `nil` are falsy. Everything else is truthy-including `
 ```
 
 {% php_note() %}
-In PHP, `nil` is the same as `null`, and `true`/`false` are the same. However, truthiness works differently:
+`nil` = PHP `null`. `true`/`false` same. But truthiness differs:
 
-**PHP**: `0`, `""`, `[]`, `null`, and `false` are all falsy
-**Phel**: Only `false` and `nil` are falsy
+**PHP**: `0`, `""`, `[]`, `null`, `false` falsy.
+**Phel**: only `false`, `nil` falsy.
 
-This means `if (0)` in PHP is false, but `(if 0 ...)` in Phel is true!
+`if (0)` in PHP is false, but `(if 0 ...)` in Phel is true.
 {% end %}
 
 ## Symbol
 
-Symbols are used to name functions and variables in Phel.
+Names functions and variables:
 
 ```phel
 symbol
@@ -47,7 +47,7 @@ my-module/my-function
 
 ## Keywords
 
-A keyword is like a symbol that begins with a colon character. However, it is used as a constant rather than a name for something. Keywords are interned and fast for equality checks.
+Like a symbol but starts with `:`. Used as a constant. Interned, fast equality.
 
 ```phel
 :keyword
@@ -57,7 +57,7 @@ A keyword is like a symbol that begins with a colon character. However, it is us
 ::
 ```
 
-Keywords are commonly used as map keys:
+Common as map keys:
 
 ```phel
 ;; Map with keyword keys
@@ -69,7 +69,7 @@ Keywords are commonly used as map keys:
 ```
 
 {% php_note() %}
-Keywords are like string constants, but more efficient for map keys. Use keywords instead of strings for map keys:
+Like string constants, more efficient as map keys. Prefer over strings:
 
 ```phel
 ; Less idiomatic:
@@ -79,12 +79,12 @@ Keywords are like string constants, but more efficient for map keys. Use keyword
 {:name "Alice" :age 30}
 ```
 
-Keywords are interned (only one instance exists in memory), making equality checks very fast.
+Interned: one instance in memory, fast equality.
 {% end %}
 
 ## Numbers
 
-Phel supports integers and floating-point numbers. Both use the underlying PHP implementation. Integers can be specified in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2) notations. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
+Integers and floats use PHP's implementation. Integers in decimal, hex, octal, binary. Binary/octal/hex may use `_` separators.
 
 ```phel
 1337 ; integer
@@ -115,7 +115,7 @@ Phel supports integers and floating-point numbers. Both use the underlying PHP i
 
 ## Strings
 
-Strings are surrounded by double quotes. The dollar sign (`$`) does not need to be escaped.
+Double-quoted. `$` doesn't need escaping.
 
 ```phel
 "hello world"
@@ -136,14 +136,14 @@ string."
 "Unicodes can be encoded: \u{1000}"
 ```
 
-String concatenation and conversion using `str`:
+Concat and convert with `str`:
 
 ```phel
 (str "Hello" " " "World")  ; => "Hello World"
 (str "The answer is " 42)  ; => "The answer is 42"
 ```
 
-Strings are iterable - they work directly with sequence functions like `map`, `filter`, `count`, `frequencies`, and `foreach`. Full UTF-8 / multibyte support is included:
+Strings are iterable: work with `map`, `filter`, `count`, `frequencies`, `foreach`. Full UTF-8 / multibyte support:
 
 ```phel
 (count "hello")             ; => 5
@@ -152,7 +152,7 @@ Strings are iterable - they work directly with sequence functions like `map`, `f
 ```
 
 {% php_note() %}
-Phel strings are PHP strings internally, so you can use all PHP string functions:
+PHP strings internally. All PHP string functions work:
 
 ```phel
 (php/strlen "hello")                 ; => 5
@@ -160,18 +160,18 @@ Phel strings are PHP strings internally, so you can use all PHP string functions
 (php/str_replace "o" "0" "hello")    ; => "hell0"
 ```
 
-Strings work almost the same as PHP double-quoted strings, with one difference: the dollar sign (`$`) doesn't need escaping.
+Same as PHP double-quoted strings, except `$` doesn't need escaping.
 {% end %}
 
 ## Lists
 
-A list is a sequence of whitespace-separated values surrounded by parentheses.
+Whitespace-separated values in parentheses:
 
 ```phel
 (do 1 2 3)
 ```
 
-A list will be interpreted as a function call, a macro call or a special form by the compiler. A list prefixed with a single quote will be interpreted as data.
+Lists are function/macro/special-form calls. Quoted lists are data:
 
 ```phel
 '(1 2 3)
@@ -179,17 +179,17 @@ A list will be interpreted as a function call, a macro call or a special form by
 
 ## Vectors
 
-A vector is a sequence of whitespace-separated values surrounded by brackets.
+Whitespace-separated values in brackets:
 
 ```phel
 [1 2 3] ; same as (vector 1 2 3)
 ```
 
-A vector in Phel is an indexed data structure. In contrast to PHP arrays, Phel vectors cannot be used as maps, hashtables or dictionaries.
+Indexed data structure. Unlike PHP arrays, vectors are not maps/hashtables.
 
 ## Maps
 
-A map is a sequence of whitespace-separated key/value pairs surrounded by curly braces. The sequence is defined as key1, value1, key2, value2, etc. There must be an even number of items.
+Whitespace-separated key/value pairs in braces. Even count: key1, value1, key2, value2.
 
 ```phel
 {} ; same as (hash-map)
@@ -206,9 +206,9 @@ A map is a sequence of whitespace-separated key/value pairs surrounded by curly 
 
 {% php_note() %}
 Unlike PHP associative arrays, Phel maps:
-- Can have **any type** as keys (not just strings/integers): vectors, lists, or even other maps
-- Are **immutable**: operations return new maps without modifying the original
-- Are **not** PHP arrays internally-they're their own data structure
+- **Any type** as keys: vectors, lists, other maps
+- **Immutable**: operations return new maps
+- **Not** PHP arrays internally
 
 ```phel
 ; PHP:
@@ -224,7 +224,7 @@ $map['name'] = 'Bob';  // Mutates in place
 
 ## Sets
 
-A set is a sequence of whitespace-separated values prefixed by `#` and surrounded by curly braces, or built from individual arguments with `hash-set`:
+Whitespace-separated values in `#{}`, or built with `hash-set`:
 
 ```phel
 #{1 2 3}         ; set literal
@@ -234,7 +234,7 @@ A set is a sequence of whitespace-separated values prefixed by `#` and surrounde
 
 ## Tagged literals
 
-Phel supports reader tags for common values:
+Reader tags for common values:
 
 ```phel
 #inst "2026-04-20T12:00:00Z"      ; => \DateTimeImmutable
@@ -244,7 +244,7 @@ Phel supports reader tags for common values:
 
 ### Custom tags
 
-Register user tags in Phel with `register-tag`:
+Register with `register-tag`:
 
 ```phel
 (ns my-app\readers
@@ -254,28 +254,28 @@ Register user tags in Phel with `register-tag`:
                         {:amount amount :currency currency}))
 ```
 
-Then in any source file:
+In any source file:
 
 ```phel
 #money [100 "EUR"]   ; => {:amount 100 :currency "EUR"}
 ```
 
-A `data-readers.phel` file at any source root is auto-loaded, so you can ship tag definitions with your library.
+A `data-readers.phel` at any source root auto-loads. Ship tag definitions with your library.
 
 ## PHP reader literals
 
-Produce native PHP arrays inline without calling `php/array`:
+Native PHP arrays inline without `php/array`:
 
 ```phel
 #php [1 2 3]          ; expands to (php-indexed-array 1 2 3)
 #php {"a" 1 "b" 2}    ; expands to (php-associative-array "a" 1 "b" 2)
 ```
 
-Expansion is non-recursive, nested Phel forms stay Phel data.
+Non-recursive expansion. Nested Phel forms stay Phel data.
 
-## Regex Literals
+## Regex literals
 
-Phel supports regex literal syntax using `#"..."` as reader sugar for PCRE patterns. This is a convenient shorthand for creating regular expressions:
+`#"..."` is reader sugar for PCRE patterns:
 
 ```phel
 #"\d+"           ; Matches one or more digits
@@ -283,7 +283,7 @@ Phel supports regex literal syntax using `#"..."` as reader sugar for PCRE patte
 #"hello\s+world" ; Matches "hello" followed by whitespace and "world"
 ```
 
-Regex literals can be used with the `re-find` and `re-matches` functions:
+Use with `re-find` and `re-matches`:
 
 ```phel
 (re-find #"\d+" "abc123def")     ; => "123"
@@ -298,12 +298,12 @@ Regex literals can be used with the `re-find` and `re-matches` functions:
 ```
 
 {% clojure_note() %}
-Regex literals use the same `#"..."` syntax as Clojure. The underlying engine is PHP's PCRE rather than Java's regex, so some pattern details may differ.
+Same `#"..."` syntax as Clojure. Engine is PHP PCRE, not Java regex, so some details differ.
 {% end %}
 
-## Anonymous Function Shorthand
+## Anonymous function shorthand
 
-The `#(...)` reader syntax provides a compact way to define anonymous functions inline, using `%` placeholders for parameters:
+`#(...)` defines anonymous functions inline. `%` placeholders:
 
 - `%` or `%1` refers to the first argument
 - `%2`, `%3`, etc. refer to subsequent arguments
@@ -320,11 +320,11 @@ The `#(...)` reader syntax provides a compact way to define anonymous functions 
 (sort-by #(get % :age) users)  ; Sort users by age
 ```
 
-> **Note:** The older `|(...)` short-form syntax with `$` placeholders is also accepted but deprecated. See [Functions and Recursion](/documentation/language/functions-and-recursion/) for details.
+> **Note:** Older `|(...)` form with `$` placeholders is deprecated. See [Functions and Recursion](/documentation/language/functions-and-recursion/).
 
-## Deref Shorthand
+## Deref shorthand
 
-The `@` reader syntax is shorthand for `(deref ...)`. It is used to dereference atoms and other reference types:
+`@` is shorthand for `(deref ...)`. Dereferences atoms and other reference types:
 
 ```phel
 (def counter (atom 0))
@@ -336,16 +336,16 @@ The `@` reader syntax is shorthand for `(deref ...)`. It is used to dereference 
 
 ## Comments
 
-A comment begins with a `;` character and continues until the end of the line. Use `;;` for standalone comments and `;` for inline comments:
+`;` runs to end of line. `;;` for standalone, `;` for inline:
 
 ```phel
 ;; This is a standalone comment
 (+ 1 2) ; This is an inline comment
 ```
 
-> **Deprecation notice:** The `#` line comment syntax and `#| ... |#` multiline comment syntax are deprecated. Use `;` and `;;` instead. The `#` prefix is now reserved for reader macros like `#()`, `#""`, and `#?()`.
+> **Deprecation:** `#` line and `#| ... |#` multiline comments are deprecated. Use `;` and `;;`. `#` prefix is reserved for reader macros (`#()`, `#""`, `#?()`).
 
-Phel also supports inline s-expression commenting with `#_` which comments out the next form. It can also be stacked to comment out two or more forms after it.
+`#_` comments out the next form. Stack to comment multiple forms:
 
 ```phel
 [:one :two :three]     ; results to [:one :two :three]
@@ -354,4 +354,4 @@ Phel also supports inline s-expression commenting with `#_` which comments out t
 [#_#_:one :two :three] ; results to [:three]
 ```
 
-See also the [comment](/documentation/reference/api/#comment) macro which ignores the forms inside and returns `nil` while still requiring the content to be valid Phel code.
+See [comment](/documentation/reference/api/#comment) macro: ignores forms, returns `nil`, still requires valid Phel code.

--- a/content/documentation/language/control-flow.md
+++ b/content/documentation/language/control-flow.md
@@ -10,9 +10,9 @@ aliases = ["/documentation/control-flow"]
 (if test then else?)
 ```
 
-A control flow structure. First evaluates _test_. If _test_ evaluates to `true`, only the _then_ form is evaluated and the result is returned. If _test_ evaluates to `false` only the _else_ form is evaluated and the result is returned. If no _else_ form is given, `nil` will be returned.
+Evaluates _test_. If truthy, returns _then_; if falsy, returns _else_ (or `nil`).
 
-The _test_ evaluates to `false` if its value is `false` or equal to `nil`. Every other value evaluates to `true`. In sense of PHP this means (`test != null && test !== false`).
+Only `false` and `nil` are falsy. Everything else truthy. PHP equivalent: `test !== null && test !== false`.
 
 ```phel
 ;; Basic if examples
@@ -50,7 +50,7 @@ The _test_ evaluates to `false` if its value is `false` or equal to `nil`. Every
 (case test & pairs)
 ```
 
-Evaluates the _test_ expression. Then iterates over each pair. If the result of the test expression matches the first value of the pair, the second expression of the pair is evaluated and returned. If no match is found, returns nil.
+Evaluates _test_, matches against first item of each pair. Returns the matching second item, or `nil` if no match.
 
 ```phel
 ;; Basic case examples
@@ -90,7 +90,7 @@ Evaluates the _test_ expression. Then iterates over each pair. If the result of 
 ```
 
 {% php_note() %}
-`case` is similar to PHP's `switch` but more concise:
+Like PHP `switch`, more concise:
 
 ```php
 // PHP
@@ -111,7 +111,7 @@ switch ($value) {
   12 :big)
 ```
 
-No `break` needed-Phel's `case` doesn't fall through.
+No `break`, no fall-through.
 {% end %}
 
 ## Cond
@@ -120,7 +120,7 @@ No `break` needed-Phel's `case` doesn't fall through.
 (cond & pairs)
 ```
 
-Iterates over each pair. If the first expression of the pair evaluates to logical true, the second expression of the pair is evaluated and returned. If no match is found, returns nil.
+Walks pairs. First pair whose test is truthy: returns its second expression. No match returns `nil`.
 
 ```phel
 ;; Basic cond examples
@@ -171,7 +171,7 @@ Iterates over each pair. If the first expression of the pair evaluates to logica
 ```
 
 {% php_note() %}
-`cond` is like a chain of `if`/`elseif` in PHP:
+Like a chain of `if`/`elseif`:
 
 ```php
 // PHP
@@ -189,7 +189,7 @@ if ($value < 0) {
   (pos? value) :positive)
 ```
 
-More elegant for multiple conditions than nested `if` expressions. Use `:else` as the last condition for a default case.
+Cleaner than nested `if`. Use `:else` as a default.
 {% end %}
 
 ## Loop
@@ -197,14 +197,16 @@ More elegant for multiple conditions than nested `if` expressions. Use `:else` a
 ```phel
 (loop [bindings*] expr*)
 ```
-Creates a new lexical context with variables defined in bindings and defines a recursion point at the top of the loop.
+
+Creates a lexical context with bindings and a recursion point at the top.
 
 ```phel
 (recur expr*)
 ```
-Evaluates the expressions in order and rebinds them to the recursion point. A recursion point can be either a `fn` or a `loop`. The recur expressions must match the arity of the recursion point exactly.
 
-Internally `recur` is implemented as a PHP while loop and therefore prevents the _Maximum function nesting level_ errors.
+Evaluates expressions and rebinds at the recursion point. Recursion point is a `fn` or `loop`. Arities must match exactly.
+
+`recur` compiles to a PHP `while` loop, avoiding _Maximum function nesting level_ errors.
 
 ```phel
 ;; Basic loop example - sum numbers from 1 to 10
@@ -249,7 +251,7 @@ Internally `recur` is implemented as a PHP while loop and therefore prevents the
 ```
 
 {% php_note() %}
-`loop`/`recur` provides tail-call optimization, which PHP doesn't support natively:
+TCO not in PHP natively:
 
 ```php
 // PHP - recursive functions can cause stack overflow
@@ -265,7 +267,7 @@ function countdown($n) {
     (recur (dec n))))  ; No stack overflow!
 ```
 
-This is critical for functional programming patterns in PHP.
+Critical for FP patterns in PHP.
 {% end %}
 
 ## Foreach
@@ -274,7 +276,8 @@ This is critical for functional programming patterns in PHP.
 (foreach [value valueExpr] expr*)
 (foreach [key value valueExpr] expr*)
 ```
-The `foreach` special form can be used to iterate over all kind of PHP datastructures for side-effects. The return value of `foreach` is always `nil`. The `loop` special form should be preferred of the `foreach` special form whenever possible.
+
+Iterate any PHP data structure for side-effects. Always returns `nil`. Prefer `loop` when possible.
 
 ```phel
 (foreach [v [1 2 3]]
@@ -286,7 +289,7 @@ The `foreach` special form can be used to iterate over all kind of PHP datastruc
 ```
 
 {% php_note() %}
-`foreach` mirrors PHP's foreach loop syntax:
+Mirrors PHP `foreach`:
 
 ```php
 // PHP
@@ -308,34 +311,30 @@ foreach (["a" => 1, "b" => 2] as $k => $v) {
   (print v))
 ```
 
-**Note:** Prefer `for` or `loop` when you need to return values. `foreach` is only for side-effects.
+**Note:** Use `for` or `loop` to return values. `foreach` is side-effects only.
 {% end %}
 
 ## For
 
-A more powerful loop functionality is provided by the `for` loop. The `for` loop is an elegant way to define and create arrays based on existing collections. It combines the functionality of `foreach`, `let`, `if` and `reduce` in one call.
+`for` builds collections from existing ones. Combines `foreach`, `let`, `if`, `reduce`.
 
 ```phel
 (for head body+)
 ```
 
-The `head` of the loop is a vector that contains a
-sequence of bindings and modifiers. A binding is a sequence of three
-values `binding :verb expr`. Where `binding` is a binding as
-in `let` and `:verb` is one of the following keywords:
+`head` is a vector of bindings and modifiers. A binding is `binding :verb expr` where `binding` works as in `let` and `:verb` is one of:
 
-* `:range` loop over a range, by using the range function.
-* `:in` loops over all values of a collection.
-* `:keys` loops over all keys/indexes of a collection.
-* `:pairs` loops over all key value pairs of a collection.
+* `:range` loop over a range
+* `:in` values of a collection
+* `:keys` keys/indexes of a collection
+* `:pairs` key-value pairs
 
-After each loop binding additional modifiers can be applied. Modifiers
-have the form `:modifier argument`. The following modifiers are supported:
+Modifiers (form `:modifier argument`):
 
-* `:while` breaks the loop if the expression is falsy.
-* `:let` defines additional bindings.
-* `:when` only evaluates the loop body if the condition is true.
-* `:reduce [accumulator initial-value]` Instead of returning a list, it reduces the values into `accumulator`. Initially `accumulator` is bound to `initial-value`. Normally with `when` macro inside `reduce` function the accumulator becomes `nil` when the condition is not met. However with `for`, `:when` can be used for conditional logic with `:reduce` without this issue.
+* `:while` break when expression is falsy
+* `:let` additional bindings
+* `:when` evaluate body only when condition is true
+* `:reduce [acc init]` reduce instead of returning a list. `acc` starts at `init`. Unlike `when` inside `reduce`, `:when` works cleanly with `:reduce`
 
 ```phel
 (for [x :range [0 3]] x) ; Evaluates to [0 1 2]
@@ -365,7 +364,7 @@ have the form `:modifier argument`. The following modifiers are supported:
 ```
 
 {% php_note() %}
-Phel's `for` is a powerful list comprehension, not like PHP's `for` loop:
+List comprehension, not PHP's `for`:
 
 ```php
 // PHP - manual array building
@@ -378,11 +377,11 @@ foreach (range(1, 3) as $x) {
 (for [x :in [1 2 3]] (inc x))  ; [2 3 4]
 ```
 
-Phel's `for` combines iteration, filtering (`:when`), early termination (`:while`), reduction (`:reduce`), and nested loops in one elegant expression-much more powerful than PHP's `for`/`foreach`.
+Combines iteration, filtering (`:when`), early termination (`:while`), reduction (`:reduce`), nested loops.
 {% end %}
 
 {% clojure_note() %}
-`for` works similarly to Clojure's `for`-list comprehensions with `:let`, `:when`, and nested bindings. The `:reduce` modifier is a Phel extension.
+Like Clojure `for` (`:let`, `:when`, nesting). `:reduce` is a Phel extension.
 {% end %}
 
 ## Do
@@ -391,7 +390,7 @@ Phel's `for` combines iteration, filtering (`:when`), early termination (`:while
 (do expr*)
 ```
 
-Evaluates the expressions in order and returns the value of the last expression. If no expression is given, `nil` is returned.
+Evaluates expressions in order. Returns the last value, or `nil` if empty.
 
 ```phel
 (do 1 2 3 4) ; Evaluates to 4
@@ -401,13 +400,13 @@ Evaluates the expressions in order and returns the value of the last expression.
 ## Dofor
 
 ```phel
-(dofor [x :in [1 2 3]] (print x)) ; Prints 1, 2, 3 and returns nil
-(dofor [x :in [2 3 4 5] :when (even? x)] (print x)) ; Prints 1, 2 and returns nil
+(dofor [x :in [1 2 3]] (print x)) ; Prints 1, 2, 3, returns nil
+(dofor [x :in [2 3 4 5] :when (even? x)] (print x)) ; Prints 2, 4, returns nil
 ```
 
-Iterating over collections for side-effects is also possible with `dofor` which has similar behavior to `for` otherwise but returns `nil` as `foreach` does.
+Like `for` but for side-effects. Returns `nil` like `foreach`.
 
-## Conditional Threading
+## Conditional threading
 
 ### cond->
 
@@ -415,7 +414,7 @@ Iterating over collections for side-effects is also possible with `dofor` which 
 (cond-> expr & clauses)
 ```
 
-Takes an expression and a set of test/form pairs. Threads the expression through each form where the corresponding test is truthy (thread-first style). Forms where the test is falsy are skipped.
+Threads expression through each form whose test is truthy (thread-first). Skips forms with falsy tests.
 
 ```phel
 (cond-> 1
@@ -439,7 +438,7 @@ Takes an expression and a set of test/form pairs. Threads the expression through
 (cond->> expr & clauses)
 ```
 
-Like `cond->` but threads as the last argument (thread-last style).
+Like `cond->` but threads as last arg (thread-last).
 
 ```phel
 (cond->> [1 2 3 4 5]
@@ -456,15 +455,15 @@ Like `cond->` but threads as the last argument (thread-last style).
 (throw expr)
 ```
 
-The _expr_ is evaluated and thrown, therefore _expr_ must return a value that implements PHP's `Throwable` interface.
+Evaluates _expr_ and throws it. Must implement PHP `Throwable`.
 
-## Try, Catch and Finally
+## Try, catch, finally
 
 ```phel
 (try expr* catch-clause* finally-clause?)
 ```
 
-All expressions are evaluated and if no exception is thrown the value of the last expression is returned. If an exception occurs and a matching _catch-clause_ is provided, its expression is evaluated and the value is returned. If no matching _catch-clause_ can be found the exception is propagated out of the function. Before returning normally or abnormally the optionally _finally-clause_ is evaluated.
+Evaluates expressions. No exception: returns last value. Matching _catch-clause_: returns its value. No match: exception propagates. _finally-clause_ runs before return.
 
 ```phel
 (try) ; Evaluates to nil
@@ -483,18 +482,18 @@ All expressions are evaluated and if no exception is thrown the value of the las
   (finally (print "test"))) ; Evaluates to "error" and prints "test"
 ```
 
-## Structured Exceptions
+## Structured exceptions
 
-Phel provides functions for creating and inspecting structured exceptions that carry data maps, inspired by Clojure's `ex-info` system. This is useful when you need to attach context to errors beyond just a message string.
+Exceptions carrying data maps, inspired by Clojure's `ex-info`. Useful for attaching context beyond a message.
 
-### Creating structured exceptions with `ex-info`
+### Creating with `ex-info`
 
 ```phel
 (ex-info message data)
 (ex-info message data cause)
 ```
 
-Creates an exception with a message string, an associated data map, and an optional cause (a previous exception). The data map can contain any information relevant to the error:
+Exception with message, data map, optional cause:
 
 ```phel
 (throw (ex-info "User not found" {:user-id 42 :status 404}))
@@ -506,9 +505,9 @@ Creates an exception with a message string, an associated data map, and an optio
     (throw (ex-info "Operation failed" {:step "processing"} e))))
 ```
 
-### Inspecting structured exceptions
+### Inspecting
 
-Use `ex-data`, `ex-message`, and `ex-cause` to extract information from structured exceptions:
+Use `ex-data`, `ex-message`, `ex-cause`:
 
 ```phel
 (def err (ex-info "Validation failed" {:field :email :reason "invalid format"}))
@@ -518,7 +517,7 @@ Use `ex-data`, `ex-message`, and `ex-cause` to extract information from structur
 (ex-cause err)    ; => nil (no cause provided)
 ```
 
-### Practical example: error handling with data
+### Example: error handling with data
 
 ```phel
 (defn find-user [id]

--- a/content/documentation/language/data-structures.md
+++ b/content/documentation/language/data-structures.md
@@ -4,19 +4,19 @@ weight = 7
 aliases = ["/documentation/data-structures"]
 +++
 
-Phel has four main data structures: **Lists**, **Vectors**, **Maps**, and **Sets**.
+Four main data structures: **Lists**, **Vectors**, **Maps**, **Sets**.
 
-All data structures are **persistent** (immutable). A persistent data structure preserves the previous version of itself when it is modified. Unlike naive immutable structures that copy everything, persistent data structures efficiently share unmodified values with their previous versions. When you "modify" a collection, you get a new version while the original remains unchanged.
+All **persistent** (immutable). Modifications return a new version sharing structure with the old. The original is unchanged.
 
 {% php_note() %}
-Think of this as "copy-on-write" for collections, similar to how PHP's copy-on-write works for variables. This prevents bugs from unexpected mutations-a common issue in PHP where passing arrays to functions can lead to surprising behavior.
+"Copy-on-write" for collections. Prevents bugs from unexpected mutations.
 {% end %}
 
 ## Lists
 
-A persistent list is simple a linked list. Access or modifications on the first element is efficient, random access is not. In Phel, a list has a special meaning. They are interpreted as function calls, macro calls or special forms by the compiler.
+Linked list. Fast first-element access, slow random access. Lists are function/macro/special-form calls.
 
-To create a list surround the white space separated values with parentheses or use the `list` function.
+Create with parens or `list`:
 
 ```phel
 (do 1 2 3)   ; list with 4 entries
@@ -24,7 +24,7 @@ To create a list surround the white space separated values with parentheses or u
 '(1 2 3)     ; use a quote to create a list
 ```
 
-To access values in a list the functions `get`, `first`, `second`, `next`, `rest` and `peek` can be used.
+Access values with `get`, `first`, `second`, `next`, `rest`, `peek`:
 
 ```phel
 (get (list 1 2 3) 0)  ; Evaluates to 1
@@ -37,14 +37,14 @@ To access values in a list the functions `get`, `first`, `second`, `next`, `rest
 (rest (list))         ; Evaluates to ()
 ```
 
-New values can only be added to the front of the list with the `cons` function.
+Add to the front with `cons`:
 
 ```phel
 (cons 1 (list))     ; Evaluates to (1)
 (cons 3 (list 1 2)) ; Evaluates to (3 1 2)
 ```
 
-To get the length of the list the `count` function can be used
+`count` for length:
 
 ```phel
 (count (list))       ; Evaluates to 0
@@ -53,9 +53,9 @@ To get the length of the list the `count` function can be used
 
 ## Vectors
 
-Vectors are an indexed, sequential data structure. They offer efficient random access (by index) and are very efficient in appending values at the end.
+Indexed, sequential. Fast random access by index, fast append at end.
 
-To create a vector, wrap the white space separated values with brackets, use the `vector` function, or coerce any collection with `vec`.
+Create with brackets, `vector`, or coerce with `vec`:
 
 ```phel
 [1 2 3]       ; Creates a new vector with three values
@@ -64,7 +64,7 @@ To create a vector, wrap the white space separated values with brackets, use the
 (vec #{1 2 3}) ; Coerce a set to a vector
 ```
 
-To get a value by its index use the `get` function. Similar to list you can use the `first`, `second` and `peek` function to access the first, second and last values of the vector.
+`get` by index. `first`, `second`, `peek` for first/second/last:
 
 ```phel
 (get [1 2 3] 0)  ; Evaluates to 1
@@ -73,20 +73,20 @@ To get a value by its index use the `get` function. Similar to list you can use 
 (peek [1 2 3])   ; Evaluates to 3
 ```
 
-New values can be appended by using the `conj` function.
+Append with `conj`:
 
 ```phel
 (conj [1 2 3] 4) ; Evaluates to [1 2 3 4]
 ```
 
-To change an existing value use the `assoc` function
+Change a value with `assoc`:
 
 ```phel
 (assoc [1 2 3] 0 4) ; Evaluates to [4 2 3]
 (assoc [1 2 3] 3 4) ; Evaluates to [1 2 3 4]
 ```
 
-A vector can be counted using the `count` function.
+Length with `count`:
 
 ```phel
 (count [])      ; Evaluates to 0
@@ -94,14 +94,14 @@ A vector can be counted using the `count` function.
 ```
 
 {% php_note() %}
-Vectors are like PHP's indexed arrays (`[0 => 'a', 1 => 'b']`), but immutable. Use vectors when you need indexed access.
+Like PHP indexed arrays (`[0 => 'a', 1 => 'b']`), but immutable.
 {% end %}
 
 ## Maps
 
-A Map contains key-value-pairs in random order. Each possible key appears at most once in the collection. Any type that implements the `HashableInterface` and `EqualsInterface` can be used as a key-including vectors, lists, or even other maps.
+Key-value pairs in any order. Each key once. Any value implementing `HashableInterface` and `EqualsInterface` can be a key (vectors, lists, maps).
 
-To create a map, wrap the key and values in curly brackets or use the `hash-map` function.
+Create with braces or `hash-map`:
 
 ```phel
 {:key1 value1 :key2 value2}          ; A new hash-map using shortcut syntax
@@ -111,7 +111,7 @@ To create a map, wrap the key and values in curly brackets or use the `hash-map`
 {[1 2] "vector-key" :keyword "keyword-key" "string" "string-key"}
 ```
 
-Use the `get` function to access a value by its key
+Access with `get`:
 
 ```phel
 (get {:a 1 :b 2} :a) ; Evaluates to 1
@@ -119,7 +119,7 @@ Use the `get` function to access a value by its key
 (get {:a 1 :b 2} :c) ; Evaluates to nil
 ```
 
-To add or update key-value pairs in the map use the `assoc` function. Multiple key-value pairs can be set in a single call.
+Add or update with `assoc`. Multiple pairs at once:
 
 ```phel
 (assoc {} :a "hello")           ; Evaluates to {:a "hello"}
@@ -127,13 +127,13 @@ To add or update key-value pairs in the map use the `assoc` function. Multiple k
 (assoc {} :a 1 :b 2 :c 3)      ; Evaluates to {:a 1 :b 2 :c 3}
 ```
 
-A value in a map can be removed with the `dissoc` function
+Remove with `dissoc`:
 
 ```phel
 (dissoc {:a "foo"} :a) ; Evaluates to {}
 ```
 
-As in the other data structures, the `count` function can be used to count the key-value-pairs.
+`count` for size:
 
 ```phel
 (count {})         ; Evaluates to 0
@@ -141,10 +141,10 @@ As in the other data structures, the `count` function can be used to count the k
 ```
 
 {% php_note() %}
-Maps are like PHP's associative arrays, but with two key differences:
+Like PHP assoc arrays, with two differences:
 
-1. **Any type can be a key** (not just strings/integers): vectors, lists, or even other maps
-2. **Immutable**: "updating" a map returns a new map; the original is unchanged
+1. **Any type as a key**: vectors, lists, other maps
+2. **Immutable**: "updating" returns a new map
 
 ```phel
 ;; PHP: $arr = ['name' => 'Alice', 'age' => 30];
@@ -159,13 +159,13 @@ Maps are like PHP's associative arrays, but with two key differences:
 ```
 {% end %}
 
-## Working with Collections
+## Working with collections
 
-Phel provides several core functions for manipulating collections. These functions work across different data structure types.
+Core functions span data structures.
 
-### Adding Elements with `conj`
+### Adding with `conj`
 
-The `conj` function adds elements to collections. The behavior depends on the collection type to maintain efficiency:
+`conj` adds elements. Behavior depends on type for efficiency:
 
 ```phel
 ;; Vectors - appends to end
@@ -184,9 +184,9 @@ The `conj` function adds elements to collections. The behavior depends on the co
 (conj {} [:a 1] [:b 2])  ; Evaluates to {:a 1 :b 2}
 ```
 
-### Associating Values with `assoc`
+### Associating with `assoc`
 
-The `assoc` function associates a value with a key in associative data structures (maps, vectors by index, structs).
+`assoc` sets a key in maps, vectors (by index), structs:
 
 ```phel
 ;; Maps - set or update key-value pairs
@@ -200,9 +200,9 @@ The `assoc` function associates a value with a key in associative data structure
 (assoc [] 0 "first")            ; Evaluates to ["first"]
 ```
 
-### Removing Values with `dissoc`
+### Removing with `dissoc`
 
-The `dissoc` function removes a key from a data structure, returning the structure without that key.
+`dissoc` removes a key:
 
 ```phel
 ;; Maps - remove key-value pair
@@ -214,9 +214,9 @@ The `dissoc` function removes a key from a data structure, returning the structu
 (dissoc #{1 2 3} 2 3)           ; Evaluates to #{1}
 ```
 
-### Nested Operations
+### Nested operations
 
-For working with nested data structures, Phel provides `-in` variants:
+`-in` variants for nested structures:
 
 ```phel
 ;; get-in - Access nested values
@@ -237,7 +237,7 @@ For working with nested data structures, Phel provides `-in` variants:
 
 {% php_note() %}
 
-### Understanding Immutability vs PHP's Mutability
+### Immutability vs PHP mutability
 
 ```phel
 ;; PHP: Mutable operations
@@ -263,12 +263,12 @@ $config['theme'] = 'light';  ; Overwrites in place
 ```
 
 **Why immutability matters:**
-- **Thread-safe**: Multiple threads can safely read the same data
-- **Predictable**: Functions can't unexpectedly modify your data
-- **Time-travel**: Keep old versions for undo/history features
-- **Easier debugging**: Data doesn't change "magically"
+- **Thread-safe** reads
+- **Predictable**: functions can't mutate your data
+- **Time-travel**: keep old versions for undo/history
+- **Easier debugging**: no surprise changes
 
-**When working with PHP code:** Use `php/aset` for PHP arrays that must be mutable:
+**With PHP code:** use `php/aset` for mutable PHP arrays:
 ```phel
 (def php-arr (php/array))
 (php/aset php-arr "key" "value")  ; Mutates the PHP array
@@ -278,9 +278,9 @@ $config['theme'] = 'light';  ; Overwrites in place
 
 {% clojure_note() %}
 
-### Clojure Compatibility
+### Clojure compatibility
 
-Phel follows Clojure's naming conventions exactly:
+Phel matches Clojure's names:
 
 | Function | Behavior | Clojure Compatible? |
 |----------|----------|---------------------|
@@ -293,13 +293,13 @@ Phel follows Clojure's naming conventions exactly:
 | `update` | Update with function | ✓ Yes |
 | `update-in` | Update nested with function | ✓ Yes |
 
-**Migration note:** The older `push`, `put`, and `unset` functions are deprecated. Use `conj`, `assoc`, and `dissoc` instead for Clojure compatibility.
+**Migration:** `push`, `put`, `unset` deprecated. Use `conj`, `assoc`, `dissoc`.
 
 {% end %}
 
 ## Structs
 
-A Struct is a special kind of Map. It only supports a predefined number of keys and is associated with a global name. The Struct not only defines itself but also a predicate function.
+A struct is a Map with a fixed set of keys and a global name. `defstruct` also defines a predicate function.
 
 ```phel
 (defstruct my-struct [a b c]) ; Defines the struct
@@ -309,13 +309,13 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
   (assoc x :a 12))            ; Evaluates to (my-struct 12 2 3)
 ```
 
-Internally, Phel Structs are PHP classes where each key correspondence to an object property. Therefore, Structs can be faster than Maps.
+Internally, Structs are PHP classes (one property per key). Faster than Maps.
 
 ## Sets
 
-A Set contains unique values in random order. All types of values are allowed that implement the `HashableInterface` and the `EqualsInterface`.
+Unique values in any order. Values must implement `HashableInterface` and `EqualsInterface`.
 
-A new set can be created using the shortcut syntax `#{}`, the `hash-set` function (from individual arguments), or the `set` function (to coerce a collection).
+Create with `#{}`, `hash-set`, or coerce with `set`:
 
 ```phel
 #{1 2 3}         ; A new set using shortcut syntax
@@ -324,29 +324,29 @@ A new set can be created using the shortcut syntax `#{}`, the `hash-set` functio
 (set '(1 2 3))   ; Works with any collection type
 ```
 
-> **Note:** `set` coerces a collection to a set (Clojure alignment). Use `hash-set` to create a set from individual arguments.
+> **Note:** `set` coerces a collection (Clojure alignment). `hash-set` builds from individual args.
 
-The `conj` function can be used to add a new value to the Set.
+Add with `conj`:
 
 ```phel
 (conj #{1 2 3} 4) ; Evaluates to #{1 2 3 4}
 (conj #{1 2 3} 2) ; Evaluates to #{1 2 3}
 ```
 
-Similar to the Map the `dissoc` function can be used to remove a value from the list
+Remove with `dissoc`:
 
 ```phel
 (dissoc #{1 2 3} 2) ; Evaluates to #{1 3}
 ```
 
-Again the `count` function can be used to count the elements in the set
+Size with `count`:
 
 ```phel
 (count #{})  ; Evaluates to 0
 (count #{2}) ; Evaluates to 1
 ```
 
-Additionally, the union of a collection of sets is the set of all elements in the collection.
+`union`: all elements of multiple sets.
 
 ```phel
 (union)               ; Evaluates to #{}
@@ -354,14 +354,14 @@ Additionally, the union of a collection of sets is the set of all elements in th
 (union #{1 2} #{0 3}) ; Evaluates to #{0 1 2 3}
 ```
 
-The intersection of two sets or more is the set containing all elements shared between those sets.
+`intersection`: elements shared by all sets.
 
 ```phel
 (intersection #{1 2} #{0 3})     ; Evaluates to #{}
 (intersection #{1 2} #{0 1 2 3}) ; Evaluates to #{1 2}
 ```
 
-The difference of two sets or more is the set containing all elements in the first set that aren't in the other sets.
+`difference`: elements in first set not in the others.
 
 ```phel
 (difference #{1 2} #{0 3})     ; Evaluates to #{1 2}
@@ -369,14 +369,14 @@ The difference of two sets or more is the set containing all elements in the fir
 (difference #{0 1 2 3} #{1 2}) ; Evaluates to #{0 3}
 ```
 
-The symmetric difference of two sets or more is the set of elements which are in either of the sets and not in their intersection.
+`symmetric-difference`: elements in some sets but not in their intersection.
 
 ```phel
 (symmetric-difference #{1 2} #{0 3})     ; Evaluates to #{0 1 2 3}
 (symmetric-difference #{1 2} #{0 1 2 3}) ; Evaluates to #{0 3}
 ```
 
-The `subset?` predicate checks if a set is a subset of another set, and `superset?` checks the inverse.
+`subset?` and `superset?`:
 
 ```phel
 (subset? (hash-set 1 2) (hash-set 1 2 3))   ; Evaluates to true
@@ -387,11 +387,11 @@ The `subset?` predicate checks if a set is a subset of another set, and `superse
 
 ## Transients
 
-Nearly all persistent data structures have a transient version (except for Persistent List). The transient version of each persistent data structure is a mutable version of them. It stores the value in the same way as the persistent version, but instead of returning a new persistent version with every modification, it modifies the current version. 
+Most persistent structures have a transient (mutable) version (not lists). Same storage, but modifies in place.
 
-Transient versions are faster and can be used as builders for new persistent collections. Since transients use the same underlying storage, it is rapid to convert a persistent data structure to a transient and back.
+Faster, used as builders. Conversion to/from persistent is cheap.
 
-For example, if we want to convert a PHP Array to a persistent map. This function can be used:
+Convert a PHP array to a persistent map:
 
 ```phel
 (defn php-array-to-map
@@ -403,9 +403,9 @@ For example, if we want to convert a PHP Array to a persistent map. This functio
     (persistent res))) ; Convert the transient map to a persistent map.
 ```
 
-## Data structures are functions
+## Data structures as functions
 
-In Phel all data structures can also be used as functions. This enables concise, elegant code:
+All data structures are callable:
 
 ```phel
 ((list 1 2 3) 0) ; Same as (get (list 1 2 3) 0)
@@ -419,9 +419,7 @@ In Phel all data structures can also be used as functions. This enables concise,
 (map :name users)  ; Evaluates to ["Alice" "Bob"]
 ```
 
-## Practical Example: Working with User Data
-
-Here's a real-world example combining multiple concepts:
+## Example: working with user data
 
 ```phel
 ;; Start with user data
@@ -478,7 +476,7 @@ Here's a real-world example combining multiple concepts:
 ;; => {:user_id 123 :user_name "Alice" :is_active true}
 ```
 
-### Common Patterns
+### Common patterns
 
 **Building data incrementally:**
 ```phel
@@ -518,9 +516,9 @@ Here's a real-world example combining multiple concepts:
 ; => {:theme "dark" :lang "en" :debug false}
 ```
 
-### Transforming Map Keys and Values
+### Transforming map keys and values
 
-Use `update-keys` and `update-vals` to apply a function to all keys or all values in a map:
+`update-keys`, `update-vals` apply a function across keys/values:
 
 ```phel
 ; Transform all keys
@@ -538,9 +536,9 @@ Use `update-keys` and `update-vals` to apply a function to all keys or all value
 ; => {:x "HELLO" :y "WORLD"}
 ```
 
-### Building Collections with `into`
+### Building collections with `into`
 
-The `into` function pours elements from one collection into another. With a third argument, it applies a transducer to transform elements as they are added:
+`into` pours elements from one collection into another. Third arg applies a transducer:
 
 ```phel
 ; Two-argument form: pour elements into a collection
@@ -557,7 +555,7 @@ The `into` function pours elements from one collection into another. With a thir
 
 ### Transducers
 
-Transducers are composable transformations that are independent of the context they run in. Many collection functions like `map`, `filter`, `remove`, `take`, `drop`, `take-while`, `drop-while`, `take-nth`, `keep`, `keep-indexed`, `distinct`, `dedupe`, `mapcat`, and `interpose` support a transducer arity (called without a collection) that returns a transducer:
+Composable transformations independent of context. `map`, `filter`, `remove`, `take`, `drop`, `take-while`, `drop-while`, `take-nth`, `keep`, `keep-indexed`, `distinct`, `dedupe`, `mapcat`, `interpose` return a transducer when called without a collection:
 
 ```phel
 ; Create a transducer by calling map/filter without a collection
@@ -573,7 +571,7 @@ Transducers are composable transformations that are independent of the context t
 (sequence xf [1 2 3 4 5])            ; => (10 30 50)
 ```
 
-Common transducer-producing functions:
+Common transducer producers:
 
 ```phel
 (into [] (take 3) (range 10))                ; => [0 1 2]
@@ -586,26 +584,26 @@ Common transducer-producing functions:
 (into [] (interpose :sep) [1 2 3])            ; => [1 :sep 2 :sep 3]
 ```
 
-Use `completing` to adapt a reducing function for use with `transduce`:
+`completing` adapts a reducing function for `transduce`:
 
 ```phel
 (def my-rf (completing conj count))
 (transduce (map inc) my-rf [1 2 3])  ; => 3
 ```
 
-The `cat` transducer concatenates inner collections:
+`cat` concatenates inner collections:
 
 ```phel
 (into [] cat [[1 2] [3 4] [5 6]])  ; => [1 2 3 4 5 6]
 ```
 
-## Walking Data Structures
+## Walking data structures
 
-The `phel\walk` module provides functions for recursively transforming nested data structures.
+`phel\walk` recursively transforms nested data.
 
 ### walk
 
-`walk` traverses a data structure, applying an `inner` function to each element and then an `outer` function to the result:
+`walk` traverses a structure, applying `inner` to each element, then `outer` to the result:
 
 ```phel
 (ns my-app
@@ -618,7 +616,7 @@ The `phel\walk` module provides functions for recursively transforming nested da
 
 ### postwalk and prewalk
 
-`postwalk` applies a function to each node bottom-up (children first), while `prewalk` applies it top-down (parent first):
+`postwalk` applies bottom-up (children first). `prewalk` applies top-down:
 
 ```phel
 ;; Double every number in a nested structure
@@ -634,7 +632,7 @@ The `phel\walk` module provides functions for recursively transforming nested da
 
 ### postwalk-replace and prewalk-replace
 
-Replace values by looking them up in a map:
+Replace values via map lookup:
 
 ```phel
 (postwalk-replace {:a :alpha :b :beta}
@@ -644,7 +642,7 @@ Replace values by looking them up in a map:
 
 ### keywordize-keys and stringify-keys
 
-Convert all map keys between keywords and strings, useful when working with PHP arrays or JSON data:
+Convert map keys between keywords and strings. Useful for PHP arrays or JSON:
 
 ```phel
 (keywordize-keys {"name" "Alice" "age" 30})

--- a/content/documentation/language/destructuring.md
+++ b/content/documentation/language/destructuring.md
@@ -4,40 +4,40 @@ weight = 8
 aliases = ["/documentation/destructuring"]
 +++
 
-Destructuring binds names to values inside data structures. Instead of manually extracting each value, you describe the shape of the data and Phel binds the pieces for you.
+Destructuring binds names to values inside data structures. Describe the shape, Phel binds the pieces.
 
-Destructuring works in `let` bindings, function parameters (`defn`, `fn`), and `loop` bindings.
+Works in `let`, function params (`defn`, `fn`), `loop`.
 
-## Sequential destructuring
+## Sequential
 
-Extract values from vectors and lists by position using vector syntax:
+Extract from vectors/lists by position with vector syntax:
 
 ```phel
 (let [[a b] [1 2]]
   (+ a b)) ; => 3
 ```
 
-### Nested destructuring
+### Nested
 
-Patterns can be nested arbitrarily deep:
+Patterns nest arbitrarily deep:
 
 ```phel
 (let [[a [b c]] [1 [2 3]]]
   (+ a b c)) ; => 6
 ```
 
-### Skipping values
+### Skipping
 
-Use `_` to ignore positions you don't care about:
+`_` ignores a position:
 
 ```phel
 (let [[a _ b] [1 2 3]]
   (+ a b)) ; => 4
 ```
 
-### Rest arguments
+### Rest args
 
-Use `&` to capture remaining elements as a sequence:
+`&` captures the remaining elements:
 
 ```phel
 (let [[a b & rest] [1 2 3 4 5]]
@@ -45,7 +45,7 @@ Use `&` to capture remaining elements as a sequence:
 ```
 
 {% php_note() %}
-Destructuring is more powerful than PHP's list() or array unpacking:
+More powerful than PHP `list()` or array unpacking:
 
 ```php
 // PHP - limited destructuring
@@ -58,30 +58,30 @@ Destructuring is more powerful than PHP's list() or array unpacking:
   )
 ```
 
-Phel's destructuring works in more places (function params, let, loop) and supports more patterns.
+Works in more places (function params, let, loop) with more patterns.
 {% end %}
 
-## Associative destructuring
+## Associative
 
-Extract values from maps by key using map syntax:
+Extract from maps by key with map syntax:
 
 ```phel
 (let [{:a a :b b} {:a 1 :b 2}]
   (+ a b)) ; => 3
 ```
 
-### Nested associative destructuring
+### Nested associative
 
-Combine map and vector patterns freely:
+Mix map and vector patterns:
 
 ```phel
 (let [{:a [a b] :c c} {:a [1 2] :c 3}]
   (+ a b c)) ; => 6
 ```
 
-### Default values with `:or`
+### Defaults with `:or`
 
-Provide defaults for keys that might be missing:
+Defaults for missing keys:
 
 ```phel
 (let [{:name name :role role :or {role "guest"}}
@@ -92,7 +92,7 @@ Provide defaults for keys that might be missing:
 Without `:or`, missing keys bind to `nil`.
 
 {% php_note() %}
-Associative destructuring lets you extract values by key:
+Extract values by key:
 
 ```php
 // PHP - manual extraction with defaults
@@ -108,9 +108,9 @@ $role = $data['role'] ?? 'guest';
 ```
 {% end %}
 
-## Index-based destructuring
+## Index-based
 
-Vectors can also be destructured by index using map syntax:
+Destructure vectors by index using map syntax:
 
 ```phel
 (let [{0 a 1 b} [1 2]]
@@ -120,11 +120,11 @@ Vectors can also be destructured by index using map syntax:
   (+ a b c)) ; => 6
 ```
 
-This is useful when you only need specific positions from a large vector.
+Useful for specific positions in a large vector.
 
-## Destructuring in function parameters
+## In function parameters
 
-Destructuring works directly in `defn` and `fn` parameter lists:
+Works directly in `defn` and `fn` params:
 
 ```phel
 (defn greet [{:name name :role role :or {role "member"}}]
@@ -134,7 +134,7 @@ Destructuring works directly in `defn` and `fn` parameter lists:
 (greet {:name "Bob"})                  ; => "Hello Bob (member)"
 ```
 
-Sequential destructuring in parameters:
+Sequential in params:
 
 ```phel
 (defn distance [[x1 y1] [x2 y2]]
@@ -144,9 +144,9 @@ Sequential destructuring in parameters:
 (distance [0 0] [3 4]) ; => 5.0
 ```
 
-## Destructuring in `loop`
+## In `loop`
 
-Use destructuring in loop bindings to work with structured data:
+Loop bindings:
 
 ```phel
 (loop [[head & tail] [1 2 3 4 5]

--- a/content/documentation/language/functions-and-recursion.md
+++ b/content/documentation/language/functions-and-recursion.md
@@ -4,7 +4,7 @@ weight = 6
 aliases = ["/documentation/functions-and-recursion"]
 +++
 
-## Anonymous Function (fn)
+## Anonymous function (fn)
 
 ```phel
 (fn [params*] expr*)
@@ -15,11 +15,11 @@ aliases = ["/documentation/functions-and-recursion"]
   ...)
 ```
 
-Defines a function. A function consists of a list of parameters and a list of expression. The value of the last expression is returned as the result of the function. All other expression are only evaluated for side effects. If no expression is given, the function returns `nil`.
+Defines a function: parameter list, expression list. Returns last expression's value. Earlier expressions evaluate for side-effects. No expressions returns `nil`.
 
-Functions can define multiple arities. When calling such a function, the clause matching the number of provided arguments is chosen. Variadic clauses are supported for at most one arity and must be the one with the most parameters. If no arity matches, a readable compile-time or runtime error is thrown.
+Functions can have multiple arities. Call dispatches on argument count. At most one variadic clause, which must have the most params. No matching arity raises a clear compile/runtime error.
 
-Function also introduces a new lexical scope that is not accessible outside the function.
+Functions introduce their own lexical scope.
 
 ```phel
 (fn []) ; Function with no arguments that returns nil
@@ -28,7 +28,7 @@ Function also introduces a new lexical scope that is not accessible outside the 
 (fn [a b] (+ a b)) ; A function that returns the sum of a and b
 ```
 
-Function can also be defined as variadic function with an infinite amount of arguments using the `&` separator.
+Variadic functions use `&`:
 
 ```phel
 (fn [& args] (count args)) ; A variadic function that counts the arguments
@@ -41,7 +41,7 @@ Function can also be defined as variadic function with an infinite amount of arg
   ([greeting name & rest] (str greeting " " name rest)))
 ```
 
-There is a shorter form to define an anonymous function. This omits the parameter list and names parameters based on their position.
+Shorter form omits the parameter list, naming params by position:
 
 * `%` or `%1` refers to the first argument
 * `%2`, `%3`, etc. refer to subsequent arguments
@@ -57,10 +57,10 @@ There is a shorter form to define an anonymous function. This omits the paramete
 (filter #(> % 3) [1 5 2 8])   ; => [5 8]
 ```
 
-> **Legacy syntax:** Phel also accepts `|(...)` with `$` / `$1` / `$&` placeholders. It still reads, but `#(...)` with `%` placeholders is preferred and matches Clojure.
+> **Legacy:** `|(...)` with `$` / `$1` / `$&` still reads. Prefer `#(...)` with `%` (matches Clojure).
 
 {% php_note() %}
-The short-form anonymous function syntax `#()` is similar to PHP's arrow functions:
+`#()` short-form is like PHP arrow functions:
 
 ```php
 // PHP
@@ -85,7 +85,7 @@ array_map(fn($x) => $x * 2, $array);
   ...)
 ```
 
-Global functions can be defined using `defn`. Like anonymous functions, they may provide multiple arities. The most specific clause based on the number of arguments is chosen at call time. A single variadic clause is allowed and must declare the maximum number of arguments.
+`defn` defines a global function. Multiple arities allowed; single variadic clause must declare the max arg count.
 
 ```phel
 (defn my-add-function [a b]
@@ -97,7 +97,7 @@ Global functions can be defined using `defn`. Like anonymous functions, they may
   ([greeting name] (str greeting " " name)))
 ```
 
-Each global function can take an optional doc comment and attribute map.
+Optional doc string and attribute map:
 
 ```phel
 (defn my-add-function
@@ -108,10 +108,10 @@ Each global function can take an optional doc comment and attribute map.
 
 ### Private functions
 
-Private functions are not exported from the namespace and cannot be accessed from other namespaces. You can create private functions in two ways:
+Private functions don't export from the namespace. Two forms:
 
-1. Using the `{:private true}` attribute map
-2. Using the `defn-` shorthand
+1. `{:private true}` attribute
+2. `defn-` shorthand
 
 ```phel
 (defn my-private-add-function
@@ -124,11 +124,11 @@ Private functions are not exported from the namespace and cannot be accessed fro
   (+ a b))
 ```
 
-Both approaches are equivalent, but `defn-` provides a more concise syntax for defining private functions.
+Equivalent, but `defn-` is more concise.
 
 ## Recursion
 
-Similar to `loop`, functions can be made recursive using `recur`. The `recur` special form enables tail-call optimization, preventing stack overflow errors.
+Like `loop`, functions can recurse with `recur`. TCO prevents stack overflow.
 
 ```phel
 ;; Recursive factorial (regular recursion - can stack overflow)
@@ -179,7 +179,7 @@ Similar to `loop`, functions can be made recursive using `recur`. The `recur` sp
 ```
 
 {% php_note() %}
-`recur` is compiled to a PHP `while` loop, preventing "Maximum function nesting level" errors that would occur with regular recursive calls in PHP.
+`recur` compiles to a PHP `while`, avoiding "Maximum function nesting level" errors:
 
 ```php
 // PHP - This will cause stack overflow for large n
@@ -197,16 +197,16 @@ function factorial($n) {
       (recur (* acc n) (dec n)))))
 ```
 
-**Key difference:** Regular recursion builds up a call stack, while `recur` reuses the same stack frame (tail-call optimization).
+**Difference:** Recursion builds the call stack; `recur` reuses one stack frame (TCO).
 {% end %}
 
 ## Multimethods
 
-Multimethods provide runtime polymorphism via dispatch functions. They decouple the dispatch mechanism from the method implementations, allowing open extension without modifying existing code.
+Runtime polymorphism via dispatch functions. Decouples dispatch from implementations, enabling open extension.
 
-### Defining a multimethod
+### Defining
 
-Use `defmulti` to define a multimethod with a dispatch function, then `defmethod` to add implementations for specific dispatch values:
+`defmulti` declares the dispatch function. `defmethod` adds implementations per dispatch value:
 
 ```phel
 ;; Define a multimethod that dispatches on the :shape key
@@ -227,9 +227,9 @@ Use `defmulti` to define a multimethod with a dispatch function, then `defmethod
 (area {:shape :triangle :base 6 :height 4})   ; => 12
 ```
 
-### Custom dispatch functions
+### Custom dispatch
 
-The dispatch function can be any function, not just a keyword:
+Dispatch function can be anything, not just a keyword:
 
 ```phel
 (defmulti greeting #(get % :language))
@@ -246,28 +246,29 @@ The dispatch function can be any function, not just a keyword:
 ```phel
 (apply f expr*)
 ```
-Calls the function with the given arguments. The last argument must be a list of values, which are passed as separate arguments, rather than a single list. Apply returns the result of the calling function.
+
+Calls `f` with the args. Last arg must be a list, spread as separate arguments. Returns the result.
 
 ```phel
 (apply + [1 2 3]) ; Evaluates to 6
 (apply + 1 2 [3]) ; Evaluates to 6
 ```
 
-Calling `(apply + 1 2 3)` is invalid because the last argument must be a list.
+`(apply + 1 2 3)` is invalid: last arg must be a list.
 
 ## Passing by reference
 
-Sometimes it is required that a variable should pass to a function by reference. This can be done by applying the `:reference` metadata to the symbol.
+Pass a variable by reference with `:reference` metadata:
 
 ```phel
 (fn [^:reference my-arr]
   (php/apush my-arr 10))
 ```
 
-Support for references is very limited in Phel. Currently, it only works for function arguments (except destructuring).
+Limited support: works for function arguments only (no destructuring).
 
 {% php_note() %}
-This is equivalent to PHP's `&` reference operator:
+Equivalent to PHP `&`:
 
 ```php
 // PHP
@@ -280,5 +281,5 @@ function addToArray(&$arr) {
   (php/apush arr 10))
 ```
 
-**Note:** Use references sparingly. Phel's immutable data structures are usually a better choice than mutating PHP arrays.
+**Note:** Prefer immutable data structures over mutating PHP arrays.
 {% end %}

--- a/content/documentation/language/global-and-local-bindings.md
+++ b/content/documentation/language/global-and-local-bindings.md
@@ -9,14 +9,15 @@ aliases = ["/documentation/global-and-local-bindings"]
 ```phel
 (def name meta? value)
 ```
-This special form binds a value to a global symbol. A definition cannot be redefined at a later point.
+
+Binds a value to a global symbol. Cannot be redefined later.
 
 ```phel
 (def my-name "phel")
 (def sum-of-three (+ 1 2 3))
 ```
 
-To each definition metadata can be attached. Metadata is either a Keyword, a String or a Map.
+Attach metadata: a Keyword, String, or Map.
 
 ```phel
 (def my-private-definition :private 12)
@@ -29,7 +30,8 @@ To each definition metadata can be attached. Metadata is either a Keyword, a Str
 ```phel
 (let [bindings*] expr*)
 ```
-Creates a new lexical context with assignments defined in bindings. Afterwards the list of expressions is evaluated and the value of the last expression is returned. If no expression is given `nil` is returned.
+
+Creates a lexical context with the bindings, then evaluates the expressions. Returns the last value (or `nil` if no expressions).
 
 ```phel
 (let [x 1
@@ -40,10 +42,10 @@ Creates a new lexical context with assignments defined in bindings. Afterwards t
       y (+ x 2)]) ; Evaluates to nil
 ```
 
-All assignments defined in _bindings_ are immutable and cannot be changed.
+All bindings are immutable.
 
 {% php_note() %}
-`let` creates block-scoped bindings, similar to PHP's block scope, but with immutability:
+Block-scoped bindings, like PHP, but immutable:
 
 ```php
 // PHP - mutable variables
@@ -61,11 +63,11 @@ $x = 10;  // Can reassign
 
 ## Binding
 
-While `let` creates a new lexical context, `binding` temporarily redefines existing definitions while executing the body. This can be useful when writing tests on functions depending on external state as `binding` allows to remap existing functions or values with mocks.
+`binding` temporarily redefines existing globals while executing the body. Useful for tests, mocking, dependency injection.
 
-**Key difference:**
-- `let` creates new local variables (lexical scope only)
-- `binding` temporarily overrides global definitions (dynamic scope)
+**Difference:**
+- `let`: new local variables (lexical scope)
+- `binding`: temporarily overrides globals (dynamic scope)
 
 ```phel
 ;; Example 1: Simple binding demonstration
@@ -129,7 +131,7 @@ While `let` creates a new lexical context, `binding` temporarily redefines exist
 ```
 
 {% php_note() %}
-`binding` is useful for dependency injection and testing, similar to mocking frameworks in PHP:
+Useful for DI and testing, similar to PHP mocking frameworks:
 
 ```php
 // PHP - using dependency injection
@@ -150,7 +152,7 @@ $service = new UserService($mockDb);
     (is (= "Alice" (:name (get-user 1))))))
 ```
 
-Binding is particularly useful for testing code that depends on global state or external systems.
+Useful for testing code with global state or external systems.
 {% end %}
 
 ## Atoms
@@ -159,13 +161,13 @@ Binding is particularly useful for testing code that depends on global state or 
 (atom value)
 ```
 
-Atoms provide a way to manage mutable state. Each atom contains a single value. Create one with the `atom` function:
+Atoms manage mutable state. Each holds a single value. Create with `atom`:
 
 ```phel
 (def foo (atom 10)) ; Define an atom with value 10
 ```
 
-The `deref` function (or the `@` reader shorthand) extracts the value. `reset!` replaces the value, and `swap!` updates it by applying a function:
+`deref` (or `@` shorthand) extracts the value. `reset!` replaces it. `swap!` applies a function:
 
 ```phel
 (def foo (atom 10))
@@ -179,10 +181,10 @@ The `deref` function (or the `@` reader shorthand) extracts the value. `reset!` 
 @foo               ; Evaluates to 22
 ```
 
-> **Note:** The original Phel names `var`, `set!`, `var?`, and `function?` still work as deprecated aliases for `atom`, `reset!`, `atom?`, and `fn?`. New code should use the Clojure-compatible names.
+> **Note:** `var`, `set!`, `var?`, `function?` are deprecated aliases for `atom`, `reset!`, `atom?`, `fn?`. Use the Clojure-compatible names.
 
 {% php_note() %}
-Atoms provide mutable state similar to PHP variables, but are explicit and contained:
+Atoms are explicit, contained mutable state:
 
 ```php
 // PHP - everything is mutable by default
@@ -194,6 +196,6 @@ $count++;
 (swap! count inc)
 ```
 
-Use Phel's immutable data structures when possible. Atoms are mainly useful for interop with PHP code or managing application state.
+Prefer immutable data structures. Atoms mainly for PHP interop or app state.
 {% end %}
 

--- a/content/documentation/language/interfaces.md
+++ b/content/documentation/language/interfaces.md
@@ -4,20 +4,20 @@ weight = 11
 aliases = ["/documentation/interfaces"]
 +++
 
-Interfaces define contracts - abstract sets of functions that structs must implement. They map directly to PHP interfaces, giving you interop with PHP's type system.
+Interfaces define contracts: abstract sets of functions that structs must implement. Map directly to PHP interfaces.
 
 ## Defining interfaces
 
-Use `definterface` to declare an interface with one or more methods:
+`definterface` declares one or more methods:
 
 ```phel
 (definterface Describable
   (describe [this] "Returns a human-readable description."))
 ```
 
-Each method must have at least one parameter (`this`), which binds to the struct instance at call time. An optional documentation string can follow the parameter list.
+Methods need at least `this`. Optional doc string follows the parameter list.
 
-You can define multiple methods in a single interface:
+Multiple methods per interface:
 
 ```phel
 (definterface Shape
@@ -25,15 +25,15 @@ You can define multiple methods in a single interface:
   (perimeter [this] "Computes the perimeter of the shape."))
 ```
 
-`definterface` also generates callable functions for each method, so you call `(area my-shape)` like any other function.
+Generates callable functions per method: `(area my-shape)` works like any function.
 
-> **Note:** Unlike PHP interfaces, Phel interfaces cannot extend other interfaces.
+> **Note:** Unlike PHP, Phel interfaces don't extend other interfaces.
 
-## Implementing interfaces with structs
+## Implementing with structs
 
-Structs are the only way to implement interfaces in Phel. A struct is a typed map with predefined keys, compiled to a PHP class internally.
+Only structs implement interfaces. A struct is a typed map with fixed keys, compiled to a PHP class.
 
-Add interface implementations after the field list in `defstruct`:
+Add implementations after the field list in `defstruct`:
 
 ```phel
 (defstruct circle [radius]
@@ -47,11 +47,11 @@ Add interface implementations after the field list in `defstruct`:
   (perimeter [this] (* 2 (+ width height))))
 ```
 
-Struct fields (`radius`, `width`, `height`) are directly accessible inside method bodies - no getter calls needed.
+Struct fields (`radius`, `width`, `height`) are directly accessible inside methods. No getters.
 
-### Calling interface methods
+### Calling methods
 
-Interface methods are called like regular functions, with the struct as the first argument:
+Like regular functions, struct first:
 
 ```phel
 (area (circle 5))           ; => 78.53975
@@ -63,7 +63,7 @@ Interface methods are called like regular functions, with the struct as the firs
 
 ### Multiple interfaces
 
-A struct can implement multiple interfaces. List each interface followed by its method implementations:
+A struct can implement many. List each followed by its methods:
 
 ```phel
 (definterface Describable
@@ -80,9 +80,9 @@ A struct can implement multiple interfaces. List each interface followed by its 
 (describe (circle 5))  ; => "Circle with radius 5"
 ```
 
-### Calling other methods from within a struct
+### Calling other methods on same struct
 
-Use `php/-> this` to call another method on the same struct:
+Use `php/-> this`:
 
 ```phel
 (definterface HasSummary
@@ -97,16 +97,16 @@ Use `php/-> this` to call another method on the same struct:
 
 ### Type checking
 
-Each struct gets an auto-generated predicate:
+Each struct gets a predicate:
 
 ```phel
 (circle? (circle 5))       ; => true
 (circle? (rectangle 4 6))  ; => false
 ```
 
-## Practical example: a renderer
+## Example: a renderer
 
-Interfaces shine when you have different types that share behavior:
+Interfaces shine when types share behavior:
 
 ```phel
 (definterface Renderable
@@ -136,7 +136,7 @@ Interfaces shine when you have different types that share behavior:
 
 ## Implementing PHP interfaces
 
-Since Phel interfaces compile to PHP interfaces, structs can also implement any PHP interface:
+Phel interfaces compile to PHP interfaces. Structs can implement any PHP interface:
 
 ```phel
 (defstruct json-config [data]
@@ -146,18 +146,18 @@ Since Phel interfaces compile to PHP interfaces, structs can also implement any 
 
 ## Protocols
 
-Protocols provide a flexible way to define a set of functions that can be extended to existing types without modifying them. Unlike interfaces (which require upfront implementation in `defstruct`), protocols can be extended to any type after the fact.
+Protocols extend functions to existing types without modifying them. Unlike interfaces (require `defstruct`), protocols extend to any type after the fact.
 
-### Defining a protocol
+### Defining
 
-Use `defprotocol` to define a protocol with one or more method signatures:
+`defprotocol` defines method signatures:
 
 ```phel
 (defprotocol Printable
   (to-string [this] "Converts the value to a printable string."))
 ```
 
-Each method must have at least one parameter (`this`). An optional doc string can follow the parameter list. A protocol can define multiple methods:
+Each method needs `this`. Optional doc string. Multiple methods allowed:
 
 ```phel
 (defprotocol Measurable
@@ -166,9 +166,9 @@ Each method must have at least one parameter (`this`). An optional doc string ca
   (dimensions [this] "Returns [width height] as a vector."))
 ```
 
-### Extending protocols to types
+### Extending to types
 
-Use `extend-type` to implement a protocol for a specific type:
+`extend-type` implements a protocol for one type:
 
 ```phel
 (extend-type :string
@@ -183,7 +183,7 @@ Use `extend-type` to implement a protocol for a specific type:
 (to-string 42)       ; => "int:42"
 ```
 
-Use `extend-protocol` to implement a single protocol across multiple types at once:
+`extend-protocol` implements one protocol across many types:
 
 ```phel
 (extend-protocol Printable
@@ -197,9 +197,9 @@ Use `extend-protocol` to implement a single protocol across multiple types at on
 (to-string true)    ; => "true"
 ```
 
-### Checking protocol support
+### Checking
 
-Use `satisfies?` to check if a value satisfies a protocol, and `extends?` to check if a type extends a protocol:
+`satisfies?` (value) and `extends?` (type):
 
 ```phel
 (satisfies? Printable "hello")  ; => true
@@ -209,18 +209,18 @@ Use `satisfies?` to check if a value satisfies a protocol, and `extends?` to che
 (extends? Printable :array)     ; => false
 ```
 
-### When to use protocols vs interfaces
+### Protocols vs interfaces
 
-- **Interfaces** are best when you control the type definition (structs) and want compile-time guarantees
-- **Protocols** are best when you need to add behavior to existing types or types you don't control
+- **Interfaces:** when you control the type (structs), compile-time guarantees.
+- **Protocols:** add behavior to existing types or types you don't control.
 
 ## Hierarchies
 
-Phel provides a hierarchy system for defining relationships between types or values. Hierarchies work with multimethods to enable inheritance-aware dispatch.
+Define relationships between types or values. Hierarchies + multimethods enable inheritance-aware dispatch.
 
-### Deriving relationships
+### Deriving
 
-Use `derive` to establish parent-child relationships between keywords:
+`derive` sets parent-child between keywords:
 
 ```phel
 (derive :circle :shape)
@@ -228,9 +228,9 @@ Use `derive` to establish parent-child relationships between keywords:
 (derive :square :rectangle)   ; A square is a rectangle
 ```
 
-### Querying hierarchies
+### Querying
 
-Use `isa?`, `parents`, `ancestors`, and `descendants` to query the hierarchy:
+`isa?`, `parents`, `ancestors`, `descendants`:
 
 ```phel
 (isa? :circle :shape)         ; => true
@@ -243,9 +243,9 @@ Use `isa?`, `parents`, `ancestors`, and `descendants` to query the hierarchy:
 (descendants :shape)          ; => #{:circle :rectangle :square}
 ```
 
-### Removing relationships
+### Removing
 
-Use `underive` to remove a parent-child relationship:
+`underive`:
 
 ```phel
 (underive :square :rectangle)
@@ -254,7 +254,7 @@ Use `underive` to remove a parent-child relationship:
 
 ### Empty hierarchy maps
 
-Use `make-hierarchy` to create the empty hierarchy map shape used by hierarchy-aware code. The public `derive`, `underive`, `isa?`, `parents`, `ancestors`, and `descendants` helpers operate on the global hierarchy.
+`make-hierarchy` creates the empty hierarchy shape. Public `derive`, `underive`, `isa?`, `parents`, `ancestors`, `descendants` operate on the global hierarchy.
 
 ```phel
 (make-hierarchy)
@@ -263,7 +263,7 @@ Use `make-hierarchy` to create the empty hierarchy map shape used by hierarchy-a
 
 ### Hierarchy-aware multimethod dispatch
 
-Hierarchies integrate with multimethods. When a multimethod dispatches on a value, it checks the hierarchy for parent matches:
+Multimethods check the hierarchy for parent matches when dispatching:
 
 ```phel
 (derive :circle :shape)

--- a/content/documentation/language/macros.md
+++ b/content/documentation/language/macros.md
@@ -6,20 +6,20 @@ aliases = ["/documentation/macros"]
 
 ## Macros
 
-Macros are functions that take code as input and return transformed code as output. A macro is like a function that is executed at compile time. They are useful to extend the syntax of the language itself.
+Macros are compile-time functions: take code, return transformed code. Used to extend the language's syntax.
 
-Phel's core library uses macros to define the language. For example, `defn` is a macro.
+Phel's core uses macros throughout. Example: `defn` is a macro.
 
 ```phel
 (defn add [a b] (+ a b))
 ```
-is transformed to
+transforms to:
 ```phel
 (def add (fn [a b] (+ a b)))
 ```
 
 {% php_note() %}
-Macros are **not** like PHP functions. They run at compile-time and transform code before execution:
+Macros aren't PHP functions. They run at compile-time, transforming code before execution:
 
 ```php
 // PHP - No macro system
@@ -34,18 +34,19 @@ Macros are **not** like PHP functions. They run at compile-time and transform co
 ; Expands to: (if (not false) "yes" "no") at compile time
 ```
 
-This is more powerful and safer than PHP's `eval()` or code generation.
+More powerful and safer than `eval()` or codegen.
 {% end %}
 
 ## Quote
 
-The quote operator is a special form, it returns its argument without evaluating it. Its purpose is to prevent any evaluation. Preceding a form with a single quote is a shorthand for `(quote form)`.
+`quote` returns its argument unevaluated. Single-quote prefix is shorthand for `(quote form)`.
 
 ```phel
-(quote my-sym) ; Evaluates to my-sym
-'my-sym ; Shorthand for (same as above)
+(quote my-sym) ; => my-sym
+'my-sym ; same
 ```
-Quote make macros possible, since its helps to distinguish between code and data. Literals like numbers and string evaluate to themselves.
+
+Quote distinguishes code from data, making macros possible. Literals (numbers, strings) evaluate to themselves.
 
 ```phel
 (quote 1) ; Evaluates to 1
@@ -62,19 +63,21 @@ Quote make macros possible, since its helps to distinguish between code and data
 (defmacro docstring? attributes? [params*] expr*)
 ```
 
-The `defmacro` function can be used to create a macro. It takes the same parameters as `defn`.
+`defmacro` creates a macro. Same params as `defn`.
 
-Together with `quote` and `defmacro`, it is now possible to define a custom `defn`, which is called `mydefn`:
+With `quote` and `defmacro`, define a custom `defn` called `mydefn`:
 
 ```phel
 (defmacro mydefn [name args & body]
   (list 'def name (apply list 'fn args body)))
 ```
-This macro is very simple at does not support all the feature of `defn`. But it illustrates the basics of a macro.
+Simple, doesn't cover all `defn` features, but shows the basics.
 
 ## Quasiquote
 
-For better readability of macros the `quasiquote` special form is defined. It turns the definition of macros around. Instead of quoting values that should not be evaluated, `quasiquote` marks values that should be evaluated. Every other value is not evaluated. A shorthand for `quasiquote` is the `` ` `` character. Values that should be evaluated are marked with the `unquote` function (shorthand `,`) or `unquote-splicing` function (shorthand `,@`). With quasiquote the `mydefn` macro can be expressed as
+`quasiquote` improves macro readability. Inverts quoting: marks what *should* evaluate, leaves the rest unevaluated. Shorthand: `` ` `` (quasiquote), `,` (unquote), `,@` (unquote-splicing).
+
+`mydefn` with quasiquote:
 
 ```phel
 (defmacro mydefn [name args & body]

--- a/content/documentation/language/namespaces.md
+++ b/content/documentation/language/namespaces.md
@@ -6,13 +6,13 @@ aliases = ["/documentation/namespaces"]
 
 ## Namespace (ns)
 
-Every Phel file is required to have a namespace. A valid namespace name starts with a letter, followed by any number of letters, numbers, or dashes. Individual parts of the namespace are separated by the `\` character. The last part of the namespace has to match the name of the file.
+Every Phel file needs a namespace. Names start with a letter, then letters/numbers/dashes. Parts separated by `\`. Last part must match filename.
 
 ```phel
 (ns name imports*)
 ```
 
-Defines the namespace for the current file and adds imports to the environment. Imports can either be _uses_ or _requires_. The keyword `:use` is used to import PHP classes, the keyword `:require` is used to import Phel modules and the keyword `:require-file` is used to load php files.
+Sets the namespace and registers imports. `:use` for PHP classes, `:require` for Phel modules, `:require-file` for PHP files.
 
 ```phel
 (ns my\custom\module
@@ -21,10 +21,10 @@ Defines the namespace for the current file and adds imports to the environment. 
   (:use Some\Php\Class))
 ```
 
-The call also sets the `*ns*` variable to the given namespace.
+Also sets `*ns*` to the namespace.
 
 {% php_note() %}
-Phel namespaces are similar to PHP namespaces, but with key differences:
+Similar to PHP namespaces, with differences:
 
 ```php
 // PHP
@@ -38,24 +38,24 @@ use My\Phel\Module as Utilities;
   (:require my\phel\module :as utilities))
 ```
 
-**Key differences:**
-- Phel uses `\` as separator (like PHP)
+**Differences:**
+- `\` separator (like PHP)
 - `:require` for Phel modules, `:use` for PHP classes
-- Functions/values are accessed with `/` not `::`
+- Access via `/`, not `::`
 {% end %}
 
 {% clojure_note() %}
-Namespaces work similarly to Clojure, but:
-- Use `\` instead of `.` as separator (following PHP conventions)
-- `:use` is for PHP classes (not Clojure vars)
-- `:require` works like Clojure's `:require`
+Like Clojure, but:
+- `\` separator instead of `.` (PHP convention)
+- `:use` is for PHP classes
+- `:require` works as in Clojure
 {% end %}
 
 ### Import a Phel module
 
-Before a Phel module can be used, it has to be imported with the keyword `:require`. Once imported, the module can be accessed by its name followed by a slash and the name of the public function or value. Namespaces are indexed from source file directory which is `src/` by default and can changed with [SrcDirs configuration option](/documentation/configuration/#srcdirs) in `phel-config.php`.
+Import with `:require`, then access as `module/name`. Namespaces resolve from `src/` (override with [SrcDirs](/documentation/configuration/#srcdirs)).
 
-Given, a module `util` is defined in the namespace `hello-world`.
+Module `util` in namespace `hello-world`:
 
 ```phel
 (ns hello-world\util)
@@ -66,7 +66,7 @@ Given, a module `util` is defined in the namespace `hello-world`.
   (print (str "Hello, " name)))
 ```
 
-Module `boot` imports module `util` and uses its functions and values.
+Module `boot` imports `util`:
 
 ```phel
 (ns hello-world\boot
@@ -75,14 +75,14 @@ Module `boot` imports module `util` and uses its functions and values.
 (util/greet util/my-name)
 ```
 
-To prevent name collision from other modules in different namespaces, aliases can be used.
+Use aliases to avoid collisions:
 
 ```phel
 (ns hello-world\boot
   (:require hello-world\util :as utilities))
 ```
 
-When names collide, names from different namespaces remain available by prefixing them with a namespace identifier (such as `phel\core`). However, care should be taken when referring to names before redefining them, as the names retain their values from the original namespaces before the redefinition.
+On collision, prefix with the namespace (e.g. `phel\core`). Names retain values from their original namespace before redefinition.
 
 ```phel
 (ns hello-world\http-client)
@@ -93,7 +93,7 @@ When names collide, names from different namespaces remain available by prefixin
 (phel\core/get (get "https://example.com") :status) ; Evaluates to 200
 ```
 
-Additionally, it is possible to refer symbols of other modules in the current namespace by using `:refer` keyword.
+`:refer` brings symbols into the current namespace:
 
 ```phel
 (ns hello-world\boot
@@ -102,31 +102,31 @@ Additionally, it is possible to refer symbols of other modules in the current na
 (greet util/my-name)
 ```
 
-Both, `:refer` and `:as` can be combined in any order.
+`:refer` and `:as` combine in any order.
 
 ### Import a PHP class
 
-PHP classes are imported with the keyword `:use`.
+`:use` imports PHP classes:
 
 ```phel
 (ns my\custom\module
   (:use Some\Php\ClassName)
 ```
 
-Once imported, a class can be referenced by its name.
+Reference by name:
 
 ```phel
 (php/new ClassName)
 ```
 
-To prevent name collision from other classes in different namespaces, aliases can be used.
+Aliases avoid collisions:
 
 ```phel
 (ns my\custom\module
   (:use Some\Php\ClassName :as BetterClassName)
 ```
 
-Importing PHP classes is considered a "better" coding style, but it is optional. Any PHP class can be used by typing its namespace with the class name.
+Importing is preferred, but optional. Use full namespace inline if needed:
 
 ```phel
 (php/new \Some\Php\ClassName)
@@ -134,33 +134,33 @@ Importing PHP classes is considered a "better" coding style, but it is optional.
 
 ## Require PHP files
 
-In some cases it is necessary to load external PHP file via PHP's `require_once` statement. This can be archived by using the `:require-file` keyword. For example, to load composer's autoload file the following code can be used:
+Load external PHP files via `:require-file` (calls `require_once`). Example for Composer autoload:
 
 ```
 (ns hello-world\boot
   (:require-file "vendor/autoload.php"))
 ```
 
-As alternative, you can also call `(php/require_once "vendor/autload.php")` anywhere in your code. However, especially for the autoload file this statement is executed to late, because Phel's core library needs to load PHP files via the autoloader. Therefore, it is recommended to use the `:require-file` method.
+`(php/require_once "vendor/autoload.php")` works elsewhere, but for autoload it runs too late since Phel's core needs the autoloader. Use `:require-file`.
 
 ## Namespaced keywords
 
-If code or data is shared to the outside world simple keywords can lead to collisions. This problem can be solved by using namespaced keywords.
+Plain keywords collide when sharing data. Namespaced keywords solve this.
 
-There are multiple options to define namespaced keywords. The most simple one is to define a fully qualified keyword with the full namespace followed by a `/` and the keyword name.
+Fully qualified: namespace, `/`, keyword name.
 
 ```phel
-:my\namespace/foo ; a absolute namespaced keyword
+:my\namespace/foo ; absolute namespaced keyword
 ```
 
-The `::` shortcut can be used to assign the current namespace to the keyword
+`::` shortcut binds current namespace:
 
 ```phel
 (ns bar)
-::foo ; Evaluates to :bar/foo
+::foo ; => :bar/foo
 ```
 
-Aliases defined in the `ns` expression can also be used
+`ns` aliases also work:
 
 ```phel
 (ns foobar

--- a/content/documentation/language/truth-and-boolean-operations.md
+++ b/content/documentation/language/truth-and-boolean-operations.md
@@ -6,9 +6,9 @@ aliases = ["/documentation/truth-and-boolean-operations"]
 
 ## Truthiness
 
-In Phel, only `false` and `nil` represent falsity. Everything else evaluates to true-including `0`, `""`, and `[]`.
+Only `false` and `nil` are falsy. `0`, `""`, `[]` all truthy.
 
-The function `truthy?` can be used to check if a value is truthy. To check for the values `true` and `false` specifically, the functions `true?` and `false?` can be used.
+`truthy?` checks truthiness. `true?` and `false?` check for the values themselves.
 
 ```phel
 (truthy? false) ; Evaluates to false
@@ -44,9 +44,9 @@ if ([]) { }       // false - won't execute
 ```
 {% end %}
 
-## Identity vs Equality
+## Identity vs equality
 
-The function `identical?` returns `true` if two values are identical. Identity is stricter than equality. It first checks if both types are identical and then compares their values. Phel keywords and symbols with the same names are always identical. Lists, vectors, maps and sets are only identical if they point to the same references.
+`identical?` returns `true` if two values are identical. Stricter than equality: types match, then values. Keywords/symbols with same name always identical. Lists, vectors, maps, sets identical only if same reference.
 
 ```phel
 (identical? true true)   ; Evaluates to true
@@ -59,9 +59,9 @@ The function `identical?` returns `true` if two values are identical. Identity i
 (identical? {} {})       ; Evaluates to false
 ```
 
-> **Note:** `id` is still accepted as a deprecated alias for `identical?`.
+> **Note:** `id` is a deprecated alias for `identical?`.
 
-To check if two values are equal, the equal function (`=`) can be used. Two values are equal if they have the same type and value. Lists, vectors, maps and sets are equal if they have same values, but they must not point to the same references.
+`=` checks equality: same type and value. Collections equal if values match (no reference check).
 
 ```phel
 (= true true) ; Evaluates to true
@@ -76,16 +76,16 @@ To check if two values are equal, the equal function (`=`) can be used. Two valu
 (= {} {}) ; Evaluates to true
 ```
 
-To check if two values are unequal, the `not=` function can be used.
+Use `not=` for inequality.
 
 {% php_note() %}
-**Comparison with PHP operators:**
+**vs PHP operators:**
 
-- `identical?` is like PHP's `===` (identity/strict equality) with support for Phel types
-- `=` is **not** like PHP's `==` (loose equality)
-- `=` compares Phel values structurally with type checking
+- `identical?` like `===` (strict, with Phel types)
+- `=` is **not** like `==` (loose)
+- `=` compares structurally with type checking
 
-If you need PHP's loose equality, use `php/==`:
+PHP loose equality: use `php/==`:
 
 ```phel
 (php/== 5 "5")      ; => true (PHP loose equality)
@@ -94,18 +94,16 @@ If you need PHP's loose equality, use `php/==`:
 ```
 {% end %}
 
-## Comparison Operations
+## Comparisons
 
-Further comparison function are:
+- `<=`: each arg ≤ next, returns bool
+- `<`: each arg strictly < next, returns bool
+- `>=`: each arg ≥ next, returns bool
+- `>`: each arg strictly > next, returns bool
 
-- `<=`: Checks if each argument is less than or equal to the following argument. Returns a boolean.
-- `<`: Checks if each argument is strictly less than the following argument. Returns a boolean.
-- `>=`: Checks if each argument is greater than or equal to the following argument. Returns a boolean.
-- `>`: Checks if each argument is strictly greater than the following argument. Returns a boolean.
+## Logical operations
 
-## Logical Operations
-
-The `and` function evaluates each expression one at a time, from left to right. If a form returns logical false, `and` returns that value and doesn't evaluate any of the other expressions, otherwise it returns the value of the last expression. Calling the `and` function without arguments returns true.
+`and` evaluates left-to-right. Returns first falsy or the last value. No args returns true.
 
 ```phel
 (and) ; Evaluates to true
@@ -115,7 +113,7 @@ The `and` function evaluates each expression one at a time, from left to right. 
 (and true 5) ; Evaluates to 5
 ```
 
-The `or` function evaluates each expression one at a time, from left to right. If a form returns a logical true value, `or` returns that value and doesn't evaluate any of the other expressions, otherwise it returns the value of the last expression. Calling `or` without arguments, returns nil.
+`or` evaluates left-to-right. Returns first truthy or the last value. No args returns nil.
 
 ```phel
 (or) ; Evaluates to nil
@@ -123,7 +121,7 @@ The `or` function evaluates each expression one at a time, from left to right. I
 (or false 5) ; Evaluates to 5
 ```
 
-The `not` function returns `true` if the given value is logical false and `false` otherwise.
+`not` returns `true` for falsy values, `false` otherwise.
 
 ```phel
 (not 1) ; Evaluates to false

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -3,16 +3,16 @@ title = "PHP Interop"
 weight = 50
 +++
 
-## Accessing global variables and named constants
+## Globals and constants
 
-Use the `php/` prefix to access the global variables (superglobals) in combination with `get`.
+Access PHP superglobals with `php/` prefix and `get`:
 
 ```phel
-(get php/$_SERVER "key") ; Similar to $_SERVER['key']
-(get php/$GLOBALS "argv") ; Similar to $GLOBALS['argv']
+(get php/$_SERVER "key") ; $_SERVER['key']
+(get php/$GLOBALS "argv") ; $GLOBALS['argv']
 ```
 
-Named constants set with PHP [`define`](https://www.php.net/manual/en/function.define.php) can be accessed in Phel via `php/CONSTANT_NAME`.
+PHP [`define`](https://www.php.net/manual/en/function.define.php) constants accessed via `php/CONSTANT_NAME`:
 
 ```phel
 (php/define "MY_SETTING" "My value") ; Calls PHP define('MY_SETTING', 'My value");
@@ -39,7 +39,7 @@ php/MY_SETTING
 
 ## Calling PHP functions
 
-PHP comes with huge set of functions that can be called from Phel by just adding a `php/` prefix to the function name.
+Add `php/` prefix to any PHP function name:
 
 ```phel
 (php/strlen "test") ; Calls PHP's strlen function and evaluates to 4
@@ -64,22 +64,22 @@ array_map($fn, $array);
 However, Phel provides functional equivalents for many operations. For example, use `(count "test")` instead of `(php/strlen "test")` when working with Phel data structures.
 {% end %}
 
-Namespaced PHP functions are called with their full path after `php/`:
+Namespaced PHP functions use full path after `php/`:
 
 ```phel
 (php/Amp\trapSignal [(php/:: SIGINT) (php/:: SIGTERM)])
 ```
 
-You can also capture a namespaced function into a Phel alias:
+Capture into a Phel alias:
 
 ```phel
 (def trap-signal php/\Amp\trapSignal)
 (trap-signal [2 15])
 ```
 
-## PHP interop shorthands
+## Interop shorthands
 
-Terse shorthands that expand to the verbose `php/*` forms below. Use whichever form reads better in context.
+Terse forms that expand to verbose `php/*`. Use whichever reads better.
 
 | Shorthand                       | Expands to                          |
 |---------------------------------|-------------------------------------|
@@ -102,13 +102,13 @@ Terse shorthands that expand to the verbose `php/*` forms below. Use whichever f
 
 `(ClassName. args)` constructor shorthand also works.
 
-## PHP class instantiation
+## Class instantiation
 
 ```phel
 (php/new expr args*)
 ```
 
-Evaluates `expr` and creates a new PHP class using the arguments. The instance of the class is returned.
+Evaluates `expr`, creates instance with `args`, returns it.
 
 ```phel
 (ns my\module
@@ -138,16 +138,16 @@ new \DateTimeImmutable();
 You can import classes with `:use` to avoid repeating the namespace, just like PHP's `use` statement.
 {% end %}
 
-## PHP method and property call
+## Method and property call
 
 ```phel
 (php/-> object (methodname expr*))
 (php/-> object property)
 ```
 
-Calls a method or property on a PHP object. Both `methodname` and `property` must be symbols and cannot be an evaluated value.
+Calls method or accesses property. Both `methodname` and `property` must be symbols, not evaluated values.
 
-You can chain multiple method calls or property accesses in one `php/->` expression. Each element is evaluated sequentially on the result of the previous call, allowing fluent-style interactions or access to nested properties.
+Chain multiple in one `php/->`. Each element evaluates on result of previous, enabling fluent chains or nested property access.
 
 ```phel
 (ns my\module)
@@ -200,14 +200,14 @@ Method calls use parentheses `(methodname args)`, while property access is just 
 The `php/->` operator is inspired by Clojure's thread-first macro `->`, but specifically designed for PHP object method chaining.
 {% end %}
 
-## PHP static method and property call
+## Static method and property
 
 ```phel
 (php/:: class (methodname expr*))
 (php/:: class property)
 ```
 
-Same as above, but for static calls on PHP classes.
+Same as above, but static.
 
 ```phel
 (ns my\module
@@ -233,14 +233,14 @@ DateTimeImmutable::createFromFormat("Y-m-d", "2020-03-22");
 ```
 {% end %}
 
-## PHP set object properties
+## Set object properties
 
 ```phel
 (php/oset (php/-> object property) value)
 (php/oset (php/:: class property) value)
 ```
 
-Use `php/oset` to set a value to a class/object property.
+Set value on class/object property.
 
 ```phel
 (def x (php/new \stdclass))
@@ -263,13 +263,13 @@ $x->name = "foo";
 **Note:** This mutates the PHP object. When possible, use Phel's immutable data structures instead.
 {% end %}
 
-## Get PHP-Array value
+## Get PHP array value
 
 ```phel
 (php/aget arr index)
 ```
 
-Equivalent to PHP's `arr[index] ?? null`.
+Equivalent: `arr[index] ?? null`.
 
 ```phel
 (php/aget ["a" "b" "c"] 0) ; Evaluates to "a"
@@ -297,15 +297,13 @@ $arr[5] ?? null;  // Returns null
 - Use `get` for **Phel data structures** (immutable vectors, maps)
 {% end %}
 
-## Get nested PHP-Array value
+## Get nested PHP array value
 
 ```phel
 (php/aget-in arr path)
 ```
 
-Resolves nested values in a PHP array using a sequence of keys or indexes. The
-`path` must be a sequential collection such as a vector. If any step in the
-path is missing, `nil` is returned.
+Resolves nested values via a sequence of keys/indexes. `path` is a sequential collection (e.g. vector). Missing step returns `nil`.
 
 ```phel
 (def users
@@ -344,13 +342,13 @@ $data['meta']['missing'] ?? null;
 This is similar to Phel's `get-in` for immutable data structures, but specifically for PHP arrays.
 {% end %}
 
-## Set PHP-Array value
+## Set PHP array value
 
 ```phel
 (php/aset arr index value)
 ```
 
-Equivalent to PHP's `arr[index] = value`.
+Equivalent: `arr[index] = value`.
 
 {% php_note() %}
 `php/aset` mutates a PHP array in place:
@@ -366,14 +364,13 @@ $arr[0] = "value";
 **Important:** This mutates the array. For immutable operations, use Phel's `assoc` on Phel data structures instead.
 {% end %}
 
-## Set nested PHP-Array value
+## Set nested PHP array value
 
 ```phel
 (php/aset-in arr path value)
 ```
 
-Creates or updates nested entries inside a PHP array. Intermediate arrays are
-created as needed to ensure the path exists before writing the value.
+Creates or updates nested entries. Missing intermediate arrays are created.
 
 ```phel
 (def data (php/array))
@@ -398,13 +395,13 @@ $data['user']['profile']['name'] = 'Charlie';
 This is the mutable counterpart to Phel's `assoc-in` for immutable data structures.
 {% end %}
 
-## Append PHP-Array value
+## Append PHP array value
 
 ```phel
 (php/apush arr value)
 ```
 
-Equivalent to PHP's `arr[] = value`.
+Equivalent: `arr[] = value`.
 
 {% php_note() %}
 `php/apush` appends to a PHP array:
@@ -420,13 +417,13 @@ $arr[] = "new value";
 For immutable operations, use `conj` on Phel vectors instead.
 {% end %}
 
-## Unset PHP-Array value
+## Unset PHP array value
 
 ```phel
 (php/aunset arr index)
 ```
 
-Equivalent to PHP's `unset(arr[index])`.
+Equivalent: `unset(arr[index])`.
 
 {% php_note() %}
 `php/aunset` removes an element from a PHP array:
@@ -442,14 +439,13 @@ unset($arr[0]);
 For immutable operations, use `dissoc` on Phel maps instead.
 {% end %}
 
-## Unset nested PHP-Array value
+## Unset nested PHP array value
 
 ```phel
 (php/aunset-in arr path)
 ```
 
-Removes a nested entry in a PHP array. Once the value is removed, parent arrays
-remain untouched even if they become empty.
+Removes nested entry. Parent arrays remain untouched even if empty after.
 
 ```phel
 (def data (php/array "user" (php/array "profile" (php/array "name" "Dora"))))
@@ -472,17 +468,11 @@ unset($data['user']['profile']['name']);
 Parent arrays remain intact even if they become empty after the unset.
 {% end %}
 
-## `__DIR__`, `__FILE__`, and `*file*`
+## `__DIR__`, `__FILE__`, `*file*`
 
-In Phel you can also use PHP Magic Methods `__DIR__` and `__FILE__`. When the
-compiler runs, these constants are expanded by PHP and therefore point to the
-generated PHP file that is executed (e.g. the temporary file under
-`.phel/cache`).
+PHP magic constants `__DIR__` and `__FILE__` work but expand at PHP compile, pointing to the generated PHP file under `.phel/cache`.
 
-Sometimes you need the path of the original Phel source file instead. For that
-Phel exposes the special var `*file*`, which contains the absolute path of the
-current Phel file. Combine it with `php/dirname` if you need the source
-directory.
+For the original Phel source path, use `*file*` (absolute path of current Phel file). Combine with `php/dirname` for the source dir.
 
 ```phel
 (println __DIR__)  ; Directory name of the generated PHP file
@@ -507,12 +497,11 @@ __FILE__  // Points to cached .php file
 Use `*file*` when you need to reference the original Phel source location, such as for loading resources relative to your source code.
 {% end %}
 
-## Calling Phel functions from PHP
+## Calling Phel from PHP
 
-Phel also provides a way to let you call Phel functions from PHP. This is useful for existing PHP application that wants to integrate Phel.
-Therefore, you have to load the Phel namespace that you want to call at the beginning of your script. This can be done directly after the `autoload.php` file was loaded.
+Useful for integrating Phel into existing PHP apps. Load the Phel namespace after `autoload.php`.
 
-For example, see [using-exported-phel-function.php](https://github.com/phel-lang/cli-skeleton/blob/main/example/using-exported-phel-function.php)
+Example: [using-exported-phel-function.php](https://github.com/phel-lang/cli-skeleton/blob/main/example/using-exported-phel-function.php)
 
 ```php
 <?php
@@ -532,12 +521,11 @@ $result = $adder->adder(1, 2, 3);
 echo 'Result = ' . $result . PHP_EOL;
 ```
 
-Phel provide two ways to call Phel functions, manually or by using the `export` command.
+Two ways: manually, or via the `export` command.
 
 ### Manually
 
-The `PhelCallerTrait` can be used to call any Phel function from an existing PHP class.
-Simply inject the trait in the class and call the `callPhel` function.
+`PhelCallerTrait` calls any Phel function from a PHP class. Inject the trait, call `callPhel`.
 
 ```php
 <?php
@@ -558,9 +546,9 @@ class MyExistingClass {
 
 ### Using the `export` command
 
-Alternatively, the `phel export` command can be used. This command will generate a wrapper class for all Phel functions that are marked as *export*.
+`phel export` generates a wrapper class for all Phel functions marked *export*.
 
-Before using the `export` command the required configuration options need to be added to `phel-config.php`:
+Add config to `phel-config.php` first:
 
 ```php
 <?php
@@ -572,9 +560,9 @@ return (new \Phel\Config\PhelConfig())
 ;
 ```
 
-A detailed description of the options can be found in the [Configuration](/documentation/configuration/#exportconfig) chapter.
+Option details: [Configuration](/documentation/configuration/#exportconfig).
 
-To mark a function as exported the following metadata needs to be added to the function:
+Mark a function exported with metadata:
 
 ```phel
 (defn my-function
@@ -583,4 +571,4 @@ To mark a function as exported the following metadata needs to be added to the f
   (+ a b))
 ```
 
-Now the `phel export` command will generate a PHP wrapper class in the target directory (in this case `src/PhelGenerated`). This class can then be used in the PHP application to call Phel functions.
+`phel export` then generates a wrapper class in the target dir (here `src/PhelGenerated`). Use it from PHP to call Phel functions.

--- a/content/documentation/reference/_index.md
+++ b/content/documentation/reference/_index.md
@@ -6,4 +6,4 @@ insert_anchor_links = "right"
 template = "section-page.html"
 +++
 
-Quick-reference material, the full API documentation, and community projects built with Phel.
+Quick reference, full API docs, community projects.

--- a/content/documentation/reference/agentic-coding.md
+++ b/content/documentation/reference/agentic-coding.md
@@ -5,22 +5,22 @@ description = "Single-page Phel reference for AI coding agents (Claude Code, Cod
 aliases = ["/documentation/llms", "/documentation/ai-agents"]
 +++
 
-A single page designed for AI coding agents (Claude Code, Codex, Cursor, Copilot, Aider, Gemini) to learn Phel without crawling the rest of the docs. Humans pairing with an agent will also find it useful.
+Single-page reference for AI agents (Claude Code, Codex, Cursor, Copilot, Aider, Gemini) to learn Phel without crawling the docs. Humans pairing with an agent benefit too.
 
-If you only have time to load one doc into an agent's context, load this one.
+Load this one if you can only load one doc into an agent's context.
 
-## What Phel Is
+## What Phel is
 
-Phel is a functional Lisp that compiles to PHP. It runs on any PHP 8.4+ runtime, ships through Composer, and interops fully with PHP libraries.
+Functional Lisp that compiles to PHP. Runs on any PHP 8.4+, ships via Composer, full PHP interop.
 
-- Immutable persistent data structures by default.
-- Macros, homoiconicity, REPL-driven development.
+- Immutable persistent data structures.
+- Macros, homoiconicity, REPL-driven dev.
 - Compiles to plain PHP. No separate runtime, no JVM.
-- Source files: `.phel`. Project config: `phel-config.php`.
+- Source: `.phel`. Config: `phel-config.php`.
 
-## Verify Before You Generate
+## Verify before you generate
 
-Before suggesting code, verify against the running install:
+Verify against the install before suggesting code:
 
 ```bash
 vendor/bin/phel doc <fn>          # function signature + docstring
@@ -33,20 +33,20 @@ vendor/bin/phel format <file>      # rewrite formatting
 vendor/bin/phel doctor             # env + extension check
 ```
 
-If a function name is uncertain, run `phel doc` or grep `vendor/phel-lang/phel-lang/src/php/Lang/` and `vendor/phel-lang/phel-lang/src/phel/core/`. Do not invent function names.
+Uncertain function name? Run `phel doc` or grep `vendor/phel-lang/phel-lang/src/php/Lang/` and `vendor/phel-lang/phel-lang/src/phel/core/`. Don't invent function names.
 
-## Installed Agent Skills
+## Installed agent skills
 
-The Phel package ships skill adapters in `vendor/phel-lang/phel-lang/.agents/`. Install for the active agent:
+Phel ships skill adapters in `vendor/phel-lang/phel-lang/.agents/`. Install for the active agent:
 
 ```bash
 vendor/bin/phel agent-install claude    # or codex, cursor, copilot, aider, gemini
 vendor/bin/phel agent-install --all     # every adapter
 ```
 
-The `.agents/` tree contains: `RULES.md`, `index.md` (intent map), `tasks/*.md` (recipes for HTTP apps, CLI tools, tests, REPL flow, validation, etc.), and `examples/`. Prefer it over guessing.
+`.agents/` contains: `RULES.md`, `index.md` (intent map), `tasks/*.md` (HTTP apps, CLI tools, tests, REPL flow, validation), `examples/`. Prefer it over guessing.
 
-## Syntax in 60 Seconds
+## Syntax in 60 seconds
 
 ```phel
 ;; Inline comment uses one semicolon.
@@ -178,7 +178,7 @@ Class/CONST
 (defmethod area :rect   [{:w w :h h}] (* w h))
 ```
 
-## Truthiness, Equality, Comments
+## Truthiness, equality, comments
 
 - Only `false` and `nil` are falsy. `0`, `""`, `[]`, `{}` are all truthy.
 - `=` is value equality across all types. `identical?` is reference equality.
@@ -204,22 +204,22 @@ Class/CONST
 
 Run with `vendor/bin/phel test`.
 
-## Common Gotchas
+## Common gotchas
 
-Read these once. They cover most failure modes agents hit.
+Most failure modes agents hit:
 
-1. **CLI args**: use `*argv*` (vector of strings, post-script-path), not `php/$argv` (which is `null` under `phel run`).
-2. **`for` vs `doseq`**: `for` builds a lazy sequence. Use `doseq` for side effects (logging, printing, IO).
-3. **`transduce` with `max`/`min`**: they have no zero-arity, so wrap and pass init: `(transduce xf (fn [a b] (max a b)) 0 coll)`.
-4. **Top-level side effects break `phel build`**: guard with `(when-not *build-mode* ...)`.
-5. **Records access by keyword**: `(get p :x)`, not `(.-x p)`.
-6. **PHP arrays are not Phel collections**: convert with `vec` or `to-php-array`. There is no `to-vec` or `to-list`.
-7. **Namespace must have at least two segments**: `(ns app\main)`, not `(ns main)`.
-8. **String module is `phel\string`** (renamed from `phel\str`).
-9. **PHP assoc literal**: `#php {"k" "v"}`, not `{:k "v"}`. Phel maps are not PHP arrays.
+1. **CLI args:** use `*argv*` (vector of strings, post-script-path). `php/$argv` is `null` under `phel run`.
+2. **`for` vs `doseq`:** `for` builds a lazy sequence. `doseq` for side-effects (logging, IO).
+3. **`transduce` with `max`/`min`:** no zero-arity. Wrap and pass init: `(transduce xf (fn [a b] (max a b)) 0 coll)`.
+4. **Top-level side-effects break `phel build`:** guard with `(when-not *build-mode* ...)`.
+5. **Record access by keyword:** `(get p :x)`, not `(.-x p)`.
+6. **PHP arrays aren't Phel collections:** convert with `vec` or `to-php-array`. No `to-vec`/`to-list`.
+7. **Namespaces need ≥2 segments:** `(ns app\main)`, not `(ns main)`.
+8. **String module:** `phel\string` (renamed from `phel\str`).
+9. **PHP assoc literal:** `#php {"k" "v"}`, not `{:k "v"}`. Phel maps aren't PHP arrays.
 10. **`recur` only in tail position** of `loop` or `fn`.
 
-## Project Layout
+## Project layout
 
 ```
 my-app/
@@ -239,36 +239,36 @@ Minimal `phel-config.php`:
 return \Phel\Config\PhelConfig::forProject('my-app\main');
 ```
 
-Full options in [Configuration](/documentation/configuration).
+Full options: [Configuration](/documentation/configuration).
 
-## Authoring Guidelines for Agents
+## Authoring guidelines for agents
 
 When generating Phel code:
 
-1. **Verify, don't invent.** Run `phel doc <fn>` or grep `src/phel/core/` before using a function name you are unsure about.
-2. **Prefer pure functions.** Push side effects to the edge. Use `atom` only when you genuinely need shared mutable state.
-3. **Thread, don't nest.** `(->> xs (filter f) (map g) (reduce h 0))` beats nested calls four levels deep.
-4. **Reach for the right comprehension.** `for` returns data, `doseq` runs effects, `dotimes` repeats, `loop`/`recur` accumulates.
-5. **Stay immutable.** `(conj v x)` returns a new vector; rebind it. Do not expect in-place mutation.
-6. **Match comment style.** `;` inline, `;;` standalone. The `#` line comment form is deprecated.
-7. **Avoid em-dashes** in any Phel docstrings or generated docs for this site. Prefer commas, colons, periods, or parentheses.
-8. **Conventional commits.** `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`. No mention of AI / LLM authorship in commit messages.
+1. **Verify, don't invent.** Run `phel doc <fn>` or grep `src/phel/core/` before using an uncertain name.
+2. **Prefer pure functions.** Push side-effects to the edge. Use `atom` only for shared mutable state.
+3. **Thread, don't nest.** `(->> xs (filter f) (map g) (reduce h 0))` beats deep nesting.
+4. **Right comprehension:** `for` returns data, `doseq` runs effects, `dotimes` repeats, `loop`/`recur` accumulates.
+5. **Stay immutable.** `(conj v x)` returns a new vector. Rebind, don't expect mutation.
+6. **Comment style:** `;` inline, `;;` standalone. `#` line comments deprecated.
+7. **No em-dashes** in docstrings or generated site docs. Prefer commas, colons, periods, parentheses.
+8. **Conventional commits.** `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`. No AI/LLM authorship references.
 
-## Where to Look Next
+## Where to look next
 
-Inside the Phel install:
+In the Phel install:
 
 - `vendor/phel-lang/phel-lang/.agents/index.md`: intent → recipe map.
-- `vendor/phel-lang/phel-lang/.agents/RULES.md`: canonical rule set + CLI map.
-- `vendor/phel-lang/phel-lang/.agents/tasks/`: recipes for HTTP, CLI, tests, debugging, validation, pattern matching.
-- `vendor/phel-lang/phel-lang/src/phel/core/`: source of every core function.
+- `vendor/phel-lang/phel-lang/.agents/RULES.md`: canonical rules + CLI map.
+- `vendor/phel-lang/phel-lang/.agents/tasks/`: HTTP, CLI, tests, debugging, validation, pattern matching.
+- `vendor/phel-lang/phel-lang/src/phel/core/`: every core function source.
 
 On this site:
 
-- [Cheat Sheet](/documentation/reference/cheat-sheet): full filterable list of core forms and functions.
-- [Language section](/documentation/language/): one page per concept (types, functions, control flow, macros, interfaces, namespaces, destructuring, recursion).
-- [PHP Interop](/documentation/php-interop): every interop form in detail.
-- [Cookbook](/documentation/guides/cookbook): copy-paste recipes for real tasks.
-- [Rosetta Stone](/documentation/guides/rosetta-stone): PHP → Phel patterns side by side.
-- [REPL guide](/documentation/tooling/repl): development loop.
+- [Cheat Sheet](/documentation/reference/cheat-sheet): filterable forms and functions.
+- [Language section](/documentation/language/): types, functions, control flow, macros, interfaces, namespaces, destructuring, recursion.
+- [PHP Interop](/documentation/php-interop): every interop form.
+- [Cookbook](/documentation/guides/cookbook): copy-paste recipes.
+- [Rosetta Stone](/documentation/guides/rosetta-stone): PHP to Phel side-by-side.
+- [REPL guide](/documentation/tooling/repl): dev loop.
 - [CLI Commands](/documentation/tooling/cli-commands): every subcommand.

--- a/content/documentation/reference/cheat-sheet.md
+++ b/content/documentation/reference/cheat-sheet.md
@@ -7,9 +7,9 @@ aliases = ["/documentation/cheat-sheet"]
 scripts = ["cheat-sheet-filter.js"]
 +++
 
-A quick reference for Phel syntax and core functions.
+Quick reference for Phel syntax and core functions.
 
-## Basic Syntax
+## Basic syntax
 
 ```phel
 ; This is a comment
@@ -25,11 +25,11 @@ my-var my-module/fn     ; symbols
 #"[a-z]+"               ; regex literal (PCRE pattern)
 ```
 
-> **Note:** The `#` line comment and `#| |#` multiline comment syntax are deprecated. Use `;` for comments instead.
+> **Note:** `#` line and `#| |#` multiline comments are deprecated. Use `;`.
 
 See [Basic Types](/documentation/language/basic-types), [Truth and Boolean Operations](/documentation/language/truth-and-boolean-operations).
 
-## Reader Syntax
+## Reader syntax
 
 ```phel
 @my-var                 ; shorthand for (deref my-var)
@@ -41,11 +41,11 @@ See [Basic Types](/documentation/language/basic-types), [Truth and Boolean Opera
 #?@(:phel [a b] :default [c])  ; splicing reader conditional
 ```
 
-The `#(...)` anonymous function shorthand is the preferred form. Use `%` or `%1` for the first argument, `%2` for the second, and `%&` for variadic rest args. The legacy `|(...)` form with `$` placeholders is still accepted but deprecated.
+`#(...)` is the preferred shorthand. `%` or `%1` first arg, `%2` second, `%&` rest. Legacy `|(...)` with `$` is deprecated.
 
-Reader conditionals (`#?()` and `#?@()`) allow code to be shared across `.cljc` files with platform-specific branches using `:phel` and `:default` keys.
+Reader conditionals (`#?()`, `#?@()`) target platforms in `.cljc` via `:phel` and `:default`.
 
-## Data Structures
+## Data structures
 
 ```phel
 [1 2 3]                 ; vector (indexed)
@@ -61,7 +61,7 @@ Reader conditionals (`#?()` and `#?@()`) allow code to be shared across `.cljc` 
 
 See [Data Structures](/documentation/language/data-structures).
 
-## Accessing Data
+## Accessing data
 
 ```phel
 (get [1 2 3] 0)           ; => 1
@@ -76,7 +76,7 @@ See [Data Structures](/documentation/language/data-structures).
 ([10 20 30] 1)             ; => 20 (vector as function)
 ```
 
-## Modifying Data
+## Modifying data
 
 ```phel
 (conj [1 2] 3)                    ; => [1 2 3]
@@ -122,7 +122,7 @@ See [Data Structures](/documentation/language/data-structures).
 
 See [Destructuring](/documentation/language/destructuring).
 
-## Defining Things
+## Defining things
 
 ```phel
 (def pi 3.14159)                  ; global binding
@@ -174,7 +174,7 @@ See [Global and Local Bindings](/documentation/language/global-and-local-binding
 
 See [Functions and Recursion](/documentation/language/functions-and-recursion).
 
-## Control Flow
+## Control flow
 
 ```phel
 (if (> x 0) "pos" "non-pos")      ; if/else
@@ -194,7 +194,7 @@ See [Functions and Recursion](/documentation/language/functions-and-recursion).
 
 See [Control Flow](/documentation/language/control-flow).
 
-## Loops & Recursion
+## Loops & recursion
 
 ```phel
 (loop [acc 0 n 10]                 ; loop with recur
@@ -244,7 +244,7 @@ See [Functions and Recursion](/documentation/language/functions-and-recursion), 
 
 See [Data Structures](/documentation/language/data-structures).
 
-## Walking Data Structures
+## Walking data structures
 
 ```phel
 (postwalk f nested)                ; transform bottom-up
@@ -256,7 +256,7 @@ See [Data Structures](/documentation/language/data-structures).
 
 See [Data Structures](/documentation/language/data-structures#walking-data-structures).
 
-## Lazy Sequences
+## Lazy sequences
 
 ```phel
 (take 5 (range))                   ; => (0 1 2 3 4)
@@ -294,9 +294,9 @@ Lazy file I/O:
 (read-file-lazy "big.txt" 4096)        ; lazy chunked reading
 ```
 
-`map`, `filter`, `take`, `drop`, `concat`, `mapcat`, `interleave`, and `partition` all return lazy sequences.
+`map`, `filter`, `take`, `drop`, `concat`, `mapcat`, `interleave`, `partition` return lazy sequences.
 
-## Threading Macros
+## Threading macros
 
 ```phel
 (-> {:name "Alice" :age 30}        ; thread-first
@@ -333,7 +333,7 @@ Lazy file I/O:
 (php/explode "," "a,b,c")          ; => PHP array ["a" "b" "c"]
 ```
 
-## Regular Expressions
+## Regular expressions
 
 ```phel
 ;; Regex literals use #"..." syntax (PCRE patterns)
@@ -351,7 +351,7 @@ Lazy file I/O:
 (valid-email? "not-an-email")      ; => false
 ```
 
-## Mutable State
+## Mutable state
 
 ```phel
 (def counter (atom 0))             ; create an atom (mutable container)
@@ -375,7 +375,7 @@ Lazy file I/O:
 
 See [Global and Local Bindings](/documentation/language/global-and-local-bindings).
 
-## Error Handling
+## Error handling
 
 ```phel
 (try
@@ -405,7 +405,7 @@ See [Global and Local Bindings](/documentation/language/global-and-local-binding
 
 See [PHP Interop](/documentation/php-interop).
 
-## Interfaces & Structs
+## Interfaces & structs
 
 ```phel
 (definterface Greetable
@@ -431,7 +431,7 @@ See [Interfaces](/documentation/language/interfaces).
 
 ## Protocols
 
-Protocols provide polymorphic dispatch based on the type of the first argument. They are more flexible than interfaces because you can extend existing types without modifying them.
+Polymorphic dispatch on the first argument's type. More flexible than interfaces, extendable to existing types.
 
 ```phel
 ;; Define a protocol
@@ -457,9 +457,9 @@ Protocols provide polymorphic dispatch based on the type of the first argument. 
 (extends? Stringable dog)                        ; => true
 ```
 
-## Hierarchy System
+## Hierarchy system
 
-Derive ad-hoc hierarchies for use with multimethods and `isa?` checks.
+Ad-hoc hierarchies for multimethods and `isa?`.
 
 ```phel
 (derive :square :shape)
@@ -477,7 +477,7 @@ Derive ad-hoc hierarchies for use with multimethods and `isa?` checks.
 
 ## Transducers
 
-Transducers are composable transformations that work independently of the data source. They avoid creating intermediate collections, making pipelines more efficient.
+Composable transformations independent of the data source. Avoid intermediate collections.
 
 ```phel
 ;; Basic transducer usage with transduce
@@ -505,7 +505,7 @@ Transducers are composable transformations that work independently of the data s
 ;; (map f), (filter pred), (take n), (drop n), (partition-all n), etc.
 ```
 
-## PHP Interop
+## PHP interop
 
 ```phel
 ;; Calling PHP functions
@@ -586,7 +586,7 @@ See [Namespaces](/documentation/language/namespaces).
 
 See [Testing](/documentation/testing).
 
-## Delay & Force
+## Delay & force
 
 ```phel
 ;; Delay defers evaluation until first access
@@ -610,7 +610,7 @@ See [Testing](/documentation/testing).
   :initk nil)
 ```
 
-## Utility Functions
+## Utility functions
 
 ```phel
 (parse-long "42")                  ; => 42
@@ -621,7 +621,7 @@ See [Testing](/documentation/testing).
 (random-uuid)                      ; => "550e8400-e29b-..." (random UUID string)
 ```
 
-## REPL Utilities
+## REPL utilities
 
 ```phel
 (source my-fn)                     ; print source code of a function

--- a/content/documentation/reference/in-the-wild.md
+++ b/content/documentation/reference/in-the-wild.md
@@ -4,13 +4,13 @@ weight = 4
 aliases = ["/documentation/in-the-wild"]
 +++
 
-This page contains a list of libraries and projects that use Phel. If you want to add your project/library to this page please create a Pull Request on GitHub.
+Libraries and projects using Phel. To add yours, open a PR on GitHub.
 
 ## Libraries
 
 * [Chemaclass/phel-cli-gui](https://github.com/Chemaclass/phel-cli-gui): Functions to render in the CLI terminal.
 * [phel-lang/phel-pdo](https://github.com/phel-lang/phel-pdo): A wrapper around PDO.
-* [phel-lang/phel-schema](https://github.com/phel-lang/phel-schema): A schema validation library for phel – inspired by zod.
+* [phel-lang/phel-schema](https://github.com/phel-lang/phel-schema): A schema validation library for phel, inspired by zod.
 * [smeghead/phel-getopt](https://github.com/smeghead/phel-getopt): A simple command-line argument parsing library for phel CLI programs.
 
 

--- a/content/documentation/reference/one-liners.md
+++ b/content/documentation/reference/one-liners.md
@@ -4,7 +4,7 @@ weight = 2
 aliases = ["/documentation/one-liners"]
 +++
 
-Elegant solutions in a single expression. These one-liners showcase Phel's expressiveness and functional power.
+Single-expression solutions. Showcase Phel's expressiveness and functional power.
 
 ## Math & Numbers
 

--- a/content/documentation/testing.md
+++ b/content/documentation/testing.md
@@ -3,10 +3,10 @@ title = "Testing"
 weight = 70
 +++
 
-Phel comes with an integrated unit testing framework.
+Built-in unit testing framework.
 
 {% php_note() %}
-Unlike PHPUnit which uses classes and methods, Phel's testing is more lightweight:
+Lighter than PHPUnit. No classes/methods:
 
 ```php
 // PHPUnit - class-based tests
@@ -21,65 +21,70 @@ class MyTest extends TestCase {
   (is (= 4 (+ 2 2))))
 ```
 
-Phel's approach is simpler for functional code and doesn't require class boilerplate.
+No class boilerplate, simpler for functional code.
 {% end %}
 
 ## Assertions
 
-The core of the library is the `is` macro, which can be used to defined assertions.
+The `is` macro defines assertions:
 
 ```phel
 (is (= 4 (+ 2 2)) "my test description")
-(is (true? (or true false)) "my othe test")
+(is (true? (or true false)) "another test")
 ```
 
-The first argument of the `is` macro must be in one of the following forms. The second argument is an optional string to describe the test.
+First arg must take one of the forms below. Second arg is an optional description string.
 
 ```phel
 (predicate expected actual)
-;; Example: (is (= 4 (+ 2 2)))
+;; (is (= 4 (+ 2 2)))
 ```
 
-This tests whether, according to `predicate`, the `actual` value is in fact what we `expected`.
+Tests `actual` against `expected` via `predicate`.
 
 ```phel
 (predicate value)
-;; Example: (is (true? (or true false)))
+;; (is (true? (or true false)))
 ```
-This tests whether the `value` satisfies the `predicate`.
+
+Tests `value` satisfies `predicate`.
 
 ```phel
 (not (predicate expected actual))
-;; Example: (is (not (= 4 (+ 2 3))))
+;; (is (not (= 4 (+ 2 3))))
 ```
 
-This tests whether, according to `predicate`, the `actual` value is **not** what we `expected`.
+Tests `actual` does **not** match `expected` via `predicate`.
 
 ```phel
 (not (predicate value))
-;; Example (is (not (true? (and true false))))
+;; (is (not (true? (and true false))))
 ```
-This tests whether the `value` does **not** satisfies the `predicate`.
+
+Tests `value` does **not** satisfy `predicate`.
 
 ```phel
 (thrown? exception-type body)
-;; Example: (is (thrown? \Exception (throw (php/new \Exception "test"))))
+;; (is (thrown? \Exception (throw (php/new \Exception "test"))))
 ```
-This tests whether the execution of `body` throws an exception of type `exception-type`.
+
+Tests `body` throws `exception-type`.
 
 ```phel
 (thrown-with-msg? exception-type msg body)
-;; Example: (is (thrown? \Exception "test"  (throw (php/new \Exception "test"))))
+;; (is (thrown? \Exception "test" (throw (php/new \Exception "test"))))
 ```
-This tests whether the execution of `body` throws an exception of type `exception-type` and that the exception has the message `msg`.
+
+Tests `body` throws `exception-type` with message `msg`.
 
 ```phel
-(output? expected body) ; For example (output? "hello" (php/echo "hello"))
+(output? expected body) ; (output? "hello" (php/echo "hello"))
 ```
-This tests whether the execution of `body` prints the `expected` text to the output stream.
+
+Tests `body` prints `expected` to output.
 
 {% php_note() %}
-Exception testing in Phel is more concise than PHPUnit:
+Exception testing more concise than PHPUnit:
 
 ```php
 // PHPUnit
@@ -109,7 +114,7 @@ echo "hello";
 
 ## Defining tests
 
-Test can be defined by using the `deftest` macro. This macro is like a function without arguments.
+`deftest` defines a test. Like a no-arg function.
 
 ```phel
 (ns my-namespace\tests
@@ -121,33 +126,33 @@ Test can be defined by using the `deftest` macro. This macro is like a function 
 
 ## Running tests
 
-Tests can be run using the `./vendor/bin/phel test` command. Tests are looked up recursively in all directories set by [setTestDirs](/documentation/configuration/#testdirs) configuration option which defaults to `tests/`.
+Run via `./vendor/bin/phel test`. Picks up tests recursively from [setTestDirs](/documentation/configuration/#testdirs), defaults to `tests/`.
 
-Pass filenames as arguments to the `phel test` command to run tests in specified files only:
+Pass filenames to run specific files:
 
 ```bash
 ./vendor/bin/phel test tests/main.phel tests/utils.phel
 ```
 
-To filter tests that should run by name, `--filter` command line argument can be used:
+Filter by name with `--filter`:
 
 ```bash
 ./vendor/bin/phel test tests/utils.phel --filter my-test-function
 ```
 
-To stop on the first failure or error, use the `--fail-fast` flag:
+Stop on first failure with `--fail-fast`:
 
 ```bash
 ./vendor/bin/phel test --fail-fast
 ```
 
-Test report can be set to more verbose TestDox format showing individual test names with `--testdox` flag. Output can also be suppressed with `--quiet` flag to only include errors or silenced fully with `--silent` flag.
+`--testdox` for TestDox format. `--quiet` for errors only, `--silent` to silence fully.
 
-See more options available by running `./vendor/bin/phel test --help`.
+Full options: `./vendor/bin/phel test --help`.
 
 ### Reporters
 
-Pick the output format with `--reporter=<name>`. The flag is repeatable so you can emit multiple formats at once.
+Pick format with `--reporter=<name>`. Repeatable for multiple formats.
 
 | Reporter    | Description                                 |
 |-------------|---------------------------------------------|
@@ -163,11 +168,11 @@ Pick the output format with `--reporter=<name>`. The flag is repeatable so you c
 ./vendor/bin/phel test --reporter=tap --reporter=junit-xml --output=build/tests.xml
 ```
 
-`phel\test/report` is a multimethod dispatching on event `:type`, so you can register custom reporters from Phel.
+`phel\test/report` is a multimethod dispatching on event `:type`. Register custom reporters from Phel.
 
 ### Selectors
 
-Filter tests by tag, namespace glob, or regex:
+Filter by tag, namespace glob, or regex:
 
 ```bash
 ./vendor/bin/phel test --include=integration
@@ -186,10 +191,10 @@ Tag tests with metadata:
   ...)
 ```
 
-Skipped tests emit a `:skipped` event.
+Skipped tests emit `:skipped` event.
 
 {% php_note() %}
-Phel's test command is similar to PHPUnit:
+Test command similar to PHPUnit:
 
 ```bash
 # PHPUnit
@@ -203,11 +208,11 @@ Phel's test command is similar to PHPUnit:
 ./vendor/bin/phel test --filter my-test-function
 ```
 
-Both support filtering, verbose output, and running specific test files.
+Both support filtering, verbose output, specific files.
 {% end %}
 
 
-If you want to run tests from Phel code, the `run-tests` function can be used. As arguments, it takes a map of options (that can be empty) and one or more namespaces that should be tested.
+Run tests from Phel code with `run-tests`. Takes options map (can be empty) and one or more namespaces.
 
 ```phel
 (run-tests {} 'my\ns\a 'my\ns\b)
@@ -215,7 +220,7 @@ If you want to run tests from Phel code, the `run-tests` function can be used. A
 
 ### Interactive testing with `test-ns`
 
-You can run tests for a single namespace interactively from the REPL using `test-ns`:
+Run tests for a single namespace from the REPL:
 
 ```phel
 (ns my-app\tests
@@ -225,11 +230,11 @@ You can run tests for a single namespace interactively from the REPL using `test
 (test-ns 'my-app\tests)
 ```
 
-This is especially useful during REPL-driven development when you want quick feedback on a specific namespace without running the full test suite.
+Useful for REPL-driven feedback without running the full suite.
 
-### Test statistics management
+### Test statistics
 
-You can manage test statistics programmatically with these functions:
+Manage stats programmatically:
 
 ```phel
 ; Reset test counters to zero
@@ -244,11 +249,11 @@ You can manage test statistics programmatically with these functions:
 (restore-stats saved)
 ```
 
-These are useful when running tests interactively in the REPL and you need to isolate results or reset state between runs.
+Useful in REPL to isolate or reset state between runs.
 
 ## Mocking
 
-Phel provides a built-in mocking framework in the `phel\mock` module for replacing functions with test doubles.
+`phel\mock` module replaces functions with test doubles.
 
 ### Creating mocks
 
@@ -295,7 +300,7 @@ Phel provides a built-in mocking framework in the `phel\mock` module for replaci
 
 ### Replacing functions in tests
 
-Use `with-mocks` to temporarily replace functions with mocks using dynamic binding. Mocks are automatically reset after the block:
+`with-mocks` temporarily replaces functions via dynamic binding. Auto-resets after the block:
 
 ```phel
 (defn fetch-user [id]
@@ -309,7 +314,7 @@ Use `with-mocks` to temporarily replace functions with mocks using dynamic bindi
 ```
 
 {% php_note() %}
-Phel's mocking is simpler than Mockery or PHPUnit mocks:
+Simpler than Mockery or PHPUnit mocks:
 
 ```php
 // PHPUnit
@@ -321,12 +326,12 @@ $mock->method('find')->willReturn(['id' => 1]);
   (find-user 42))
 ```
 
-No class structure needed - mock any function directly.
+No class structure. Mock any function directly.
 {% end %}
 
 ## Property-based testing
 
-The `phel\test\gen` module provides generators, `sample`, `quick-check`, and `defspec` with a seedable PRNG.
+`phel\test\gen` provides generators, `sample`, `quick-check`, `defspec` with seedable PRNG.
 
 ```phel
 (ns my-app\tests
@@ -338,4 +343,4 @@ The `phel\test\gen` module provides generators, `sample`, `quick-check`, and `de
   (is (= xs (reverse (reverse xs)))))
 ```
 
-Failing cases are shrunk via `phel\test\shrink` (rose tree). On failure, a `:defspec-failed` event is emitted with `:shrunk-args`, `:original-args`, `:shrink-steps`, and `:seed`. Opt out with `^:no-shrink` or `:shrink? false`.
+Failing cases shrink via `phel\test\shrink` (rose tree). On failure, `:defspec-failed` event emits `:shrunk-args`, `:original-args`, `:shrink-steps`, `:seed`. Opt out with `^:no-shrink` or `:shrink? false`.

--- a/content/documentation/tooling/_index.md
+++ b/content/documentation/tooling/_index.md
@@ -9,4 +9,4 @@ template = "section-page.html"
 insert_after = "Configuration"
 +++
 
-Phel ships with a complete development toolkit - a CLI with build, format, and export commands, an interactive REPL, editor integrations, and everything you need to publish your own libraries.
+Complete dev toolkit: CLI (build, format, export), interactive REPL, editor integrations, library publishing.

--- a/content/documentation/tooling/cli-commands.md
+++ b/content/documentation/tooling/cli-commands.md
@@ -4,16 +4,16 @@ weight = 1
 aliases = ["/documentation/cli-commands"]
 +++
 
-Phel includes a series of commands out-of-the-box.
+Built-in commands.
 
 ```bash
-# To see an overview of all commands.
+; Overview of all commands
 vendor/bin/phel list
 ```
 
 ## Initialize a new project
 
-Scaffold a new Phel project with minimal configuration:
+Scaffold a new Phel project:
 
 ```bash
 vendor/bin/phel init
@@ -30,7 +30,7 @@ vendor/bin/phel init
 #       --no-gitignore    Skip generating .gitignore
 ```
 
-`phel init` defaults to the **Flat** layout (`src/`, `tests/`). Pass `--nested` for the legacy `src/phel/<name>/` layout.
+Defaults to **Flat** layout (`src/`, `tests/`). `--nested` for legacy `src/phel/<name>/`.
 
 ```bash
 # Flat layout (default)
@@ -55,7 +55,7 @@ php phel build
 #       --source-map|--no-source-map  Enable source maps
 ```
 
-Build the current project into the main php path. This means that the compiled phel code into PHP will be saved in that directory being the entry point the `out/index.php`, and you can run the PHP code directly using the PHP interpreter. This will improve the runtime performance, because there won't be a need to compile the code again.
+Compiles Phel to PHP, writing to the configured main path (entry point `out/index.php`). Run the resulting PHP directly. Skips recompilation, improving runtime.
 
 [Configuration](/documentation/configuration/#buildconfig) in `phel-config.php`:
 ```php
@@ -68,9 +68,7 @@ return (new \Phel\Config\PhelConfig())
 
 ## Export definitions
 
-Export all definitions with the metadata `{:export true}` as PHP classes. 
-
-It generates PHP classes at namespace level and a method for each exported definition. This allows you to use the exported phel functions from your PHP code.
+Exports definitions with `{:export true}` metadata as PHP classes. Generates one class per namespace, one method per exported definition. Lets you call Phel functions from PHP.
 
 ```bash
 vendor/bin/phel export
@@ -88,7 +86,7 @@ return (new \Phel\Config\PhelConfig())
 
 ## Format phel files
 
-Formats the given files. You can pass relative or absolute paths.
+Formats files. Accepts relative or absolute paths.
 
 ```bash
 vendor/bin/phel format
@@ -106,21 +104,21 @@ return (new PhelConfig())
     ->setFormatDirs(['src', 'tests']);
 ```
 
-The formatter aligns key/value pairs in `cond`, `case`, `condp`, and bindings of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let`.
+Aligns key/value pairs in `cond`, `case`, `condp`, and bindings of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let`.
 
-## Read-Eval-Print Loop
+## Read-eval-print loop
 
-Start a Repl. This is and interactive prompt (stands for Read-eval-print loop). It is very helpful to test out small tasks or to play around with the language itself.
+Interactive prompt for quick tests and language exploration.
 
 ```bash
 vendor/bin/phel repl
 ```
 
-Read more about the [REPL](/documentation/tooling/repl) in its own chapter.
+See [REPL](/documentation/tooling/repl).
 
 ## Run a script
 
-Code can be executed from the command line by calling the run command, followed by the file path or namespace:
+Run a file or namespace:
 
 ```bash
 vendor/bin/phel run
@@ -142,11 +140,11 @@ return (new PhelConfig())
     ->setSrcDirs(['src']);
 ```
 
-Read more about [running the code](/documentation/getting-started/#running-the-code) in the getting started page.
+See [Running the code](/documentation/getting-started/#running-the-code).
 
-## Test your phel logic
+## Test your Phel logic
 
-Tests the given files. If no filenames are provided all tests in the "tests" directory are executed.
+Runs tests. No paths runs everything in `tests/`.
 
 ```bash
 vendor/bin/phel test
@@ -167,7 +165,7 @@ vendor/bin/phel test
 #       --testdox           Shortcut for --reporter=testdox.
 ```
 
-Test selectors (`--include`, `--exclude`, `--ns`, regex `--filter`) and pluggable reporters (`default`, `testdox`, `dot`, `tap`, `junit-xml`) are documented in [Testing](/documentation/testing/).
+Test selectors and reporters: see [Testing](/documentation/testing/).
 
 [Configuration](/documentation/configuration/#testdirs) in `phel-config.php`:
 ```php
@@ -176,18 +174,11 @@ return (new PhelConfig())
     ->setTestDirs(['tests']);
 ```
 
-Use the `filter` option to run only the tests that contain that filter.
-
-[Configuration](/documentation/configuration/) in `phel-config.php`:
-```php
-<?php
-return (new PhelConfig())
-    ->setTestDirs(['tests']);
-```
+Use `filter` to run matching tests only.
 
 ## Evaluate an expression
 
-Evaluate a Phel expression and print the result. Pass a literal expression, or `-` to read from stdin.
+Evaluate and print. Pass a literal expression, or `-` for stdin.
 
 ```bash
 vendor/bin/phel eval '(+ 1 2 3)'
@@ -197,11 +188,9 @@ echo '(map inc [1 2 3])' | vendor/bin/phel eval -
 # => [2 3 4]
 ```
 
-Pass `-` to read the expression from stdin.
-
 ## Lint
 
-Static analysis with configurable rules (unresolved-symbol, arity-mismatch, unused-binding, unused-require, unused-import, shadowed-binding, redundant-do, duplicate-key, invalid-destructuring, discouraged-var).
+Static analysis. Rules: unresolved-symbol, arity-mismatch, unused-binding, unused-require, unused-import, shadowed-binding, redundant-do, duplicate-key, invalid-destructuring, discouraged-var.
 
 ```bash
 vendor/bin/phel lint
@@ -216,10 +205,9 @@ vendor/bin/phel lint
 
 Configure rules in `phel-lint.phel` at the project root.
 
-
 ## Watch
 
-Reload changed namespaces in dependency order. Backends: inotify, fswatch, polling.
+Reloads changed namespaces in dependency order. Backends: inotify, fswatch, polling.
 
 ```bash
 vendor/bin/phel watch
@@ -227,7 +215,7 @@ vendor/bin/phel watch
 #   watch [paths]... [-b backend] [--poll=500] [--debounce=100]
 ```
 
-Programmatic usage from Phel:
+From Phel:
 
 ```phel
 (ns my-app
@@ -239,7 +227,7 @@ Programmatic usage from Phel:
 
 ## nREPL
 
-bencode-over-TCP nREPL server. Supports `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, `completions`, `lookup`, `info`, `eldoc`.
+Bencode-over-TCP nREPL server. Ops: `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, `completions`, `lookup`, `info`, `eldoc`.
 
 ```bash
 vendor/bin/phel nrepl --port=7888 --host=127.0.0.1
@@ -247,10 +235,9 @@ vendor/bin/phel nrepl --port=7888 --host=127.0.0.1
 
 Connect from any nREPL-aware editor.
 
-
 ## LSP
 
-Language Server Protocol (v3.17) over stdio. Supports hover, definition, references, completion, document/workspace symbols, rename, formatting, and debounced diagnostics.
+LSP v3.17 over stdio. Supports hover, definition, references, completion, document/workspace symbols, rename, formatting, debounced diagnostics.
 
 ```bash
 vendor/bin/phel lsp
@@ -275,7 +262,7 @@ vendor/bin/phel api-daemon
 
 ## Agent install
 
-Write skill/recipe files for AI coding assistants: Claude Code, Cursor, Codex, Gemini, Copilot, Aider.
+Writes skill/recipe files for AI coding assistants: Claude Code, Cursor, Codex, Gemini, Copilot, Aider.
 
 ```bash
 vendor/bin/phel agent-install           # pick platform interactively
@@ -289,10 +276,10 @@ vendor/bin/phel agent-install --all     # all platforms
 
 ## Clear caches
 
-Clear the namespace and compiled code caches:
+Clear namespace and compiled-code caches:
 
 ```bash
 vendor/bin/phel cache:clear
 ```
 
-This removes all cached data from the cache directory. Useful when the cache becomes stale or after upgrading Phel versions.
+Removes everything in the cache dir. Useful for stale caches or after upgrades.

--- a/content/documentation/tooling/editor-support.md
+++ b/content/documentation/tooling/editor-support.md
@@ -4,39 +4,26 @@ weight = 3
 aliases = ["/documentation/editor-support"]
 +++
 
-Phel integrates with popular editors through community-maintained plugins and
-extensions. Install the tool that matches your workflow and point it at your
-project directory.
+Editor integration via community plugins. Install the one matching your workflow.
 
 ## PhpStorm
 
-Use the [Phel IntelliJ plugin](https://github.com/phel-lang/phel-intellij-plugin)
-for syntax highlighting, structural editing, and REPL actions within PhpStorm or
-other JetBrains IDEs. Install it via *Settings → Plugins → Marketplace* and
-search for “Phel”.
+[Phel IntelliJ plugin](https://github.com/phel-lang/phel-intellij-plugin): syntax highlighting, structural editing, REPL actions. Install via *Settings → Plugins → Marketplace*, search "Phel".
 
 ## VSCode
 
-The [Phel VS Code extension](https://github.com/phel-lang/phel-vs-code-extension)
-adds syntax highlighting, snippets, and inline evaluation support. Install it
-from the VS Code marketplace and reload the editor for the language features to
-activate.
+[Phel VS Code extension](https://github.com/phel-lang/phel-vs-code-extension): syntax highlighting, snippets, inline evaluation. Install from the VS Code marketplace, reload.
 
 ## Emacs
 
-[interactive-lang-tools](https://codeberg.org/mmontone/interactive-lang-tools)
-ships Phel support for Emacs, including editing helpers and REPL integration.
-Follow the repository instructions to add it to your Emacs configuration, then
-open a `.phel` file to enable the mode.
+[interactive-lang-tools](https://codeberg.org/mmontone/interactive-lang-tools): Phel support for Emacs, editing helpers, REPL integration. Follow the repo instructions.
 
 ## Vim
 
-[`phel.vim`](https://github.com/danirod/phel.vim) provides core editing
-support-syntax highlighting, filetype detection, and indentation. Install it
-through your plugin manager of choice:
+[`phel.vim`](https://github.com/danirod/phel.vim): syntax highlighting, filetype detection, indentation. Install via your plugin manager:
 
 ```vim
 Plug 'danirod/phel.vim'
 ```
 
-Reload Vim and open a Phel file to confirm the highlighting is active.
+Reload Vim, open a Phel file.

--- a/content/documentation/tooling/phel-helpers.md
+++ b/content/documentation/tooling/phel-helpers.md
@@ -4,15 +4,15 @@ weight = 5
 aliases = ["/documentation/tooling/phel-helpers"]
 +++
 
-The Phel standard library ships with helpers for inspecting values during development. These tools are perfect for quick debugging without setting up external tools.
+Stdlib ships helpers for inspecting values during development. Quick debugging without external tools.
 
-## Global Tap System
+## Global tap system
 
-The tap system provides a global dispatch mechanism for routing debug values to one or more handlers. Values flow through `tap>`, which in turn invokes every function registered with `add-tap`.
+Routes debug values to handlers. `tap>` invokes every function registered via `add-tap`.
 
 ### `tap>`
 
-Sends a value to every registered tap handler. Returns `true`.
+Sends a value to every registered handler. Returns `true`.
 
 ```phel
 (tap> {:event :user-login :user-id 42})
@@ -31,12 +31,12 @@ Register or unregister a handler function:
 (remove-tap my-logger)
 ```
 
-Exceptions thrown by individual taps are swallowed so one misbehaving handler does not affect the others.
+Exceptions in individual taps are swallowed so one bad handler doesn't break others.
 
 **Use cases:**
-- Routing debug output to a log file or external tool
-- Collecting values during a test run for later inspection
-- Building custom debugging dashboards
+- Route debug output to a log file or external tool
+- Collect values during a test run
+- Custom debugging dashboards
 
 ```phel
 ;; Collect tapped values during a test
@@ -53,9 +53,9 @@ Exceptions thrown by individual taps are swallowed so one misbehaving handler do
 (remove-tap collector)
 ```
 
-## Pretty Printing
+## Pretty printing
 
-The `phel\pprint` module provides `pprint` and `pprint-str` for readable output of nested data structures.
+`phel\pprint` provides `pprint` and `pprint-str` for readable nested data output.
 
 ```phel
 (ns my-app
@@ -70,11 +70,11 @@ The `phel\pprint` module provides `pprint` and `pprint-str` for readable output 
 ;;  :count 2}
 ```
 
-`pprint-str` returns the formatted string instead of printing it. Both accept an optional width parameter.
+`pprint-str` returns the formatted string. Both accept an optional width.
 
-## PHP Native Inspection
+## PHP native inspection
 
-Since Phel values are PHP objects under the hood, you can call any PHP inspection function with the `php/` prefix:
+Phel values are PHP objects. Any PHP inspection function works via `php/`:
 
 ```phel
 (php/var_dump (+ 2 2))
@@ -83,11 +83,11 @@ Since Phel values are PHP objects under the hood, you can call any PHP inspectio
 (php/print_r {:a 1 :b 2})
 ```
 
-For more advanced output, use [Symfony's VarDumper](/documentation/tooling/php-tools/) via `(php/dump ...)` and `(php/dd ...)`.
+Advanced output: [Symfony VarDumper](/documentation/tooling/php-tools/) via `(php/dump ...)` and `(php/dd ...)`.
 
-## Next Steps
+## Next steps
 
-- For deeper debugging, set up [XDebug](/documentation/tooling/xdebug-setup/)
-- Use [PHP native tools](/documentation/tooling/php-tools/) for familiar debugging
-- Use [`pprint`](/documentation/api/#pprint) for readable output of nested data structures
-- Check the [API documentation](/documentation/api/) for more helpers
+- Deeper debugging: [XDebug](/documentation/tooling/xdebug-setup/)
+- Familiar debugging: [PHP native tools](/documentation/tooling/php-tools/)
+- Readable output: [`pprint`](/documentation/api/#pprint)
+- More: [API docs](/documentation/api/)

--- a/content/documentation/tooling/php-tools.md
+++ b/content/documentation/tooling/php-tools.md
@@ -4,11 +4,11 @@ weight = 7
 aliases = ["/documentation/tooling/php-tools"]
 +++
 
-Since Phel compiles to PHP, you can use familiar PHP debugging functions and tools. These are perfect for quick inspections and work alongside Phel's built-in helpers.
+Phel compiles to PHP, so PHP debugging functions work. Pairs with Phel's built-in helpers.
 
 ## Native var_dump()
 
-You can use any PHP function simply using the `php/` prefix:
+Any PHP function via `php/` prefix:
 
 ```phel
 ;; Dumping a definition by its name
@@ -25,18 +25,18 @@ int(4)
 int(6)
 ```
 
-Additionally, you can call `(php/die)` to force the execution of the process so that you can debug a particular value at your own rhythm.
+`(php/die)` halts execution so you can inspect at leisure.
 
 ### When to use var_dump()
 
-- **Quick and dirty debugging**: No setup required
-- **Inspecting PHP objects**: See internal PHP structure
-- **Checking types**: Verify PHP type conversions
-- **Legacy code**: When working with existing PHP codebases
+- **Quick debugging:** no setup
+- **Inspect PHP objects:** internal structure
+- **Type checks:** verify type conversions
+- **Legacy code:** existing PHP codebases
 
 ## Symfony VarDumper: dump() & dd()
 
-Symfony has an awesome [VarDumper Component](https://symfony.com/doc/current/components/var_dumper.html) which you can use in your Phel projects as well. You can install it by using composer, under your `require-dev` dependencies.
+Use [Symfony VarDumper](https://symfony.com/doc/current/components/var_dumper.html). Install via composer under `require-dev`:
 
 ```json
 "require-dev": {
@@ -44,7 +44,7 @@ Symfony has an awesome [VarDumper Component](https://symfony.com/doc/current/com
 },
 ```
 
-And then, the same drill, you can `dump()` a definition by its name or the function result:
+`dump()` a definition or result:
 
 ```phel
 (php/dump (+ 4 4))
@@ -52,7 +52,7 @@ And then, the same drill, you can `dump()` a definition by its name or the funct
 8
 ```
 
-Additionally, you can also use `dd()` to dump and die the execution of the program as soon as it reaches that point:
+`dd()` dumps and halts:
 
 ```phel 
 (php/dd (+ 5 5))
@@ -62,22 +62,13 @@ Additionally, you can also use `dd()` to dump and die the execution of the progr
 
 ### Why Symfony VarDumper?
 
-**Beautiful output:**
-- Syntax highlighting
-- Collapsible nested structures
-- Better formatting than var_dump()
+**Beautiful output:** syntax highlighting, collapsible nested structures, better formatting than var_dump().
 
-**Rich information:**
-- Object properties and methods
-- Resource types
-- Circular references detection
+**Rich info:** object properties/methods, resource types, circular references.
 
-**Web-friendly:**
-- Nice HTML output in browsers
-- Dark mode support
-- Copy-to-clipboard functionality
+**Web-friendly:** HTML output, dark mode, copy-to-clipboard.
 
-### Best Practices
+### Best practices
 
 ```phel
 ;; Use dump() during development
@@ -95,9 +86,9 @@ Additionally, you can also use `dd()` to dump and die the execution of the progr
       (save)))  ; Never reached
 ```
 
-## Check the Evaluated PHP
+## Check the evaluated PHP
 
-You can keep the generated temporal PHP files for debugging purposes. Useful when you see an error occurring on `/private/var/folders/qq/dvftwj.../T/__phelV2KvGD` but the file does not exist. Read the [docs](/documentation/configuration/#keepgeneratedtempfiles).
+Keep generated temp PHP files for debugging. Useful when an error references `/private/var/folders/.../T/__phelV2KvGD` that no longer exists. See [docs](/documentation/configuration/#keepgeneratedtempfiles).
 
 ```php
 <?php # phel-config-local.php
@@ -107,18 +98,18 @@ return (require __DIR__ . '/phel-config.php')
 ;
 ```
 
-> TIP: Add this file to the `.gitignore` of the project, so you can have control over the configuration while on development without changing the global config.
+> TIP: Add to `.gitignore` to control dev config without touching the global one.
 
-### Inspecting Compiled PHP
+### Inspecting compiled PHP
 
-Once you enable `setKeepGeneratedTempFiles(true)`, you can:
+After `setKeepGeneratedTempFiles(true)`:
 
-1. **Find the generated files**: Look for temp files in `/tmp/` or your system's temp directory
-2. **Read the PHP code**: See exactly how Phel compiles to PHP
-3. **Understand errors**: Match error line numbers to your Phel code
-4. **Learn the compiler**: See optimization patterns
+1. **Find the files** in `/tmp/` or system temp dir.
+2. **Read the PHP** to see how Phel compiles.
+3. **Understand errors** by matching line numbers.
+4. **Learn the compiler** by seeing optimization patterns.
 
-**Example workflow:**
+**Example:**
 
 ```phel
 ;; Your Phel code
@@ -126,7 +117,7 @@ Once you enable `setKeepGeneratedTempFiles(true)`, you can:
   (str "Hello, " name "!"))
 ```
 
-With `setKeepGeneratedTempFiles(true)`, you can find and read the generated PHP:
+Generated PHP:
 
 ```php
 <?php
@@ -136,15 +127,15 @@ function greet($name) {
 }
 ```
 
-This is invaluable for:
-- **Debugging compiler issues**
-- **Understanding performance**
-- **Learning Phel internals**
-- **Reporting bugs** with concrete examples
+Useful for:
+- Debugging compiler issues
+- Understanding performance
+- Learning Phel internals
+- Reporting bugs with concrete examples
 
-## PHP Error Reporting
+## PHP error reporting
 
-Enable detailed error reporting during development:
+Detailed errors in development:
 
 ```php
 <?php # phel-config-local.php
@@ -157,14 +148,14 @@ return (require __DIR__ . '/phel-config.php')
 ;
 ```
 
-This helps catch:
+Catches:
 - Type errors
 - Undefined variables
-- Deprecated function calls
-- PHP warnings and notices
+- Deprecated calls
+- Warnings and notices
 
-## Next Steps
+## Next steps
 
-- Use [Phel's debug helpers](/documentation/tooling/phel-helpers/) for Phel-native debugging
-- Set up [XDebug](/documentation/tooling/xdebug-setup/) for professional step-through debugging
-- Check the [configuration docs](/documentation/configuration/) for more development settings
+- [Phel debug helpers](/documentation/tooling/phel-helpers/) for native debugging
+- [XDebug](/documentation/tooling/xdebug-setup/) for step-through debugging
+- [Config docs](/documentation/configuration/) for more dev settings

--- a/content/documentation/tooling/repl.md
+++ b/content/documentation/tooling/repl.md
@@ -6,15 +6,15 @@ aliases = ["/documentation/repl"]
 
 ## Interactive prompt
 
-Phel comes with an interactive Read-Eval-Print Loop. The REPL lets you evaluate Phel expressions and see results immediately - invaluable for exploring the language, testing ideas, and debugging.
+Phel ships with an interactive Read-Eval-Print Loop. Evaluate expressions, see results instantly. Useful for exploring, testing, debugging.
 
-Start it with:
+Start:
 
 ```bash
 ./vendor/bin/phel repl
 ```
 
-Type any Phel expression and press Enter:
+Type any expression, press Enter:
 
 ```phel
 Welcome to the Phel Repl
@@ -25,7 +25,7 @@ user:2> (str "Hello, " "world!")
 "Hello, world!"
 ```
 
-Multiline expressions work automatically - the prompt changes to `....` until the expression is complete:
+Multiline works: prompt switches to `....` until the expression is complete.
 
 ```phel
 user:1> (defn greet [name]
@@ -34,18 +34,18 @@ user:3> (greet "Phel")
 "Hello, Phel!"
 ```
 
-Press `Ctrl-D` or type `exit` to end the session.
+`Ctrl-D` or `exit` to quit.
 
-The prompt shows the current namespace (defaults to `user`) and tracks `(ns ...)` and `(in-ns ...)` switches. `def` returns a printable var ref (e.g. `#'user/my-var`).
+Prompt shows current namespace (defaults to `user`), tracks `(ns ...)` and `(in-ns ...)`. `def` returns a printable var ref (e.g. `#'user/my-var`).
 
 ## History variables
 
-The REPL tracks recent evaluations and the last exception:
+REPL tracks recent results and the last exception:
 
-- `*1`, result of the last expression
-- `*2`, result of the previous one
-- `*3`, two before that
-- `*e`, last exception thrown at the prompt
+- `*1` last result
+- `*2` previous
+- `*3` two before
+- `*e` last exception
 
 ```phel
 user:1> (+ 1 2)
@@ -62,7 +62,7 @@ user:4> (php/-> *e (getMessage))
 
 ### doc
 
-Look up documentation for any function or macro in scope:
+Show docs for any function or macro in scope:
 
 ```phel
 user:1> (doc all?)
@@ -76,11 +76,11 @@ user:2> (doc map)
 ...
 ```
 
-This is the fastest way to check function signatures and behavior without leaving the REPL.
+Fastest way to check signatures without leaving the REPL.
 
 ### require
 
-Import a Phel namespace into the REPL session. The arguments are the same as the `:require` clause in `ns`:
+Import a Phel namespace. Same args as `:require` in `ns`:
 
 ```phel
 user:1> (require phel\html :as h)
@@ -91,7 +91,7 @@ user:2> (h/html [:span {:class "greeting"} "Hello"])
 
 ### dir
 
-List all public definitions in a namespace:
+List public definitions in a namespace:
 
 ```phel
 user:1> (dir "phel\\string")
@@ -104,7 +104,7 @@ escape
 
 ### apropos
 
-Search for symbols matching a pattern across all loaded namespaces:
+Search symbols by pattern across loaded namespaces:
 
 ```phel
 user:1> (apropos "map")
@@ -118,7 +118,7 @@ phel\core/zipmap
 
 ### search-doc
 
-Search docstrings for a keyword or phrase:
+Search docstrings:
 
 ```phel
 user:1> (search-doc "lazy")
@@ -131,7 +131,7 @@ phel\core/take
 
 ### use
 
-Add an alias for a PHP class, same as the `:use` clause in `ns`:
+Alias a PHP class. Same as `:use` in `ns`:
 
 ```phel
 user:1> (use \DateTimeImmutable)
@@ -140,13 +140,13 @@ user:2> (php/-> (php/new DateTimeImmutable) (format "Y-m-d"))
 "2026-02-07"
 ```
 
-## Introspection functions
+## Introspection
 
-The REPL provides several functions for inspecting code, namespaces, and macros.
+Inspect code, namespaces, macros.
 
 ### source
 
-Display the source code of a function or macro:
+Show source of a function or macro:
 
 ```phel
 user:1> (source filter)
@@ -156,7 +156,7 @@ user:1> (source filter)
 
 ### find-fn
 
-Search for functions by example -- provide an input and expected output, and Phel will find matching functions:
+Find functions by input/output example:
 
 ```phel
 user:1> (find-fn [1 2 3] 3)
@@ -167,7 +167,7 @@ phel\core/last
 
 ### symbol-info
 
-Get detailed metadata about a symbol, including its type, namespace, and documentation:
+Symbol metadata: type, namespace, docs:
 
 ```phel
 user:1> (symbol-info map)
@@ -176,7 +176,7 @@ user:1> (symbol-info map)
 
 ### Namespace introspection
 
-Inspect namespaces and their contents:
+Inspect namespaces:
 
 ```phel
 user:1> (ns-publics 'phel\core)
@@ -208,7 +208,7 @@ Create, find, remove namespaces and intern vars at runtime (`phel\repl`):
 
 ### Macro expansion
 
-Expand macros to see the code they generate:
+Expand macros to see generated code:
 
 ```phel
 user:1> (macroexpand-1 '(defn foo [x] x))
@@ -218,7 +218,7 @@ user:2> (macroexpand '(defn foo [x] x))
 ; Fully expands all macros
 ```
 
-### Evaluation functions
+### Evaluation
 
 Evaluate code from strings or files:
 
@@ -232,7 +232,7 @@ user:2> (load-file "src/my/app.phel")
 
 ### Interactive testing
 
-Run tests for a namespace directly from the REPL:
+Run tests for a namespace from the REPL:
 
 ```phel
 user:1> (require phel\test :refer [test-ns])
@@ -244,7 +244,7 @@ See also [Testing](/documentation/testing/) for `reset-stats`, `get-stats`, and 
 
 ## Auto-injected utilities
 
-When you switch namespaces with `(in-ns ...)`, the REPL automatically injects the core utilities (`doc`, `require`, `use`) into the new namespace so they are always available without manual imports.
+`(in-ns ...)` auto-injects `doc`, `require`, `use` into the new namespace. No manual imports.
 
 ```phel
 user:1> (in-ns 'my\app)
@@ -252,13 +252,13 @@ my\app:2> (doc map)
 ; Works immediately -- no require needed
 ```
 
-## REPL-driven development workflow
+## REPL-driven workflow
 
-The REPL is most powerful when used as your primary development feedback loop - not just for one-off tests.
+Use the REPL as your primary feedback loop, not just one-off tests.
 
 ### Explore data interactively
 
-Build up data transformations step by step, verifying each stage:
+Build transformations step by step, verifying each stage:
 
 ```phel
 user:1> (def users [{:name "Alice" :role :admin}
@@ -274,7 +274,7 @@ user:5> (map :name *1)
 
 ### Test functions as you write them
 
-Define a function, test it immediately, refine, repeat:
+Define, test, refine, repeat:
 
 ```phel
 user:1> (defn fizzbuzz [n]
@@ -294,7 +294,7 @@ user:9> (map fizzbuzz (range 1 16))
 
 ### Explore PHP interop
 
-The REPL is great for discovering how PHP functions and classes behave in Phel:
+Try PHP functions and classes interactively:
 
 ```phel
 user:1> (use \DateTimeImmutable)
@@ -310,7 +310,7 @@ user:5> (php/json_encode (php/array 1 2 3))
 
 ### Inspect data structures
 
-Use the REPL to understand how Phel's persistent data structures work:
+See persistent data structures in action:
 
 ```phel
 user:1> (def m {:a 1 :b 2 :c 3})
@@ -328,8 +328,8 @@ user:6> (vals m)
 
 ## Tips
 
-- **Use `doc` liberally** - it's faster than switching to the browser to look up a function.
-- **Build up complex expressions incrementally** - start simple, verify, then compose.
-- **Copy working REPL expressions into your source files** - the REPL is a scratchpad for your final code.
-- **Use `require` to load your project modules** - test your own code interactively.
-- **`Ctrl-C` cancels the current input** if you get stuck in an incomplete expression.
+- **Use `doc` liberally:** faster than the browser.
+- **Build expressions incrementally:** start simple, verify, compose.
+- **Copy working expressions into source files:** the REPL is a scratchpad.
+- **Use `require` to load your modules:** test your code live.
+- **`Ctrl-C` cancels current input** if stuck mid-expression.

--- a/content/documentation/tooling/xdebug-setup.md
+++ b/content/documentation/tooling/xdebug-setup.md
@@ -4,7 +4,7 @@ weight = 6
 aliases = ["/documentation/debug/xdebug-setup"]
 +++
 
-[XDebug](https://xdebug.org/) is a powerful PHP debugging extension that enables step-through debugging with breakpoints, variable inspection, and call stack analysis. This is particularly useful for Phel core/compiler development and understanding how your Phel code compiles to PHP.
+[XDebug](https://xdebug.org/) enables step-through debugging with breakpoints, variable inspection, call stack analysis. Useful for Phel core/compiler dev and seeing how your Phel compiles to PHP.
 
 <details class="dev-note">
 <summary>
@@ -15,9 +15,9 @@ aliases = ["/documentation/debug/xdebug-setup"]
 
 <p style="font-size: 1.5em;font-weight: bold">Installation</p>
 
-**Recommended: Install via [PIE](https://github.com/php/pie)** (PHP Installer for Extensions)
+**Recommended: [PIE](https://github.com/php/pie)** (PHP Installer for Extensions)
 
-PIE is the modern replacement for PECL. Download the latest `pie.phar` from the [PIE releases](https://github.com/php/pie/releases), then:
+PIE replaces PECL. Get latest `pie.phar` from [releases](https://github.com/php/pie/releases):
 
 ```bash
 # Install PIE
@@ -29,9 +29,9 @@ sudo mv pie.phar /usr/local/bin/pie
 pie install xdebug/xdebug
 ```
 
-**Note:** PECL is now deprecated. PIE is the official successor and recommended installation method.
+**Note:** PECL deprecated. PIE is the official successor.
 
-**Alternative methods:**
+**Alternatives:**
 
 ```bash
 # Via system package manager (Ubuntu/Debian)
@@ -42,7 +42,7 @@ brew install php
 brew install php-xdebug
 ```
 
-**For Docker/container environments**, add to your `Dockerfile`:
+**Docker/containers,** add to your `Dockerfile`:
 
 ```dockerfile
 # Using PIE (recommended)
@@ -66,7 +66,7 @@ php -v
 
 <p style="font-size: 1.5em;font-weight: bold">Configuration</p>
 
-Configure XDebug in your `php.ini` or create a dedicated config file (`/etc/php/conf.d/xdebug.ini` or similar):
+Configure in `php.ini` or a dedicated file (`/etc/php/conf.d/xdebug.ini`):
 
 ```ini
 [xdebug]
@@ -85,15 +85,15 @@ xdebug.client_port=9003
 # xdebug.log=/tmp/xdebug.log
 ```
 
-**Key settings:**
-- `xdebug.mode=debug` - Enable debugging mode
-- `xdebug.start_with_request=yes` - Start debugging on every request
-- `xdebug.client_port=9003` - Default port for XDebug 3.x (was 9000 in XDebug 2.x)
+**Settings:**
+- `xdebug.mode=debug` enable debugging
+- `xdebug.start_with_request=yes` debug on every request
+- `xdebug.client_port=9003` default port (XDebug 2.x used 9000)
 
-**For containers/VMs:**
-- Set `xdebug.client_host=host.docker.internal` (Docker Desktop)
-- Or set to your host machine's IP address
-- Ensure the debug port (9003) is exposed/forwarded
+**Containers/VMs:**
+- `xdebug.client_host=host.docker.internal` (Docker Desktop)
+- Or use host IP
+- Expose/forward port 9003
 
 </div>
 </details>
@@ -139,29 +139,29 @@ Create `.vscode/launch.json` in your Phel project:
 | `skipPhelInternals` | boolean  | true     | Skip stepping through Phel runtime code                     |
 | `skipFiles`         | string[] | []       | Glob patterns for files to skip when stepping               |
 
-**Path Mappings** are crucial when using Docker/VMs. Map the container's path to your local workspace:
+**Path mappings** matter for Docker/VMs. Map container path to local workspace:
 
-- Container path: `/var/www/html` (or wherever your code lives in the container)
-- Local path: `${workspaceFolder}` (your local project directory)
+- Container: `/var/www/html`
+- Local: `${workspaceFolder}`
 
 **Usage:**
 
-1. Set breakpoints directly in `.phel` files by clicking left of line numbers
-2. Press `F5` or click "Run and Debug" → "Debug Phel"
-3. Run your Phel code (CLI or web request)
-4. Execution will pause at breakpoints, showing Phel source context
+1. Click left of a line number in `.phel` to set a breakpoint.
+2. Press `F5` or "Run and Debug" → "Debug Phel".
+3. Run your Phel code (CLI or web).
+4. Execution pauses at breakpoints with Phel source context.
 
-**Additional Commands:**
+**Commands:**
 
-- `Phel: Show Compiled PHP Location` - Shows which PHP line a Phel line maps to
-- `Phel: Clear Source Map Cache` - Clears cached source map data
+- `Phel: Show Compiled PHP Location` shows the mapped PHP line
+- `Phel: Clear Source Map Cache` clears cached source maps
 
-> **Note:** The extension auto-detects the cache directory from `phel-config.php`. If your project uses a custom temp directory, it will be discovered automatically.
+> **Note:** Cache dir auto-detected from `phel-config.php`.
 
 <details>
 <summary><strong>Alternative: Using PHP Debug Extension</strong></summary>
 
-If you prefer debugging at the PHP level (or don't have the Phel extension installed), you can use the [PHP Debug extension](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug):
+For PHP-level debugging (or no Phel extension), use the [PHP Debug extension](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug):
 
 ```json
 {
@@ -180,42 +180,25 @@ If you prefer debugging at the PHP level (or don't have the Phel extension insta
 }
 ```
 
-With this approach, you'll need to set breakpoints in the compiled PHP files (found in the temp directory). Use `setKeepGeneratedTempFiles(true)` in `phel-config.php` to preserve the compiled files for inspection.
+Set breakpoints in compiled PHP files (in the temp dir). Use `setKeepGeneratedTempFiles(true)` in `phel-config.php` to preserve them.
 
 </details>
 
 ### PHPStorm
 
-PHPStorm has built-in XDebug support:
+PHPStorm has built-in XDebug support.
 
-- **Configure PHP Interpreter:**
-  - Go to: `Settings` → `PHP` → `CLI Interpreter`
-  - Add or select your PHP interpreter
-  - Verify XDebug shows as "Installed ✓"
+- **PHP Interpreter:** `Settings` → `PHP` → `CLI Interpreter`. Add/select PHP, verify XDebug "Installed ✓".
+- **Debug:** `Settings` → `PHP` → `Debug`. Port `9003`. Check "Can accept external connections".
+- **Path Mappings (Docker/VM):** `Settings` → `PHP` → `Servers`. New server. Map local to container (e.g. `/Users/you/phel-project` → `/var/www/html`).
+- **Start listening:** phone icon in the toolbar, or `Run` → `Start Listening for PHP Debug Connections`.
+- Set breakpoints, run.
 
-- **Configure Debug Settings:**
-  - Go to: `Settings` → `PHP` → `Debug`
-  - Set XDebug port to `9003`
-  - Check "Can accept external connections"
-
-- **Path Mappings (for Docker/VM):**
-  - Go to: `Settings` → `PHP` → `Servers`
-  - Add a new server configuration
-  - Map your project root to the container path:
-    - Local: `/Users/you/phel-project`
-    - Remote: `/var/www/html`
-
-- **Start Listening:**
-  - Click the phone icon in the toolbar: "Start Listening for PHP Debug Connections"
-  - Or use menu: `Run` → `Start Listening for PHP Debug Connections`
-
-- **Set breakpoints** and run your code
-
-Detailed guide: [VVV PHPStorm XDebug Setup](https://varyingvagrantvagrants.org/docs/en-US/references/xdebug-and-phpstorm/)
+Guide: [VVV PHPStorm XDebug Setup](https://varyingvagrantvagrants.org/docs/en-US/references/xdebug-and-phpstorm/).
 
 ### Emacs
 
-XDebug uses the Debug Adapter Protocol (DAP). Set up [dap-mode](https://emacs-lsp.github.io/dap-mode/):
+XDebug uses DAP. Set up [dap-mode](https://emacs-lsp.github.io/dap-mode/):
 
 ```elisp
 (use-package dap-mode
@@ -257,33 +240,24 @@ dap.configurations.php = {
 }
 ```
 
-## Debugging Phel Code
+## Debugging Phel code
 
-### With VS Code Phel Extension
+### With VS Code Phel extension
 
-The Phel VS Code extension provides a seamless debugging experience:
+1. **Breakpoints in `.phel`:** click the gutter. Auto-mapped to PHP lines.
+2. **Source-level traces:** stack traces show Phel file names and line numbers.
+3. **Phel-native variables:** vectors as `[3 items]`, maps as `{2 entries}`, keywords as `:status`, lists as `(5 items)`.
+4. **Skip internals:** stepping skips Phel runtime. Disable with `"skipPhelInternals": false`.
+5. **Hover for mapping:** hover a breakpoint to see the PHP file/line.
 
-1. **Set breakpoints in `.phel` files**: Click in the gutter next to any line. The extension automatically maps these to the corresponding PHP lines.
+### With other editors
 
-2. **Source-level debugging**: Stack traces show Phel file names and line numbers, not the compiled PHP.
+Without native Phel support:
 
-3. **Phel-native variable display**: Variables are shown with Phel formatting (e.g. vectors as `[3 items]`, maps as `{2 entries}`, keywords as `:status`, lists as `(5 items)`).
-
-4. **Skip internals**: By default, stepping skips Phel runtime code. Disable with `"skipPhelInternals": false` if debugging the Phel runtime itself.
-
-5. **Hover for mapping info**: Hover over a breakpoint to see which PHP file/line it maps to.
-
-### With Other Editors
-
-When debugging Phel code with XDebug in editors without native Phel support:
-
-1. **Breakpoints in compiled PHP**: Since Phel compiles to PHP, you'll be stepping through the generated PHP code. Use `setKeepGeneratedTempFiles(true)` in `phel-config.php` to inspect the compiled output.
-
-2. **Path mapping is critical**: Ensure your editor knows how to map container/VM paths to local paths.
-
-3. **Debugging the compiler**: For Phel core development, set breakpoints in the compiler code (`vendor/phel-lang/phel-lang/src/`).
-
-4. **REPL debugging**: You can debug REPL sessions by running the REPL with XDebug enabled.
+1. **Breakpoints in compiled PHP:** Phel compiles to PHP. Use `setKeepGeneratedTempFiles(true)` to inspect output.
+2. **Path mapping:** map container/VM paths to local.
+3. **Compiler debugging:** breakpoints in `vendor/phel-lang/phel-lang/src/`.
+4. **REPL debugging:** start REPL with XDebug enabled.
 
 ## Troubleshooting
 
@@ -300,7 +274,7 @@ php -i | grep xdebug
 telnet localhost 9003
 ```
 
-**Enable XDebug logging** to diagnose connection problems:
+**Enable XDebug logging:**
 
 ```ini
 xdebug.log=/tmp/xdebug.log
@@ -309,15 +283,15 @@ xdebug.log_level=7
 
 **Common issues:**
 
-- **Port conflicts**: XDebug 3.x uses port 9003 (not 9000). Update your editor configuration.
-- **Firewall**: Ensure port 9003 is not blocked by firewall rules.
-- **Path mappings**: Double-check that container paths match your actual paths. Use `pwd` inside the container to verify.
-- **Docker**: Use `host.docker.internal` instead of `localhost` for `xdebug.client_host`.
-- **WSL2/VM**: May need to use the host machine's network IP address.
+- **Port:** XDebug 3.x uses 9003, not 9000. Update editor config.
+- **Firewall:** unblock 9003.
+- **Path mappings:** `pwd` inside container to verify.
+- **Docker:** use `host.docker.internal` instead of `localhost`.
+- **WSL2/VM:** may need host network IP.
 
-**Testing XDebug connection:**
+**Test connection:**
 
-Create a simple test script:
+Simple test:
 
 ```php
 <?php
@@ -325,4 +299,4 @@ xdebug_break(); // Hard breakpoint
 echo "XDebug is working!\n";
 ```
 
-Run it and verify your debugger connects.
+Run it, verify the debugger connects.

--- a/content/documentation/web/_index.md
+++ b/content/documentation/web/_index.md
@@ -9,4 +9,4 @@ template = "section-page.html"
 insert_after = "PHP Interop"
 +++
 
-Phel includes built-in support for building web applications. These pages cover HTTP request/response handling and HTML rendering using Phel's data-structure-based template syntax.
+Built-in web support. Pages: HTTP request/response handling, HTML rendering via Phel's data-structure templates.

--- a/content/documentation/web/html-rendering.md
+++ b/content/documentation/web/html-rendering.md
@@ -4,11 +4,11 @@ weight = 2
 aliases = ["/documentation/html-rendering"]
 +++
 
-Phel offers a template syntax based on Phel's data structures. It uses vectors to represent elements and maps to represent an element's attributes. All values are automatically escaped to provide better defense against cross-site scripting (XSS).
+Template syntax based on Phel data structures. Vectors are elements, maps are attributes. Values auto-escape for XSS protection.
 
 ## Syntax
 
-The `html` function in the module `phel\html` is the main function to generate HTML. See the following example:
+`html` from `phel\html` generates HTML:
 
 ```phel
 (ns my-namespace
@@ -18,14 +18,14 @@ The `html` function in the module `phel\html` is the main function to generate H
 ;; Evaluates to <span class="foo">bar</span>
 ```
 
-The data structure that is accepted by `html` takes one of the following forms:
+Forms:
 
 ```phel
 [tag body+]
 [tag attributes body+]
 ```
 
-The first item in the vector is a mandatory tag name. It can be either a keyword or a string. The second item is an optional map of attributes. All subsequent items in the vector are treated as the element body. This can include strings, nested vectors or lists.
+First item: tag name (keyword or string). Second item: optional attribute map. Rest: body (strings, nested vectors, lists).
 
 ```phel
 (html [:div]) ; Evaluates to "<div></div>"
@@ -35,11 +35,11 @@ The first item in the vector is a mandatory tag name. It can be either a keyword
 (html [:div {:id "foo"}]) ; Evaluates to "<div id=\"foo\"></div>"
 ```
 
-## Classes and Styles
+## Classes and styles
 
-A common need in building HTML templates is to adjust an element's class list and its inline styles. Therefore, Phel provides special enhancements for `class` and `style` attributes.
+Phel enhances `class` and `style` attributes.
 
-Instead of concatenating an inline style string, a map can be used. The next two examples evaluate to the same result.
+Use a map for styles instead of a string. Both forms equivalent:
 
 ```phel
 (html [:div {:style "background:green;color:red;"} "bar"])
@@ -48,7 +48,7 @@ Instead of concatenating an inline style string, a map can be used. The next two
 ;; "<div style=\"background:green;color:red;\">bar</div>"
 ```
 
-Class lists can be built by vectors or maps. If a map is provided, the keys of the map are the class names, and the values are evaluated to true or false. Only keys with true values are added to the final class list.
+Class lists: vector or map. Map keys are class names; only truthy keys appear in the final list.
 
 ```phel
 (html [:div {:class [:a]}]) ; <div class=\"a\"></div>
@@ -59,7 +59,7 @@ Class lists can be built by vectors or maps. If a map is provided, the keys of t
 
 ## Conditional rendering
 
-To conditionally render parts of the HTML, the `if` expression can be used.
+Use `if`:
 
 ```phel
 (html [:div [:p "a"] (if true [:p "b"] [:p "c"])])
@@ -68,9 +68,9 @@ To conditionally render parts of the HTML, the `if` expression can be used.
 ;; Evaluates to "<div><p>a</p><p>c</p></div>"
 ```
 
-## Rendering sequential data structures
+## Rendering sequential data
 
-Similar to conditional rendering, the `for` expression can be used to render iterables such as vectors, lists and sets.
+`for` over vectors, lists, sets:
 
 ```phel
 (html [:ul (for [i :range [0 3]] [:li i])])
@@ -80,9 +80,9 @@ Similar to conditional rendering, the `for` expression can be used to render ite
 ;; Evaluates to "<ul><li>3</li><li>4</li><li>5</li></ul>"
 ```
 
-## Raw Html
+## Raw HTML
 
-By default, all values are automatically escaped to provide better defense against cross-site scripting (XSS). In order to output unescaped HTML, the `raw-string` function can be used.
+Values auto-escape for XSS protection. For unescaped output, use `raw-string`:
 
 ```phel
 (html [:span (raw-string "<a></a>")])
@@ -91,11 +91,11 @@ By default, all values are automatically escaped to provide better defense again
 
 ## Doctypes
 
-To add a doctype at the beginning of each element document, the `doctype` function can be used.
+Use `doctype` for the document doctype:
 
 ```phel
 (html (doctype :html5) [:div])
 ;; Evaluates to "<!DOCTYPE html>\n<div></div>"
 ```
 
-The `doctype` function supports the following values: `:html5`, `:xhtml-transitional`, `:xhtml-strict` and `:html4`.
+Supported values: `:html5`, `:xhtml-transitional`, `:xhtml-strict`, `:html4`.

--- a/content/documentation/web/http-request-and-response.md
+++ b/content/documentation/web/http-request-and-response.md
@@ -4,11 +4,11 @@ weight = 1
 aliases = ["/documentation/http-request-and-response"]
 +++
 
-## HTTP Request
+## HTTP request
 
-Phel provides an easy method to access the current HTTP request. While in PHP the request is distributed in different globals variables (`$_GET`, `$_POST`, `$_SERVER`, `$_COOKIES` and `$_FILES`) Phel normalizes them into a single struct. All functions and structs are defined in the `phel\http` module.
+PHP scatters the request across `$_GET`, `$_POST`, `$_SERVER`, `$_COOKIES`, `$_FILES`. Phel normalizes them into one struct. All in `phel\http`.
 
-The request struct is defined like this:
+Request struct:
 
 ```phel
 (defstruct request [
@@ -43,7 +43,7 @@ The request struct is defined like this:
 ])
 ```
 
-To create a request struct the `phel\http` module must be imported. Then the `request-from-globals` function can be called.
+Import `phel\http`, call `request-from-globals`:
 
 ```phel
 (ns my-namepace
@@ -52,9 +52,9 @@ To create a request struct the `phel\http` module must be imported. Then the `re
 (http/request-from-globals) ; Evaluates to a request struct
 ```
 
-## HTTP Response
+## HTTP response
 
-The `phel\http` module also contains a response struct. This struct can be used to send HTTP responses to the client. The response struct takes the following values.
+`phel\http` includes a response struct for sending responses:
 
 ```phel
 (defstruct response [
@@ -66,7 +66,7 @@ The `phel\http` module also contains a response struct. This struct can be used 
 ])
 ```
 
-To make it easier to create responses. Phel has two helpers methods to create a response.
+Two helpers create responses:
 
 ```phel
 (ns my-namepace
@@ -81,7 +81,7 @@ To make it easier to create responses. Phel has two helpers methods to create a 
 ;; Evaluates to (response 200 {} "Hello World" "1.1" "OK")
 ```
 
-To send the response to the client the `emit-response` function can be used.
+Send with `emit-response`:
 
 ```phel
 (ns my-namepace
@@ -92,6 +92,6 @@ To send the response to the client the `emit-response` function can be used.
   (http/emit-response rsp))
 ```
 
-## HTTP Router
+## HTTP router
 
-A Phel router based on symfony routing component: [phel-lang/router](https://github.com/phel-lang/router)
+Phel router on top of Symfony routing: [phel-lang/router](https://github.com/phel-lang/router).

--- a/content/documentation/why-phel.md
+++ b/content/documentation/why-phel.md
@@ -3,13 +3,13 @@ title = "Why Phel?"
 weight = 3
 +++
 
-You already know PHP. So why learn a Lisp that compiles to the same runtime?
+You know PHP. Why learn a Lisp on the same runtime?
 
-Honest answers below. No marketing. If Phel isn't right for you, that's fine.
+Honest answers below. If Phel doesn't fit, that's fine.
 
 ## Do I need to know Lisp?
 
-No. The whole syntax is one rule: the first element inside parentheses is the function, everything after it is an argument.
+No. One rule: first element inside parentheses is the function, the rest are arguments.
 
 ```php
 // PHP
@@ -23,30 +23,30 @@ str_contains($haystack, $needle);
 (php/str_contains haystack needle)
 ```
 
-No operator precedence, no special cases, no ambiguity. The [Practice exercises](/practice/basic) get you comfortable in an hour.
+No operator precedence, no special cases. [Practice exercises](/practice/basic) get you comfortable in an hour.
 
 ## Why Lisp syntax specifically?
 
-1. **Homoiconicity.** Phel code is Phel data (lists, vectors, maps). Macros manipulate code with the same functions you use on data.
-2. **Macros.** Extend the language with new syntax that looks built-in. See [Macros](/documentation/language/macros).
-3. **Regularity.** One pattern: `(function arg1 arg2 ...)`. Once internalized, you can read any Phel code.
+1. **Homoiconicity.** Code is data (lists, vectors, maps). Macros manipulate code with the same functions you use on data.
+2. **Macros.** Extend the language with built-in-looking syntax. See [Macros](/documentation/language/macros).
+3. **Regularity.** One pattern: `(function arg1 arg2 ...)`. Read any Phel code once you internalize it.
 
-The unfamiliar feeling fades faster than expected, usually within a few days of actual use.
+Unfamiliar feeling fades within days of use.
 
 ## Why not just modern PHP?
 
-Modern PHP is great. Some things are not on its roadmap:
+Modern PHP is great. Some things aren't on its roadmap:
 
-- **Immutable data structures by default.** Data never changes in place. Eliminates whole classes of bugs (stale state, unexpected mutations, order-dependent side effects).
-- **A real macro system.** Operates on code as data. PHP attributes and codegen are not the same.
-- **REPL-driven development.** Evaluate expressions interactively, build programs incrementally. See [REPL](/documentation/tooling/repl).
-- **Functional-first design.** Pure functions, pipelines, data transformation. PHP can do FP, but its stdlib and conventions push toward OOP.
+- **Immutable data structures by default.** Eliminates stale state, unexpected mutations, order-dependent side effects.
+- **Real macro system.** Operates on code as data. PHP attributes and codegen are not the same.
+- **REPL-driven development.** Evaluate expressions interactively, build incrementally. See [REPL](/documentation/tooling/repl).
+- **Functional-first design.** Pure functions, pipelines, data transformation. PHP allows FP but pushes OOP.
 
-PHP is not bad. Phel and PHP optimize for different things on the same runtime.
+Phel and PHP optimize for different things on the same runtime.
 
 ## Can I use existing PHP libraries?
 
-Yes, fully. Phel has full PHP interop through the `php/` prefix:
+Yes. Full interop through the `php/` prefix:
 
 ```phel
 (php/strlen "hello")                          ; => 5
@@ -59,42 +59,38 @@ Composer packages work. Any class, trait, function, constant. See [PHP Interop](
 
 ## Isn't a compilation step a hassle?
 
-No. `vendor/bin/phel run` or the REPL compiles transparently. No build pipeline, no watcher, no output dir to manage. Same as TypeScript → JavaScript or Sass → CSS. Deployment is plain PHP files on existing infra.
+No. `vendor/bin/phel run` or the REPL compiles transparently. No build pipeline, watcher, or output dir. Same idea as TypeScript or Sass. Deploys as plain PHP.
 
 ## What about performance?
 
-Phel compiles to standard PHP. Runtime performance is comparable to handwritten PHP. Persistent data structures carry some overhead vs plain arrays since "modification" creates a new structure. Negligible for web requests, CLI tools, data processing.
+Compiles to standard PHP. Runtime comparable to handwritten PHP. Persistent data structures add some overhead vs plain arrays since "modification" creates a new structure. Negligible for web, CLI, data processing.
 
-The trade-off is explicit: trade micro-performance for correctness and DX. For tight inner loops over millions of mutations, plain PHP arrays win. For everything else, immutability wins.
+Trade-off: micro-performance for correctness and DX. For tight inner loops over millions of mutations, plain PHP arrays win. Otherwise immutability wins.
 
 ## What about debugging?
 
-PHP's full debugging ecosystem works:
+Full PHP debugging ecosystem works:
 
-- **Phel helpers**: `tap>`, `add-tap`, `pprint` for inline inspection.
-- **PHP native**: `var_dump`, `print_r`, Symfony `dump()` all work since Phel values are PHP objects.
-- **XDebug**: full step-through with breakpoints, call stacks, variable inspection. PhpStorm and VS Code.
+- **Phel helpers**: `tap>`, `add-tap`, `pprint`.
+- **PHP native**: `var_dump`, `print_r`, Symfony `dump()`. Phel values are PHP objects.
+- **XDebug**: step-through, breakpoints, variable inspection. PhpStorm and VS Code.
 
 See [Debug helpers](/documentation/tooling/phel-helpers/) and [XDebug setup](/documentation/tooling/xdebug-setup/).
 
 ## What about IDE support?
 
-Editor support exists for the major editors:
-
-- **VS Code**, **PhpStorm**, **Emacs**, **Vim**: syntax highlighting, REPL/nREPL integration, formatting.
-
-See [Editor Support](/documentation/tooling/editor-support).
+VS Code, PhpStorm, Emacs, Vim: syntax highlighting, REPL/nREPL, formatting. See [Editor Support](/documentation/tooling/editor-support).
 
 ## Is Phel production-ready?
 
-The core language is stable and well-tested. Great fit for:
+Core is stable and tested. Good fit for:
 
-- Side projects and personal tools
+- Side projects, personal tools
 - CLI applications
 - Internal tools and scripts
-- Learning functional programming on a runtime you already know
-- Prototyping with REPL-driven development
+- Learning FP on a runtime you know
+- REPL-driven prototyping
 
-The community is small but active. Need battle-tested enterprise stability with LTS guarantees? Phel is not there yet. Want a productive, expressive language on PHP and OK being an early adopter? Phel delivers.
+Community small but active. Need LTS-grade enterprise stability? Not yet. Want expressive PHP and OK being an early adopter? Phel delivers.
 
-See [In the Wild](/documentation/reference/in-the-wild) for what people are building.
+See [In the Wild](/documentation/reference/in-the-wild) for what people build.


### PR DESCRIPTION
## Summary
- Trim verbose intros, redundant transitions, and filler prose across all hand-written documentation pages.
- Preserve every code example, anchor, link, and dev-note (`<details>`) block.
- Normalise section headings to sentence case where they were title-case.

## Scope
38 files in `content/documentation/`:
- Top-level: `_index`, `getting-started`, `installation`, `why-phel`, `configuration`, `php-interop`, `testing`
- `language/*` (11 files)
- `guides/*` (4 files)
- `tooling/*` (8 files)
- `web/*` (3 files)
- `reference/*` (5 files, excluding auto-generated `api/`)

`reference/api/*` is skipped because it is auto-generated from the vendored phel-lang sources.

## Test plan
- [x] `zola build` succeeds (116 pages, 10 sections, no errors)
- [ ] Spot-check rendered pages on staging for layout regressions
- [ ] Verify dev-note callouts and anchors still render and link correctly