### PR TITLE
docs: DX audit pass across core docs (fix breakers, version drift, consistency)

### DIFF
--- a/.claude/skills/update-phel/SKILL.md
+++ b/.claude/skills/update-phel/SKILL.md
@@ -37,7 +37,18 @@ This repo pins `phel-lang/phel-lang` in `composer.json` and mirrors the active v
    (`build/doc-snippets-baseline.json`) is empty, so ANY newly-broken snippet
    is reported as a regression and fails. See "When snippets break" below.
 
-5. **Commit.** Use this exact subject (matches prior `chore: bump phel-lang to 0.39.0` convention):
+5. **Scan prose for stale version strings.** The snippet harness only runs ` ```phel ` blocks, so versions written in prose, JSON examples, and upgrade headings drift silently (they are never executed). After bumping to vX.Y.Z, grep for and update any that still name an older version:
+   ```bash
+   grep -rnE '"phel-lang/phel-lang": *"\^0\.[0-9]+"|^## Upgrading|var-dumper' content/
+   ```
+   Update at least:
+   - `content/documentation/installation.md` - the `## Upgrading to ...` heading, the `composer require phel-lang/phel-lang:^X.Y` command, and a short breaking-changes list for the new minor (pull from the release notes).
+   - `content/documentation/guides/coming-from-clojure.md` - the example `composer.json` pin.
+   - `content/documentation/tooling/php-tools.md` - the `symfony/var-dumper` constraint should match this repo's own `composer.json`.
+
+   These prose fixes belong in the same commit or a follow-up `docs:` commit.
+
+6. **Commit.** Use this exact subject (matches prior `chore: bump phel-lang to 0.39.0` convention):
    ```
    chore: bump phel-lang to X.Y.Z
    ```

--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -16,6 +16,7 @@ Phel is a functional Lisp that compiles to PHP: persistent data structures, immu
 3. [Basic Types](/documentation/language/basic-types/) then [Data Structures](/documentation/language/data-structures/) - the core you use everywhere
 4. [Cheat Sheet](/documentation/reference/cheat-sheet/) - keep it open while you code
 5. [Cookbook](/documentation/guides/cookbook/) - copy-paste recipes for real tasks
+6. [Build a Web App](/documentation/guides/build-a-web-app/) - a complete guestbook, end to end
 
 Coming from another language? Jump to [Rosetta Stone: PHP to Phel](/documentation/guides/rosetta-stone/) or [Coming from Clojure](/documentation/guides/coming-from-clojure/).
 
