### PR TITLE
Bump phel-lang to 0.42.0 and document new PHP interop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=8.4",
         "ext-json": "*",
-        "phel-lang/phel-lang": "^0.41",
+        "phel-lang/phel-lang": "^0.42",
         "gacela-project/gacela": "^1.14"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7f10b4578063c6497b1c38fa46c0e0b",
+    "content-hash": "7deb33a04ed5a3507ddd3231a0651f97",
     "packages": [
         {
             "name": "amphp/amp",
@@ -242,16 +242,16 @@
         },
         {
             "name": "phel-lang/phel-lang",
-            "version": "v0.41.0",
+            "version": "v0.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "8ba7e55096ff7dd08ea2a2640f85367c57e778f5"
+                "reference": "6a9f875a8975790ec3bfa082e2f5e93fccf78661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/8ba7e55096ff7dd08ea2a2640f85367c57e778f5",
-                "reference": "8ba7e55096ff7dd08ea2a2640f85367c57e778f5",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/6a9f875a8975790ec3bfa082e2f5e93fccf78661",
+                "reference": "6a9f875a8975790ec3bfa082e2f5e93fccf78661",
                 "shasum": ""
             },
             "require": {
@@ -259,7 +259,7 @@
                 "gacela-project/gacela": "^1.14",
                 "php": ">=8.4",
                 "symfony/console": "^6.0|^7.0|^8.0",
-                "symfony/routing": "^7.3"
+                "symfony/routing": "^7.3|^8.0"
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.50",
@@ -267,10 +267,10 @@
                 "friendsofphp/php-cs-fixer": "^3.94",
                 "phpbench/phpbench": "^1.6",
                 "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^10.5",
-                "psalm/plugin-phpunit": "^0.19",
+                "phpunit/phpunit": "^11.0|^12.0|^13.0",
+                "psalm/plugin-phpunit": "^0.19|^0.20",
                 "rector/rector": "^2.3",
-                "symfony/var-dumper": "^7.4",
+                "symfony/var-dumper": "^7.4|^8.0",
                 "vimeo/psalm": "^6.16"
             },
             "bin": [
@@ -310,7 +310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phel-lang/phel-lang/issues",
-                "source": "https://github.com/phel-lang/phel-lang/tree/v0.41.0"
+                "source": "https://github.com/phel-lang/phel-lang/tree/v0.42.0"
             },
             "funding": [
                 {
@@ -318,7 +318,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-06-01T09:54:22+00:00"
+            "time": "2026-06-06T09:43:55+00:00"
         },
         {
             "name": "psr/container",
@@ -943,34 +943,29 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.13",
+            "version": "v8.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
+                "reference": "18e6213e536842285dfdd29604e43ac8f784d17d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
-                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/18e6213e536842285dfdd29604e43ac8f784d17d",
+                "reference": "18e6213e536842285dfdd29604e43ac8f784d17d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/config": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/yaml": "<6.4"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1004,7 +999,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.13"
+                "source": "https://github.com/symfony/routing/tree/v8.0.13"
             },
             "funding": [
                 {
@@ -1024,7 +1019,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T11:20:33+00:00"
+            "time": "2026-05-24T11:21:57+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/config.toml
+++ b/config.toml
@@ -31,4 +31,4 @@ extra_grammars = ["syntaxes/phel.tmLanguage.json", "syntaxes/clojure.tmLanguage.
 # Put all your custom variables here
 
 repo_content_url = "https://github.com/phel-lang/phel-lang.org/edit/master/content/"
-phel_version = "v0.41.0"
+phel_version = "v0.42.0"

--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -95,7 +95,7 @@ return (new \Phel\Config\PhelConfig())
 
 </details>
 
-> **Note:** Old `setX()` setters are deprecated since 0.37 and emit notices. Use the `withX()` chain, the API is immutable.
+> **Note:** Old `setX()` setters are deprecated and emit notices. Use the `withX()` chain, the API is immutable.
 
 ## Next steps
 

--- a/content/documentation/guides/coming-from-clojure.md
+++ b/content/documentation/guides/coming-from-clojure.md
@@ -391,7 +391,7 @@ Use Composer. `composer.json` replaces `deps.edn`:
 ```json
 {
   "require": {
-    "phel-lang/phel-lang": "^0.41",
+    "phel-lang/phel-lang": "^0.42",
     "php": ">=8.4"
   }
 }

--- a/content/documentation/installation.md
+++ b/content/documentation/installation.md
@@ -208,14 +208,33 @@ Editor integration: nREPL + LSP. See [Editor Support](/documentation/tooling/edi
 </div>
 </details>
 
-## Upgrading to 0.41
+## Upgrading to 0.42
 
 ```bash
-composer require phel-lang/phel-lang:^0.41
+composer require phel-lang/phel-lang:^0.42
 ./vendor/bin/phel cache:clear        # or: rm -rf .phel/cache
 ```
 
 Always clear the cache after upgrading: compiled PHP from earlier installs references renamed core types and fails to load otherwise. Rebuild downstream projects too.
+
+Behaviour changes in 0.42:
+
+- Structs print with a `.` separator instead of `\` (e.g. `(my.ns.point 1 2)`). Snapshot tests or code that parses struct output must match the new form.
+- `str/index-of` returns `nil` for an empty search string instead of throwing a PHP `ValueError`.
+- Lexer columns are counted in code points, so error locations in multibyte source point at the right column.
+- `if-let`, `when-let`, `if-some`, `when-first` are now hygienic: a user binding named like the macros' internal temporary no longer collides.
+
+New in 0.42 (richer typed PHP interop, all opt-in):
+
+- `phel.reflect`: read PHP 8 attributes (`class-attributes` / `method-attributes` / ...) and bridge native enums (`enum->keyword` / `keyword->enum` / `enum-values`).
+- `defenum` native backed enums and `defexception` with an optional parent class.
+- `php/ref` passes a local by reference into `php/->` / `php/::` and plain PHP calls like `preg_match` / `sort`.
+- `hydrate` / `bean` bridge a Phel map and a typed PHP object both ways.
+- PHP 8 named arguments in `php/new` / `php/->` / `php/::` via the `:&` marker, e.g. `(php/new \App\Mailer :& :host "smtp")`.
+- `iterator-seq` builds a lazy seq over any PHP `Traversable`.
+- `defstruct` `:php` blocks declare inline PHP magic methods; `phel format` and `phel.http` JSON bodies / response builders round it out.
+
+See the [0.42 release notes](/releases/0-42-life-php-everything/) for the full list.
 
 Breaking changes in 0.41:
 

--- a/content/documentation/language/functions-and-recursion.md
+++ b/content/documentation/language/functions-and-recursion.md
@@ -134,7 +134,7 @@ Equivalent, but `defn-` is more concise.
 
 ### Defn metadata shortcuts
 
-Tag a `defn` with metadata to wrap the body automatically (added in 0.37):
+Tag a `defn` with metadata to wrap the body automatically:
 
 <!-- phel-test: skip -->
 ```phel
@@ -155,7 +155,7 @@ Tag a `defn` with metadata to wrap the body automatically (added in 0.37):
 
 ### Return and parameter types (`:tag`)
 
-Annotate types with `:tag` metadata (added in 0.37). The compiler emits PHP type declarations and runs static checks at compile time:
+Annotate types with `:tag` metadata. The compiler emits PHP type declarations and runs static checks at compile time:
 
 ```phel
 (defn ^int add [^int a ^int b] (+ a b))

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -65,7 +65,7 @@ array_map($fn, $array);
 However, Phel provides functional equivalents for many operations. For example, use `(count "test")` instead of `(php/strlen "test")` when working with Phel data structures.
 {% end %}
 
-Namespaced PHP functions use full path after `php/`. Three equivalent forms accepted (added in 0.37, last two are backslash-free):
+Namespaced PHP functions use full path after `php/`. Three equivalent forms accepted (last two are backslash-free):
 
 <!-- phel-test: skip -->
 ```phel
@@ -240,6 +240,44 @@ DateTimeImmutable/ATOM
 (DateTimeImmutable/createFromFormat "Y-m-d" "2020-03-22")
 ```
 {% end %}
+
+## Named arguments
+
+PHP 8 named arguments are passed after a `:&` marker as `:key value` pairs. Works in `php/new`, `php/->`, and `php/::`. Keyword keys map to the PHP parameter names; order is then irrelevant.
+
+```phel
+(let [dt (php/:: \DateTime
+                 (createFromFormat :& :format "Y-m-d" :datetime "2026-06-06"))]
+  (php/-> dt (format "Y-m-d"))) ; => "2026-06-06"
+```
+
+{% php_note() %}
+```php
+// PHP
+\DateTime::createFromFormat(format: "Y-m-d", datetime: "2026-06-06");
+new \App\Mailer(host: "smtp", port: 587);
+```
+
+<!-- phel-test: skip -->
+```phel
+;; Phel
+(php/:: \DateTime (createFromFormat :& :format "Y-m-d" :datetime "2026-06-06"))
+(php/new \App\Mailer :& :host "smtp" :port 587)
+```
+{% end %}
+
+## By-reference arguments
+
+Some PHP functions write through a `&$ref` parameter (`preg_match`, `sort`, ...). Wrap a **local** binding in `php/ref` to pass it by reference; the local must be `let`-bound (a top-level `def` is not a PHP variable).
+
+```phel
+(let [subject "order-42"
+      matches (php/array)]
+  (php/preg_match "/(\d+)/" subject (php/ref matches))
+  (php/aget matches 1)) ; => "42"
+```
+
+`php/ref` also works inside `php/->` / `php/::` calls.
 
 ## Set object properties
 
@@ -510,6 +548,21 @@ __FILE__  // Points to cached .php file
 
 Use `*file*` when you need to reference the original Phel source location, such as for loading resources relative to your source code.
 {% end %}
+
+## Map to typed object and back
+
+`hydrate` and `bean` bridge a Phel map and a typed PHP object both ways: `hydrate` rebuilds an instance from a map (skipping the constructor, like an ORM rehydrating an entity), and `bean` reads an object's public properties back into a map with keyword keys.
+
+<!-- phel-test: skip -->
+```phel
+;; class App\Point { public int $x; public int $y; }
+(def p (hydrate "App\\Point" {:x 1 :y 2})) ; => App\Point instance
+(bean p)                                    ; => {:x 1 :y 2}
+```
+
+To read PHP 8 attributes and bridge native enums, see `phel.reflect`
+(`class-attributes`, `enum->keyword`, ...) in the
+[API reference](/documentation/reference/api/reflect).
 
 ## Catching PHP exceptions
 

--- a/content/documentation/testing.md
+++ b/content/documentation/testing.md
@@ -73,7 +73,7 @@ The `is` macro defines assertions. Optional second argument is a description str
 (is (nil? (get {} :missing)))      ; any predicate works
 ```
 
-For collection equality, failures render a unified diff (added in 0.37) so missing/extra entries are obvious:
+For collection equality, failures render a unified diff so missing/extra entries are obvious:
 
 ```
 FAIL (= a b)

--- a/content/documentation/tooling/repl.md
+++ b/content/documentation/tooling/repl.md
@@ -59,7 +59,7 @@ user:4> (.getMessage *e)
 "Division by zero"
 ```
 
-Eval errors render as a headline + optional hint + trace with internal frames hidden (added in 0.37). Full PHP frames remain on `*e` for inspection via interop.
+Eval errors render as a headline + optional hint + trace with internal frames hidden. Full PHP frames remain on `*e` for inspection via interop.
 
 ## Built-in helpers
 


### PR DESCRIPTION
## Summary

- Bump `phel-lang/phel-lang` `^0.41` → `^0.42` (0.42.0). Lock refresh also pulls `symfony/routing` 8.0; post-update hook rewrote `config.toml` `phel_version = "v0.42.0"`.
- Document the new 0.42 PHP interop in `php-interop.md`: named arguments (`:&` marker), by-reference args (`php/ref`), and map↔typed-object (`hydrate`/`bean`). All runnable snippets verified against the runtime.
- Update `installation.md` upgrade notes (0.42 behaviour changes + new features) and bump composer pins in `installation.md` and `coming-from-clojure.md` to `^0.42`.
- Drop inline `added in 0.x` version stamps across the docs: pages describe the latest stable release, so per-feature version annotations are noise.

## Tests

- `composer test` → 47 tests pass
- `composer test:snippets` → 476 pass, 0 failed

API reference pages (`reference/api/*`, gitignored) regenerate at deploy. `errors.md` regeneration was reverted to keep hand-curated "Learn more" links (unrelated to the bump).