### PR TITLE
chore: bump phel-lang to 0.44.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "php": ">=8.4",
         "ext-json": "*",
-        "phel-lang/phel-lang": "^0.42",
-        "gacela-project/gacela": "^1.14"
+        "phel-lang/phel-lang": "^0.44",
+        "gacela-project/gacela": "^1.15"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7deb33a04ed5a3507ddd3231a0651f97",
+    "content-hash": "f5cbc06c80e9495ed8c41635bce9853c",
     "packages": [
         {
             "name": "amphp/amp",
@@ -89,16 +89,16 @@
         },
         {
             "name": "gacela-project/container",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "62a409c918fe0e301b909da1c54aea189bd6e76a"
+                "reference": "6251aaf6973ab7ddc41f596a18a8ea9334582a1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/62a409c918fe0e301b909da1c54aea189bd6e76a",
-                "reference": "62a409c918fe0e301b909da1c54aea189bd6e76a",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/6251aaf6973ab7ddc41f596a18a8ea9334582a1b",
+                "reference": "6251aaf6973ab7ddc41f596a18a8ea9334582a1b",
                 "shasum": ""
             },
             "require": {
@@ -145,7 +145,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/resolver/issues",
-                "source": "https://github.com/gacela-project/container/tree/0.8.0"
+                "source": "https://github.com/gacela-project/container/tree/0.8.1"
             },
             "funding": [
                 {
@@ -153,24 +153,24 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-08T22:36:48+00:00"
+            "time": "2026-06-05T11:50:32+00:00"
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.14.4",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "d3058fa16b4748adca17d7e5b940c0dc5daa3e61"
+                "reference": "378c69c45446f60c821ea1c3bb4638ca052c7d94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/d3058fa16b4748adca17d7e5b940c0dc5daa3e61",
-                "reference": "d3058fa16b4748adca17d7e5b940c0dc5daa3e61",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/378c69c45446f60c821ea1c3bb4638ca052c7d94",
+                "reference": "378c69c45446f60c821ea1c3bb4638ca052c7d94",
                 "shasum": ""
             },
             "require": {
-                "gacela-project/container": "^0.8",
+                "gacela-project/container": "^0.8.1",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -210,8 +210,8 @@
             ],
             "authors": [
                 {
-                    "name": "Jose Maria Valera Reales",
-                    "email": "chemaclass@outlook.es",
+                    "name": "Jose M. Valera Reales",
+                    "email": "gacela@chemaclass.com",
                     "homepage": "https://chemaclass.com"
                 },
                 {
@@ -230,7 +230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.14.4"
+                "source": "https://github.com/gacela-project/gacela/tree/1.15.0"
             },
             "funding": [
                 {
@@ -238,25 +238,25 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-04-20T09:41:26+00:00"
+            "time": "2026-06-05T12:00:26+00:00"
         },
         {
             "name": "phel-lang/phel-lang",
-            "version": "v0.42.0",
+            "version": "v0.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "6a9f875a8975790ec3bfa082e2f5e93fccf78661"
+                "reference": "35bd394a8b7bcae55600aa03d8bdfd2909fc3a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/6a9f875a8975790ec3bfa082e2f5e93fccf78661",
-                "reference": "6a9f875a8975790ec3bfa082e2f5e93fccf78661",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/35bd394a8b7bcae55600aa03d8bdfd2909fc3a10",
+                "reference": "35bd394a8b7bcae55600aa03d8bdfd2909fc3a10",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^3.1",
-                "gacela-project/gacela": "^1.14",
+                "gacela-project/gacela": "^1.15",
                 "php": ">=8.4",
                 "symfony/console": "^6.0|^7.0|^8.0",
                 "symfony/routing": "^7.3|^8.0"
@@ -267,6 +267,8 @@
                 "friendsofphp/php-cs-fixer": "^3.94",
                 "phpbench/phpbench": "^1.6",
                 "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0|^12.0|^13.0",
                 "psalm/plugin-phpunit": "^0.19|^0.20",
                 "rector/rector": "^2.3",
@@ -310,7 +312,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phel-lang/phel-lang/issues",
-                "source": "https://github.com/phel-lang/phel-lang/tree/v0.42.0"
+                "source": "https://github.com/phel-lang/phel-lang/tree/v0.44.0"
             },
             "funding": [
                 {
@@ -318,7 +320,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-06-06T09:43:55+00:00"
+            "time": "2026-06-13T08:40:25+00:00"
         },
         {
             "name": "psr/container",
@@ -858,16 +860,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -919,7 +921,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -939,7 +941,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/routing",

--- a/config.toml
+++ b/config.toml
@@ -31,4 +31,4 @@ extra_grammars = ["syntaxes/phel.tmLanguage.json", "syntaxes/clojure.tmLanguage.
 # Put all your custom variables here
 
 repo_content_url = "https://github.com/phel-lang/phel-lang.org/edit/master/content/"
-phel_version = "v0.42.0"
+phel_version = "v0.44.0"

--- a/content/documentation/guides/coming-from-clojure.md
+++ b/content/documentation/guides/coming-from-clojure.md
@@ -391,7 +391,7 @@ Use Composer. `composer.json` replaces `deps.edn`:
 ```json
 {
   "require": {
-    "phel-lang/phel-lang": "^0.42",
+    "phel-lang/phel-lang": "^0.44",
     "php": ">=8.4"
   }
 }

--- a/content/documentation/installation.md
+++ b/content/documentation/installation.md
@@ -208,14 +208,29 @@ Editor integration: nREPL + LSP. See [Editor Support](/documentation/tooling/edi
 </div>
 </details>
 
-## Upgrading to 0.42
+## Upgrading to 0.44
 
 ```bash
-composer require phel-lang/phel-lang:^0.42
+composer require phel-lang/phel-lang:^0.44
 ./vendor/bin/phel cache:clear        # or: rm -rf .phel/cache
 ```
 
 Always clear the cache after upgrading: compiled PHP from earlier installs references renamed core types and fails to load otherwise. Rebuild downstream projects too.
+
+Behaviour changes in 0.44:
+
+- Requires `gacela-project/gacela: ^1.15`. Editing `phel-config.php` takes effect immediately again (the stale merged-config cache is cleared on change).
+- `phel test` exit codes are stricter: it no longer exits `0` when nothing ran, bad paths/selectors fail loudly, and `--list` no longer appends a false `No tests matched`. CI relying on the old lenient codes may start failing as intended.
+- `await-all` (and `pmap`, built on it) now return results in input order instead of completion order. Code that tolerated shuffled concurrent results sees deterministic ordering now.
+- The docs doctest harness (`composer test-docs`, `tests/doctest/`) was removed; user-facing guides now live on [phel-lang.org](https://phel-lang.org/documentation/).
+
+New in 0.44 (config tooling + sharper test runner): `phel config` prints the merged config with provenance, `phel test --coverage` and `--watch`, `phel build --report`, `phel init --template=<name>`, optimization levels (`phel build -O <level>`), LSP PHP interop, and a REPL reload workflow (`(reload!)`, `(run-tests ...)`). See the [0.44 release notes](/releases/0-44-feedback-loop/).
+
+Behaviour changes in 0.43:
+
+- A `never` / `void` / `null` `:tag` return on a value-returning function is now a compile error instead of a load-time fatal (`mixed`, `?T`, and union/intersection tags still pass).
+
+New in 0.43 (typed PHP interop): `php/callable` first-class callables, `defstruct ^:php/readonly` fields, `defenum` methods + interfaces, `^:php/override` (`#[\Override]`), and `definterface` typed class constants. See the [0.43 release notes](/releases/0-43-first-class-callable/).
 
 Behaviour changes in 0.42:
 
@@ -234,7 +249,7 @@ New in 0.42 (richer typed PHP interop, all opt-in):
 - `iterator-seq` builds a lazy seq over any PHP `Traversable`.
 - `defstruct` `:php` blocks declare inline PHP magic methods; `phel format` and `phel.http` JSON bodies / response builders round it out.
 
-See the [0.42 release notes](/releases/0-42-life-php-everything/) for the full list.
+See the [0.42 release notes](/releases/0-42-life-everything/) for the full list.
 
 Breaking changes in 0.41:
 


### PR DESCRIPTION
## Summary

Bump `phel-lang/phel-lang` from `v0.42.0` to `v0.44.0` (latest release) and refresh the upgrade documentation.

## Changes

- `composer.json` / `composer.lock`: `phel-lang/phel-lang ^0.44`, plus `gacela-project/gacela ^1.15` (required by 0.44 for the immediate `phel-config.php` cache invalidation fix).
- `config.toml`: `phel_version` rewritten to `v0.44.0` by the `post-update-cmd` hook (not hand-edited).
- `content/documentation/installation.md`: upgrade section retargeted to 0.44, with behaviour-change + new-feature notes for both 0.43 and 0.44. Fixed a broken release link (`0-42-life-php-everything` -> `0-42-life-everything`).
- `content/documentation/guides/coming-from-clojure.md`: composer pin `^0.42` -> `^0.44`.

## Verification

- `composer test` -> 47/47 pass.
- `composer test:snippets` -> 565/565 pass, 0 regressions.
- `zola build` -> clean, internal links resolve.

Release notes: [0.43](https://github.com/phel-lang/phel-lang/releases/tag/v0.43.0), [0.44](https://github.com/phel-lang/phel-lang/releases/tag/v0.44.0).