### PR TITLE
ci: fail deploy loudly on FTP 5xx errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,30 @@ jobs:
         run: zola build
 
       - name: Deploy via LFTP
+        env:
+          FTP_USERNAME: ${{ secrets.ftp_username }}
+          FTP_PASSWORD: ${{ secrets.ftp_password }}
+          FTP_HOST: ${{ secrets.ftp_host }}
+          FTP_TARGET: ${{ secrets.ftp_remote_target_dir }}
         run: |
+          set -euo pipefail
           sudo apt-get update && sudo apt-get install -y lftp
+
+          # Fail the lftp session on any command error, retry transient network errors.
           lftp -c "
-            open -u ${{ secrets.ftp_username }},${{ secrets.ftp_password }} ${{ secrets.ftp_host }};
-            ls;
-            mirror --reverse --delete --depth-first --overwrite --verbose public/ ${{ secrets.ftp_remote_target_dir }};
-          "
+            set cmd:fail-exit yes;
+            set net:max-retries 3;
+            set net:timeout 30;
+            set mirror:parallel-transfer-count 1;
+            open -u \"\$FTP_USERNAME\",\"\$FTP_PASSWORD\" \"\$FTP_HOST\";
+            mirror --reverse --delete --depth-first --overwrite --verbose public/ \"\$FTP_TARGET\";
+          " 2>&1 | tee lftp.log
+
+          # lftp's mirror can report per-file failures (e.g. 550 - cannot create
+          # directory, usually disk quota / permissions on the server) without a
+          # non-zero exit. Treat any server 5xx error as a hard, loud failure so a
+          # partial deploy never passes silently.
+          if grep -E "Access failed|^(mkdir|chmod|put|get): |[Ff]atal error|55[0-9]" lftp.log; then
+            echo "::error::LFTP deploy reported server errors (5xx). Likely disk quota or write permissions on the FTP host. Deploy is incomplete - failing the job."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

New documentation pages 404 in production (e.g. `/documentation/performance/`, `/documentation/deployment/`, `/documentation/framework-integration/`, `/documentation/lazy-sequences/`, AI guide). Pages build fine locally and navbar links are correct: the **deploy** is failing.

The `Deploy via LFTP` step in `main.yml` has been failing on every push to master. `lftp mirror` reports per-file errors:

```
chmod: Access failed: 550 ./deployment: No such file or directory
chmod: Access failed: 550 ./framework-integration: No such file or directory
chmod: Access failed: 550 ./lazy-sequences: No such file or directory
chmod: Access failed: 550 ./performance: No such file or directory
```

The server accepts overwrites of existing files but cannot create brand-new directories (550), so only net-new pages are missing. Root cause is server-side: disk quota / write permissions on the FTP host.

## What this PR does

This does **not** fix the server: it makes the failure honest. Previously `lftp` could report 5xx errors yet the step still passed green, so a partial deploy looked successful.

- `set cmd:fail-exit yes` + retries/timeout for transient network errors
- tee `lftp` output to a log, then grep for `Access failed` / 5xx / fatal errors and force `exit 1` with a `::error::` annotation
- move FTP credentials into `env:` (quoted, no shell-injection via secrets)

## Still required (server-side, not in this repo)

1. Free space / fix write permissions on the FTP host
2. Re-run deploy: `gh workflow run main.yml`