@@ -28,7 +29,7 @@ Coming from another language? Jump to [Rosetta Stone: PHP to Phel](/documentatio
   </a>
   <a href="/documentation/guides/" class="section-page-card">
     <h3 class="section-page-card__title">Guides</h3>
-    <p class="section-page-card__desc">Transition guides for PHP and Clojure developers, plus a cookbook of real-world recipes.</p>
+    <p class="section-page-card__desc">Build a complete web app end to end, transition guides for PHP and Clojure developers, and a cookbook of real-world recipes.</p>
   </a>
   <a href="/documentation/tooling/" class="section-page-card">
     <h3 class="section-page-card__title">Tooling</h3>

--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -39,7 +39,9 @@ Covers running, testing, formatting, building. Defaults handle the rest.
 
 ```php
 <?php
-// phel-config.php, every with*() option, default values shown
+// phel-config.php, every with*() option with its default value shown.
+// withLayout(ProjectLayout::Flat|Nested|Root) is a shortcut that sets the
+// src/test/format/export dirs below in one call; use it instead of those setters.
 return (new \Phel\Config\PhelConfig())
     ->withSrcDirs(['src'])
     ->withTestDirs(['tests'])
@@ -54,6 +56,8 @@ return (new \Phel\Config\PhelConfig())
     ->withPhelDir('.phel')
     ->withEnableNamespaceCache(true)
     ->withEnableCompiledCodeCache(true)
+    ->withEnableAsserts(true)
+    ->withWarnDeprecations(false)
     ->withMainPhelNamespace('your-ns.index')
     ->withMainPhpPath('out/index.php')
     ->withBuildDestDir('out')

--- a/content/documentation/guides/coming-from-clojure.md
+++ b/content/documentation/guides/coming-from-clojure.md
@@ -362,68 +362,17 @@ Use `;` and `;;`. Legacy `#` line and `#| ... |#` block comments still read but 
 
 ## PHP interop
 
-Phel's equivalent of Clojure's Java interop. `php/` prefix unlocks the PHP ecosystem.
+Phel's equivalent of Clojure's Java interop: the `php/` prefix unlocks the whole PHP ecosystem, and the Clojure-style shorthands carry over.
 
-### Calling PHP functions
+| Clojure                   | Phel                                                            |
+|---------------------------|-----------------------------------------------------------------|
+| `(Math/pow 2 10)`         | `(php/pow 2 10)` (any PHP function via `php/`)                   |
+| `(Classname. args)`       | `(php/new Classname args)`                                      |
+| `(.method obj args)`      | `(php/-> obj (method args))` or `(.method obj args)`            |
+| `(Classname/method args)` | `(php/:: Classname (method args))` or `(Classname/method args)` |
+| array element             | `(php/aget arr key)` (PHP arrays, not Phel data structures)     |
 
-```phel
-(php/strlen "hello")                        ; => 5
-(php/array_reverse (to-php-array [3 1 2]))  ; PHP array_reverse
-(php/date "Y-m-d")                          ; => "2024-01-15"
-(php/json_encode (to-php-array {:a 1}))
-```
-
-### Creating objects
-
-```phel
-(ns my.app
-  (:use DateTimeImmutable))
-
-(def now (php/new DateTimeImmutable))
-(def db (php/new \PDO "sqlite::memory:"))
-```
-
-### Method calls
-
-```phel
-(ns my.app
-  (:use DateTimeImmutable))
-
-(def now (php/new DateTimeImmutable))
-
-;; Instance methods - two equivalent forms:
-(php/-> now (format "Y-m-d"))
-(.format now "Y-m-d")            ; .method shorthand
-
-;; Chaining
-(php/-> (DateTimeImmutable. "2024-01-15")
-        (modify "+1 month")
-        (format "Y-m-d"))
-```
-
-### Static methods and constants
-
-```phel
-;; Static methods - two equivalent forms:
-(php/:: DateTimeImmutable (createFromFormat "Y-m-d" "2024-03-22"))
-(DateTimeImmutable/createFromFormat "Y-m-d" "2024-03-22")  ; shorthand
-
-;; Constants
-(php/:: DateTimeImmutable ATOM)
-DateTimeImmutable/ATOM                                      ; shorthand
-```
-
-### PHP array access
-
-For PHP arrays (not Phel data structures), use `php/aget`, `php/aset`:
-
-```phel
-(def config (php/json_decode (php/file_get_contents "config.json") true))
-(php/aget config "database")
-(php/aget-in config ["database" "host"])
-```
-
-Full interop reference: [PHP Interop](/documentation/php-interop).
+See [PHP Interop](/documentation/php-interop/) for the full reference: functions, objects, method and static calls, constants, and PHP-array access.
 
 ## What you'll miss (and workarounds)
 

--- a/content/documentation/guides/coming-from-clojure.md
+++ b/content/documentation/guides/coming-from-clojure.md
@@ -442,7 +442,7 @@ Use Composer. `composer.json` replaces `deps.edn`:
 ```json
 {
   "require": {
-    "phel-lang/phel-lang": "^0.40",
+    "phel-lang/phel-lang": "^0.41",
     "php": ">=8.4"
   }
 }

--- a/content/documentation/guides/cookbook.md
+++ b/content/documentation/guides/cookbook.md
@@ -537,7 +537,7 @@ Persistent KV store backed by JSON. Get, put, delete, list keys.
     (store-save path updated)
     updated))
 
-(store-put-many [[:lang "phel"] [:version "0.37"] [:status "awesome"]])
+(store-put-many [[:lang "phel"] [:version "0.41"] [:status "awesome"]])
 (println (str "All keys: " (store-keys)))
 ```
 

--- a/content/documentation/guides/rosetta-stone.md
+++ b/content/documentation/guides/rosetta-stone.md
@@ -1240,8 +1240,6 @@ $result = implode(", ",
 </div>
 </div>
 
-<script src="/rosetta-stone.js" defer></script>
-
 ## Next steps
 
 - [Cookbook](/documentation/guides/cookbook/) - ready-made recipes for common tasks

--- a/content/documentation/installation.md
+++ b/content/documentation/installation.md
@@ -208,14 +208,24 @@ Editor integration: nREPL + LSP. See [Editor Support](/documentation/tooling/edi
 </div>
 </details>
 
-## Upgrading from 0.38
+## Upgrading to 0.41
 
 ```bash
-composer require phel-lang/phel-lang:^0.39
+composer require phel-lang/phel-lang:^0.41
 ./vendor/bin/phel cache:clear        # or: rm -rf .phel/cache
 ```
 
-Cached PHP from earlier installs references renamed core types and fails to load otherwise. Rebuild downstream projects after upgrade.
+Always clear the cache after upgrading: compiled PHP from earlier installs references renamed core types and fails to load otherwise. Rebuild downstream projects too.
+
+Breaking changes in 0.41:
+
+- Stricter argument errors: `take` with a non-int count, `remove` / `select-keys` on a non-seqable, `int` / `long` / `float` / `double` on non-numeric values, and `get` / `assoc` / `update` with non-int keys now raise clean Phel errors instead of leaking a PHP `TypeError`. Code that leaned on silent coercion must pass real values.
+- Clojure-aligned laziness: `map`, `filter`, `remove`, `concat`, `distinct`, and `repeatedly` no longer realize their head eagerly, `map` over `nil` returns a lazy seq, and `LazySeq` no longer drops `nil` values. Force with `doall` or `vec` where you relied on eager evaluation.
+
+Breaking changes in 0.40:
+
+- `phel agent-install`: the `.agents/` docs tree is now copied by default. The `--with-docs` flag is gone; use `--no-docs` to opt out.
+- Map destructuring with `:keys` / `:strs` / `:syms` and a non-vector value now reports a shape error instead of silently dropping the binding.
 
 Breaking changes in 0.39 (Clojure-aligned core type renames):
 

--- a/content/documentation/language/destructuring.md
+++ b/content/documentation/language/destructuring.md
@@ -161,3 +161,4 @@ Loop bindings:
 
 - [Functions and recursion](/documentation/language/functions-and-recursion/) - destructure function arguments
 - [Data structures](/documentation/language/data-structures/) - the collections you destructure
+- [Cheat sheet](/documentation/reference/cheat-sheet/) - keep it open while coding

--- a/content/documentation/language/global-and-local-bindings.md
+++ b/content/documentation/language/global-and-local-bindings.md
@@ -246,4 +246,5 @@ Prefer immutable data structures. Atoms mainly for PHP interop or app state.
 
 - [Control flow](/documentation/language/control-flow/) - branch and loop over your bindings
 - [Functions and recursion](/documentation/language/functions-and-recursion/) - define and compose behavior
+- [Cheat sheet](/documentation/reference/cheat-sheet/) - keep it open while coding
 

--- a/content/documentation/language/interfaces.md
+++ b/content/documentation/language/interfaces.md
@@ -350,3 +350,4 @@ Multimethods check the hierarchy for parent matches when dispatching:
 
 - [Functions and recursion](/documentation/language/functions-and-recursion/) - multimethods for open dispatch
 - [Data structures](/documentation/language/data-structures/) - structs and the maps they build on
+- [Cheat sheet](/documentation/reference/cheat-sheet/) - keep it open while coding

--- a/content/documentation/language/macros.md
+++ b/content/documentation/language/macros.md
@@ -163,3 +163,4 @@ If the same result is achievable by passing values or functions, write a functio
 
 - [Functions and recursion](/documentation/language/functions-and-recursion/) - the default tool; prefer it over macros
 - [Basic types](/documentation/language/basic-types/) - quote, lists, and symbols that macros manipulate
+- [Cheat sheet](/documentation/reference/cheat-sheet/) - keep it open while coding

--- a/content/documentation/language/namespaces.md
+++ b/content/documentation/language/namespaces.md
@@ -200,3 +200,4 @@ Fully qualified: namespace, `/`, keyword name.
 
 - [Interfaces](/documentation/language/interfaces/) - share behavior across types within a namespace
 - [Configuration](/documentation/configuration/) - set the source paths namespaces resolve from
+- [Cheat sheet](/documentation/reference/cheat-sheet/) - keep it open while coding

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -617,3 +617,4 @@ Mark a function exported with metadata:
 - [Error Handling](/documentation/language/error-handling/): `try`, `catch`, `finally`, `ex-info`.
 - [Configuration](/documentation/configuration/): `withExport*` options for `phel export`.
 - [PHP API reference](/documentation/reference/api/php): every `php/*` builtin.
+- [Rosetta Stone](/documentation/guides/rosetta-stone/): PHP and Phel side by side, interop included.

--- a/content/documentation/reference/cheat-sheet.md
+++ b/content/documentation/reference/cheat-sheet.md
@@ -366,7 +366,7 @@ Requires `(:require phel.string :as str)`:
 
 ```phel
 (ns my-app.strings
-  (:require phel\string :as str))
+  (:require phel.string :as str))
 
 (str/lower-case "HELLO")           ; => "hello"
 (str/upper-case "hello")           ; => "HELLO"
@@ -721,8 +721,8 @@ Integer division (`/`) returns a `Ratio` when not evenly divisible. Use `float` 
 
 ```phel
 (ns my-app.serialize
-  (:require phel\edn :as edn)
-  (:require phel\transit :as transit))
+  (:require phel.edn :as edn)
+  (:require phel.transit :as transit))
 
 ;; phel.edn: eval-free EDN read/write (data only, no code execution)
 (edn/read-string "{:a 1 :b [2 3]}")    ; => {:a 1, :b [2 3]}
@@ -734,13 +734,11 @@ Integer division (`/`) returns a `Ratio` when not evenly divisible. Use `float` 
 (transit/read-string "[\"~:foo\",1]")  ; => [:foo 1]
 ```
 
-Require with `(:require phel.edn :as edn)` / `(:require phel.transit :as transit)`.
-
 ## Reflection
 
 ```phel
 (ns my-app.introspect
-  (:require phel\reflect :as reflect))
+  (:require phel.reflect :as reflect))
 
 ;; phel.reflect: introspect PHP classes via reflection
 (reflect/class-info \DateTime)         ; => map of name, methods, properties, ...
@@ -748,8 +746,6 @@ Require with `(:require phel.edn :as edn)` / `(:require phel.transit :as transit
 (reflect/properties \DateInterval)     ; => vector of property-info maps
 (reflect/supers \RuntimeException)     ; => parent classes + interfaces
 ```
-
-Require with `(:require phel.reflect :as reflect)`.
 
 ## REPL utilities
 

--- a/content/documentation/reference/errors.md
+++ b/content/documentation/reference/errors.md
@@ -26,7 +26,7 @@ A symbol could not be resolved to a definition in the current scope.
 
 **Common cause:** A typo, a missing `(:require ...)` for the namespace the symbol lives in, an alias that does not match, or using a binding before it is defined.
 
-**Fix:** Check the spelling, require the namespace (e.g. `(:require phel\string :as str)` for `str/...`), or move the definition above its first use. The error message suggests near matches.
+**Fix:** Check the spelling, require the namespace (e.g. `(:require phel.string :as str)` for `str/...`), or move the definition above its first use. The error message suggests near matches.
 
 ### PHEL002 : Arity error
 
@@ -60,6 +60,8 @@ A macro threw while expanding.
 
 **Fix:** Check the arguments at the call site and inspect the expansion with `(macroexpand '(your-form ...))`.
 
+**Learn more:** [Macros](/documentation/language/macros/).
+
 ### PHEL006 : Inline expansion error
 
 An inline-expanded function failed to expand.
@@ -84,6 +86,8 @@ A binding vector is invalid.
 
 **Fix:** Provide an even number of `name value` pairs and use valid destructuring targets (symbols, vectors, maps).
 
+**Learn more:** [Destructuring](/documentation/language/destructuring/), [Global and local bindings](/documentation/language/global-and-local-bindings/).
+
 ### PHEL009 : Interface error
 
 An interface or protocol definition (or its implementation) is invalid.
@@ -92,6 +96,8 @@ An interface or protocol definition (or its implementation) is invalid.
 
 **Fix:** Use `definterface` for inline implementation, or `defprotocol` plus `extend-type` per struct.
 
+**Learn more:** [Interfaces](/documentation/language/interfaces/).
+
 ### PHEL010 : Recur error
 
 `recur` was used incorrectly.
@@ -99,6 +105,8 @@ An interface or protocol definition (or its implementation) is invalid.
 **Common cause:** `recur` appeared outside a `loop`/`fn` tail position, or with an argument count that does not match the recursion point.
 
 **Fix:** Use `recur` only in tail position, with as many arguments as the enclosing `loop`/`fn` binds.
+
+**Learn more:** [Functions and recursion](/documentation/language/functions-and-recursion/).
 
 ### PHEL011 : Not callable
 

--- a/content/documentation/testing.md
+++ b/content/documentation/testing.md
@@ -255,6 +255,18 @@ Re-run each test N times, randomize discovery order, and seed for reproducible r
 
 `--seed=<int>` alone fixes the seed for the default deterministic order.
 
+### Parallel execution
+
+Run namespaces across subprocess workers to speed up large suites:
+
+```bash
+./vendor/bin/phel test --parallel=auto   # CPU detection, capped at 8 workers
+./vendor/bin/phel test --parallel=4      # fixed worker count
+./vendor/bin/phel test --parallel=max    # every core the kernel reports
+```
+
+Auto-disabled for `--reporter=tap`, `--list`, and when a profiler hook is installed.
+
 {% php_note() %}
 Test command similar to PHPUnit:
 

--- a/content/documentation/tooling/_index.md
+++ b/content/documentation/tooling/_index.md
@@ -7,4 +7,4 @@ template = "section-page.html"
 description = "The Phel developer toolkit: CLI commands, the interactive REPL, editor integrations, and step debugging with Xdebug."
 +++
 
-Everything around writing Phel day to day. The **CLI** drives building, formatting, testing, and exporting; the **REPL** is where you explore and iterate; **editor support** and **Xdebug** wire Phel into your workflow.
+Everything around writing Phel day to day. The **CLI** drives building, formatting, testing, and exporting; the **REPL** is where you explore and iterate; **editor support**, **Xdebug**, and **PHP debugging tools** (`dump`/`dd`) wire Phel into your workflow.

--- a/content/documentation/tooling/cli-commands.md
+++ b/content/documentation/tooling/cli-commands.md
@@ -167,6 +167,7 @@ vendor/bin/phel test
 #       --repeat=N          Run each test N times (default 1).
 #       --seed=INT          Seed used for randomized order.
 #       --random-order      Run tests in random order (uses --seed if given).
+#       --parallel=N        Run namespaces in subprocess workers: int, "auto" (capped at 8), or "max".
 ```
 
 Test selectors and reporters: see [Testing](/documentation/testing/).

--- a/content/documentation/tooling/cli-commands.md
+++ b/content/documentation/tooling/cli-commands.md
@@ -305,7 +305,9 @@ vendor/bin/phel agent-install --auto       # only platforms detected in project
 vendor/bin/phel agent-install --check      # report installed vs current; exits 1 on drift
 vendor/bin/phel agent-install --list       # enumerate platforms, sources, targets, state
 vendor/bin/phel agent-install --uninstall  # remove skill files, restore .pre-phel.bak
-#   --with-docs        Include reference docs (.agents/)
+#   The shared .agents/ docs tree is copied by default; pass --no-docs to skip it.
+#   --with-examples    Also copy example projects into .agents/examples/ (excluded by default)
+#   --no-docs          Skip the .agents/ docs tree
 #   --dry-run          Show what would be written
 #   --force            Overwrite existing files
 ```

--- a/content/documentation/tooling/php-tools.md
+++ b/content/documentation/tooling/php-tools.md
@@ -41,7 +41,7 @@ Use [Symfony VarDumper](https://symfony.com/doc/current/components/var_dumper.ht
 
 ```json
 "require-dev": {
-    "symfony/var-dumper": "^6.4|^7.0"
+    "symfony/var-dumper": "^7.4"
 },
 ```
 

--- a/content/documentation/tooling/xdebug-setup.md
+++ b/content/documentation/tooling/xdebug-setup.md
@@ -103,7 +103,7 @@ xdebug.client_port=9003
 
 ### VSCode
 
-Install the [PHP Debug extension](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug):
+Install the [Phel VS Code extension](https://github.com/phel-lang/phel-vs-code-extension). It ships the `phel` debug adapter that the `launch.json` below uses (the generic PHP Debug extension only provides `"type": "php"` and cannot step through `.phel` files):
 
 Create `.vscode/launch.json` in your Phel project:
 

--- a/content/documentation/web/routing.md
+++ b/content/documentation/web/routing.md
@@ -26,7 +26,7 @@ A route is `[path data]`, where `data` is a map. Put a 1-arg `request -> respons
   (http/response-from-map {:status 200 :body (html [:h1 "Home"])}))
 
 (defn show-user [request]
-  (let [id (get-in request [:attributes :match :id])]
+  (let [id (get-in request [:attributes :match :path-params :id])]
     (http/response-from-map {:status 200 :body (html [:h1 (str "User " id)])})))
 
 (def routes
@@ -34,7 +34,7 @@ A route is `[path data]`, where `data` is a map. Put a 1-arg `request -> respons
    ["/users/{id}" {:name :user :get {:handler show-user}}]])
 ```
 
-A handler returns a response, built with `response-from-map` from [Request and Response](/documentation/web/http-request-and-response/). Path variables like `{id}` arrive under `[:attributes :match]` on the request.
+A handler returns a response, built with `response-from-map` from [Request and Response](/documentation/web/http-request-and-response/). Path variables like `{id}` arrive under `[:attributes :match :path-params]` on the request.
 
 ## Build a router and a handler
 
@@ -90,7 +90,8 @@ A handler returns a response, built with `response-from-map` from [Request and R
                    :get {:handler (fn [request] {:status 200 :body "User"})}}]])
 
 (router/match-by-path (router/router routes) "/users/42")
-;; the matched route data, including :path-params {:id 42}
+;; the full match map: {:route-name :user :template "/users/{id}"
+;;                      :data {...} :path "/users/42" :path-params {:id 42}}
 
 (router/generate (router/router routes) :user {:id 42})
 ;; Evaluates to "/users/42"


### PR DESCRIPTION
Multi-agent DX audit of the 37 core documentation pages (API reference and release notes excluded). Every objective finding was verified against the Phel runtime and filesystem before fixing; the full snippet suite passes (474/474, 0 regressions).

## Runtime breakers (confirmed by running the code)
- **routing**: `show-user` read the path var from `[:attributes :match :id]` (always `nil`); correct key is `[:attributes :match :path-params :id]`. Silent because no test read the value.
- **cli-commands**: documented `agent-install --with-docs`, which errors at runtime. Real flags are `--with-examples` / `--no-docs` (docs copy by default).
- **xdebug-setup**: told readers to install the generic *PHP Debug* extension, then gave a `"type": "phel"` `launch.json`. Now points at the Phel VS Code extension that ships the `phel` debug adapter.

## Version drift (none caught by the snippet harness: prose/JSON is never executed)
Repo ships `phel-lang/phel-lang ^0.41`, but prose had drifted to three different stale values.
- installation: upgrade section rewritten to land on 0.41, with 0.40/0.41 breaking changes.
- coming-from-clojure: example `composer.json` `^0.40` -> `^0.41`.
- php-tools: `symfony/var-dumper` `^6.4|^7.0` -> `^7.4` (matches repo).
- cookbook: refreshed stale `0.37` sample.
- **`update-phel` skill** gained a prose version-string scan step so this stops recurring.

## Consistency & quick wins
- Cheat-sheet footer bullet now on all 11 language pages (was 5).
- errors.md codes (PHEL005/008/009/010) cross-link to their concept pages (was a nav island).
- Require syntax normalized to the dot form (dropped deprecated backslash separator).
- Build a Web App surfaced on the docs landing page; PHP debugging tools in the tooling intro.
- Duplicated PHP-interop reference in the Clojure guide collapsed to a compact table pointing at php-interop.md (-55 lines), with a back-link added.
- `test --parallel` documented in testing.md and cli-commands.md.
- configuration full-reference block completed; rosetta-stone double script-load removed.

## Verification
- `composer test:snippets`: 474/474 pass, 0 regressions.
- Every added internal link resolves to a real route.
- No em-dashes introduced (project rule).

## Out of scope (noted for follow-up)
- `practice/basic.md` and `practice/challenges.md` link to `/documentation/language/arithmetic` (404 -> should be `basic-types`). Practice pages were excluded from this audit.
- 62 low/subjective prose findings (verbosity, dedup-able examples) not applied; available on request.