### PR TITLE
ci: authenticate GitHub releases API to fix rate-limited build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         run: composer install --no-interaction --no-ansi --no-progress
 
       - name: Generate API documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: composer build
 
       - name: Setup Node.js

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
         run: composer install
 
       - name: Generate API Documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: composer build
 
       - name: Setup Node.js

--- a/build/src/ReleasesGenerator/Infrastructure/GitHubReleasePages.php
+++ b/build/src/ReleasesGenerator/Infrastructure/GitHubReleasePages.php
@@ -92,14 +92,25 @@ final readonly class GitHubReleasePages
 
     private function fetchReleasesPage(string $url): array
     {
+        $headers = [
+            'User-Agent: Phel-Website-Generator',
+            'Accept: application/vnd.github+json',
+            'X-GitHub-Api-Version: 2022-11-28',
+        ];
+
+        // Authenticate when a token is available (GitHub Actions sets GITHUB_TOKEN).
+        // Lifts the rate limit from 60 to 5000 req/hr, which is why unauthenticated
+        // CI runs hit HTTP 403 on the shared runner IPs.
+        $token = getenv('GITHUB_TOKEN') ?: getenv('GH_TOKEN');
+        if (is_string($token) && $token !== '') {
+            $headers[] = 'Authorization: Bearer ' . $token;
+        }
+
         $context = stream_context_create([
             'http' => [
                 'method' => 'GET',
-                'header' => [
-                    'User-Agent: Phel-Website-Generator',
-                    'Accept: application/vnd.github+json',
-                    'X-GitHub-Api-Version: 2022-11-28',
-                ],
+                'header' => $headers,
+                'ignore_errors' => true,
             ],
         ]);
 
@@ -109,6 +120,13 @@ final readonly class GitHubReleasePages
             throw new RuntimeException("Failed to fetch releases from GitHub API: {$url}");
         }
 
+        $status = $this->statusCodeFromHeaders($http_response_header ?? []);
+        if ($status !== 0 && $status >= 400) {
+            throw new RuntimeException(
+                "GitHub API returned HTTP {$status} for {$url}. Response: " . substr($response, 0, 500),
+            );
+        }
+
         $releases = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
 
         if (!is_array($releases)) {
@@ -116,6 +134,23 @@ final readonly class GitHubReleasePages
         }
 
         return $releases;
+    }
+
+    /**
+     * @param list<string> $responseHeaders
+     */
+    private function statusCodeFromHeaders(array $responseHeaders): int
+    {
+        // The status line (e.g. "HTTP/1.1 403 Forbidden") is the first header;
+        // on redirects the last status line wins.
+        $status = 0;
+        foreach ($responseHeaders as $header) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $matches) === 1) {
+                $status = (int) $matches[1];
+            }
+        }
+
+        return $status;
     }
 
     /**


### PR DESCRIPTION
## Problem

The deploy + CI `composer build` step (`generate-releases.php`) fails intermittently with:

```
PHP Fatal error: Uncaught RuntimeException: Failed to fetch releases from GitHub API:
https://api.github.com/repos/phel-lang/phel-lang/releases?per_page=100&page=1
```

The call was **unauthenticated**, so it hit GitHub's 60 req/hr limit on shared runner IPs and got HTTP 403.

## Fix

- `GitHubReleasePages`: send `Authorization: Bearer <token>` when `GITHUB_TOKEN`/`GH_TOKEN` is set (60 -> 5000 req/hr). Unauthenticated local runs still work.
- Surface the real HTTP status in the exception (`ignore_errors` + parse status line) instead of a generic "Failed to fetch".
- Pass `secrets.GITHUB_TOKEN` to the build step in both `ci.yml` and `main.yml`.

Note: this fixes the *build* step. The separate FTP `Deploy` failure (550, server disk/permissions) is unrelated and still requires a server-side fix.