### PR TITLE
fix(mobile): keep toolbar visible

### DIFF
--- a/content/documentation/installation.md
+++ b/content/documentation/installation.md
@@ -7,14 +7,14 @@ Requires **PHP 8.4+**. Pick the method matching your workflow.
 
 ## Which method?
 
-| Goal                                        | Use                                                  |
-| ------------------------------------------- | ---------------------------------------------------- |
-| New project with tests + scripts            | [**Composer skeleton**](#new-project-from-skeleton)  |
-| Add to existing Composer project            | [**Composer require**](#add-to-an-existing-project)  |
-| Run a single file, no setup                 | [**PHAR**](#phar-no-project-setup)                   |
-| **No PHP installed** (Docker only)          | [**Docker**](#docker-no-php-required)                |
-| Reproducible dev shells                     | [**Nix**](#nix)                                      |
-| Fastest path                                | [Getting Started](/documentation/getting-started) →  |
+| Goal                               | Use                                               |
+|------------------------------------|---------------------------------------------------|
+| New project with tests + scripts   | [Composer skeleton](#new-project-from-skeleton)   |
+| Add to existing Composer project   | [Composer require](#add-to-an-existing-project)   |
+| Run a single file, no setup        | [PHAR](#phar-no-project-setup)                    |
+| **No PHP installed** (Docker only) | [Docker](#docker-no-php-required)                 |
+| Reproducible dev shells            | [Nix](#nix)                                       |
+| Fastest path                       | [Getting Started](/documentation/getting-started) |
 
 ## Composer (recommended)
 

--- a/css/base.css
+++ b/css/base.css
@@ -414,13 +414,13 @@ table td:not(:first-child) {
 
 @media (max-width: 768px) {
   table {
+    width: 100%;
     max-width: 100%;
+    table-layout: fixed;
     border-radius: var(--radius-lg);
     overflow: hidden;
-    display: block;
-    overflow-x: auto;
+    word-break: break-word;
   }
-
 }
 
 th {

--- a/css/components/header.css
+++ b/css/components/header.css
@@ -38,6 +38,26 @@
   .site-header {
     position: relative;
   }
+
+  body.menu-open .site-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: var(--z-modal);
+    background: rgba(255, 255, 255, 0.98);
+  }
+
+  body.menu-open .site-header__container {
+    position: relative;
+    z-index: var(--z-popover);
+    background: inherit;
+  }
+
+  body.menu-open.dark .site-header,
+  .dark body.menu-open .site-header {
+    background: #151a24f6;
+  }
 }
 
 @media (max-width: 767px) {
@@ -65,7 +85,6 @@
   padding: 8px;
   border-radius: var(--radius-md);
   transition: all var(--duration-fast) var(--ease-out);
-  z-index: calc(var(--z-fixed) + 50);
   flex-shrink: 0;
 }
 
@@ -281,7 +300,7 @@
   background: rgba(255, 255, 255, 0.98);
   backdrop-filter: blur(var(--backdrop-blur-lg));
   -webkit-backdrop-filter: blur(var(--backdrop-blur-lg));
-  z-index: 999999;
+  z-index: var(--z-modal-backdrop);
   overflow-y: auto;
   animation: fadeIn var(--duration-normal) var(--ease-out);
 }
@@ -293,7 +312,7 @@
 }
 
 .mobile-menu__nav {
-  padding: var(--space-xl) var(--space-lg);
+  padding: calc(var(--header-height) + var(--space-lg)) var(--space-lg) var(--space-xl);
 }
 
 .mobile-menu__nav ul {
@@ -553,4 +572,5 @@ body.menu-open {
   .dark .mobile-menu-toggle:hover {
     background: rgba(191, 164, 255, 0.15);
   }
+
 }

--- a/css/components/search.css
+++ b/css/components/search.css
@@ -106,7 +106,7 @@
   bottom: 0;
   width: 100vw;
   height: 100vh;
-  z-index: 999999;
+  z-index: var(--z-tooltip);
   display: none;
   align-items: flex-start;
   justify-content: center;


### PR DESCRIPTION
## 📚 Description

Keep the navbar visible on menu resolution when the menu is open, and make tables full-width.

- Pin site-header above the mobile menu overlay so the hamburger animates to X and the logo stays visible while the menu is open.
- Reorder z-index tokens (overlay/header/container/search modal) using the theme z-index scale instead of arbitrary large values.
- Drop the elevated z-index on the hamburger toggle so the search modal layers above it when the menu is closed.
- Render markdown tables full-width on mobile instead of horizontal scroll, with table-layout: fixed and word-break.
- Tighten the installation page comparison table formatting.