### PR TITLE
ci: fix lftp env var expansion in deploy step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,15 +56,19 @@ jobs:
           set -euo pipefail
           sudo apt-get update && sudo apt-get install -y lftp
 
-          # Fail the lftp session on any command error, retry transient network errors.
+          # Run the mirror. Don't let set -e abort before the diagnostics below run;
+          # capture lftp's real exit code via PIPESTATUS instead.
+          set +e
           lftp -c "
             set cmd:fail-exit yes;
             set net:max-retries 3;
             set net:timeout 30;
             set mirror:parallel-transfer-count 1;
-            open -u \"\$FTP_USERNAME\",\"\$FTP_PASSWORD\" \"\$FTP_HOST\";
-            mirror --reverse --delete --depth-first --overwrite --verbose public/ \"\$FTP_TARGET\";
+            open -u \"$FTP_USERNAME\",\"$FTP_PASSWORD\" \"$FTP_HOST\";
+            mirror --reverse --delete --depth-first --overwrite --verbose public/ \"$FTP_TARGET\";
           " 2>&1 | tee lftp.log
+          lftp_rc=${PIPESTATUS[0]}
+          set -e
 
           # lftp's mirror can report per-file failures (e.g. 550 - cannot create
           # directory, usually disk quota / permissions on the server) without a
@@ -72,5 +76,10 @@ jobs:
           # partial deploy never passes silently.
           if grep -E "Access failed|^(mkdir|chmod|put|get): |[Ff]atal error|55[0-9]" lftp.log; then
             echo "::error::LFTP deploy reported server errors (5xx). Likely disk quota or write permissions on the FTP host. Deploy is incomplete - failing the job."
+            exit 1
+          fi
+
+          if [ "$lftp_rc" -ne 0 ]; then
+            echo "::error::LFTP exited with code $lftp_rc. Deploy failed."
             exit 1
           fi


### PR DESCRIPTION
## Problem

The deploy hardening in #230 moved FTP credentials to `env:` and referenced them as `\$FTP_HOST` inside the `lftp -c` string. The backslash stopped **bash** from expanding them, and **lftp does not expand env vars itself**, so the deploy failed with:

```
open: $FTP_HOST: Name or service not known
```

## Fix

- Drop the backslash so bash expands `$FTP_USERNAME` / `$FTP_PASSWORD` / `$FTP_HOST` / `$FTP_TARGET` into the lftp script (values still come from `secrets` via `env:`, masked in logs).
- Capture lftp's exit code via `PIPESTATUS` and re-enable `set -e` afterwards, so the 5xx diagnostics from #230 still run instead of `set -e` aborting first.
- Fail loudly on any non-zero lftp exit.

Note: still does not make the FTP `550` (server disk/permissions) go green: that remains a server-side fix. This just restores a working connection + honest failure reporting.