### PR TITLE
docs: document the match macro in control flow

### DIFF
--- a/content/documentation/language/control-flow.md
+++ b/content/documentation/language/control-flow.md
@@ -198,6 +198,84 @@ if ($value < 0) {
 Cleaner than nested `if`. Use `:else` as a default.
 {% end %}
 
+For destructuring-by-shape (matching the structure of vectors and maps, not just running predicates), see [Match](#match) below.
+
+## Match
+
+`match` lives in `phel.match` and dispatches by _shape_: it destructures the subject and binds names in one step. It expands to nested `cond` + `let` at compile time, so there is no runtime overhead beyond the checks you write.
+
+```phel
+(ns my-app.main (:require phel.match :refer [match]))
+
+(defn describe [x]
+  (match [x]
+    [0]                   "zero"
+    [[a b]]               (str "pair " a " / " b)
+    [{:type :err :msg m}] (str "error: " m)
+    [(n :guard pos?)]     "positive"
+    :else                 "other"))
+
+(describe 0)                        ; => "zero"
+(describe [1 2])                    ; => "pair 1 / 2"
+(describe {:type :err :msg "boom"}) ; => "error: boom"
+(describe 5)                        ; => "positive"
+```
+
+The subject is a vector of one or more targets; every pattern is a vector whose length must equal the target count.
+
+### Pattern kinds
+
+| Pattern | Matches |
+| --- | --- |
+| `42`, `:key`, `"s"` | literal equality |
+| `_` | wildcard (matches anything, binds nothing) |
+| `sym` | binds the target to `sym` |
+| `[a b c]` | a vector of exactly 3 elements, recursively matched |
+| `[head & tail]` | a vector, binding the remaining slice to `tail` |
+| `{:k sym}` | a map with key `:k`, binding its value to `sym` |
+| `(pat :as name)` | matches `pat`, also binds the whole subject to `name` |
+| `(pat :guard pred)` | matches `pat`, then requires `(pred subject)` truthy |
+| `(:or alt1 alt2 ...)` | any alternative matches (literal/structural only, no bindings) |
+
+### Guards
+
+A `:guard` adds a runtime predicate on top of a structural pattern:
+
+```phel
+(ns my-app.main (:require phel.match :refer [match]))
+
+(defn sign [n]
+  (match [n]
+    [(x :guard neg?)] "negative"
+    [(x :guard pos?)] "positive"
+    :else             "zero"))
+
+(sign -3) ; => "negative"
+(sign 7)  ; => "positive"
+(sign 0)  ; => "zero"
+```
+
+### Rest binding
+
+End a vector pattern with `& rest` to capture the remaining slice:
+
+```phel
+(ns my-app.main (:require phel.match :refer [match]))
+
+(match [[10 20 30]]
+  [[head & tail]] (str head ":" (count tail))) ; => "10:2"
+```
+
+### Pitfalls
+
+* Each pattern vector's length must equal the target count.
+* `:else` must be the final clause.
+* `:or` alternatives may not introduce bindings; they are literal or structural only.
+* Nested patterns bind left-to-right; a later binding shadows an earlier one with the same name.
+* A `:guard` predicate runs against the raw value. Numeric predicates coerce non-numbers, so `(pos? [1 2])` is truthy. Put literal and structural patterns _before_ an open numeric guard.
+
+See also [`phel.schema`](/documentation/reference/api/schema/) for shapes reusable across validation and matching, and `case`/`cond`/`condp` above for simpler dispatch without destructuring. Full API: [match reference](/documentation/reference/api/match/).
+
 ## Loop
 
 <!-- phel-test: skip -->
@@ -501,6 +579,7 @@ For catching PHP exceptions, structured errors with `ex-info`/`ex-data`, excepti
 
 ## Next steps
 
+- [Match reference](/documentation/reference/api/match/) - all `match` pattern kinds and the full API
 - [Error handling](/documentation/language/error-handling/) - throw, catch, and structured errors in depth
 - [Functions and recursion](/documentation/language/functions-and-recursion/) - `loop`/`recur` and tail calls
 - [Cheat sheet](/documentation/reference/cheat-sheet/) - keep it open while coding


### PR DESCRIPTION
## 🤔 What & why

The control-flow page is the dispatch hub (`if`, `case`, `cond`, `condp`, conditional threading) but had **zero coverage of the `match` macro** from `phel.match`. The corelib's `docs/match-guide.md` was deleted when guides moved to the site, leaving a gap. This folds match coverage into its natural home.

## ✨ What was added

A new `## Match` section in `content/documentation/language/control-flow.md`, placed **after `## Cond`** (and before `## Loop`) in the natural dispatch order, since match is the shape-dispatching sibling of `case`/`cond`. Proportional to its neighbors:

- Quickstart (literal / vector / map / guard / `:else`)
- A pattern-kinds table
- Guards subsection
- Rest-binding (`& tail`) subsection
- A short pitfalls list
- Cross-links to the `match` and `schema` API references

Discoverability:
- One-line pointer added to the **Cond** section ("for destructuring-by-shape, see Match below").
- **Next steps** now lists the match API reference.

## 🔧 API corrections (verified against the installed runtime in `vendor/`)

The source guide was reconstructed from memory; I verified every pattern kind with `vendor/bin/phel run` and corrected two drifts:

1. **`:guard` / `:as` operate on a _pattern_, not strictly a bare symbol.** The source wrote `(sym :guard pred)` / `(sym :as name)`; the actual form is `(pattern :guard pred)` / `(pattern :as name)`, where the pattern can be a bare symbol *or* a nested vector/map. The table now says `(pat :guard pred)` / `(pat :as name)`.
2. **`:or` alternatives may not introduce bindings** (literal/structural only). Binding alternatives error at expand time. Documented this explicitly in the pitfalls list and the table.

The numeric-guard pitfall from the source checks out: `(pos? [1 2])` is truthy (non-numbers coerce), so structural patterns must precede an open numeric guard.

## ✅ Snippets

CI runs every ` ```phel ` block via `phel run`. All match snippets are self-contained (full `(ns ... (:require phel.match :refer [match]))` header) and runnable.

`php build/run-doc-snippets.php --verbose content/documentation/language/control-flow.md`:
- **14 passed** (was 11; +3 new match snippets), **12 skipped**, 0 failed, no regressions.

`zola check --skip-external-links` clean (only pre-existing legal-page orphan warnings).

Folds the match-coverage gap flagged in phel-lang/phel-lang#2425.