### PR TITLE
fix: docs site quality (error-reference deploy wipe + em-dashes)

### DIFF
--- a/build/src/ErrorReference/ErrorReferenceGenerator.php
+++ b/build/src/ErrorReference/ErrorReferenceGenerator.php
@@ -12,7 +12,7 @@ use Phel\Shared\Exceptions\ErrorCode;
  * with curated cause/fix prose. If Phel adds a code without prose here, generation
  * fails, forcing the docs to be updated alongside the bump.
  *
- * @psalm-type TEntry = array{meaning: string, cause: string, fix: string}
+ * @psalm-type TEntry = array{meaning: string, cause: string, fix: string, learnMore?: string}
  */
 final class ErrorReferenceGenerator
 {
@@ -55,6 +55,7 @@ final class ErrorReferenceGenerator
             'meaning' => 'A macro threw while expanding.',
             'cause' => 'The macro received arguments it did not expect, or its own body raised during expansion.',
             'fix' => 'Check the arguments at the call site and inspect the expansion with `(macroexpand \'(your-form ...))`.',
+            'learnMore' => '[Macros](/documentation/language/macros/).',
         ],
         'PHEL006' => [
             'meaning' => 'An inline-expanded function failed to expand.',
@@ -70,16 +71,19 @@ final class ErrorReferenceGenerator
             'meaning' => 'A binding vector is invalid.',
             'cause' => 'An odd number of binding forms in `let`/`loop`, or a binding target that cannot be destructured.',
             'fix' => 'Provide an even number of `name value` pairs and use valid destructuring targets (symbols, vectors, maps).',
+            'learnMore' => '[Destructuring](/documentation/language/destructuring/), [Global and local bindings](/documentation/language/global-and-local-bindings/).',
         ],
         'PHEL009' => [
             'meaning' => 'An interface or protocol definition (or its implementation) is invalid.',
             'cause' => 'A malformed `definterface`/`defprotocol`, or trying to implement a `defprotocol` inline in `defstruct` (only `definterface` can be implemented inline).',
             'fix' => 'Use `definterface` for inline implementation, or `defprotocol` plus `extend-type` per struct.',
+            'learnMore' => '[Interfaces](/documentation/language/interfaces/).',
         ],
         'PHEL010' => [
             'meaning' => '`recur` was used incorrectly.',
             'cause' => '`recur` appeared outside a `loop`/`fn` tail position, or with an argument count that does not match the recursion point.',
             'fix' => 'Use `recur` only in tail position, with as many arguments as the enclosing `loop`/`fn` binds.',
+            'learnMore' => '[Functions and recursion](/documentation/language/functions-and-recursion/).',
         ],
         'PHEL011' => [
             'meaning' => 'A value that is not a function was called.',
@@ -227,6 +231,9 @@ final class ErrorReferenceGenerator
                 $out .= "{$entry['meaning']}\n\n";
                 $out .= "**Common cause:** {$entry['cause']}\n\n";
                 $out .= "**Fix:** {$entry['fix']}\n";
+                if (isset($entry['learnMore'])) {
+                    $out .= "\n**Learn more:** {$entry['learnMore']}\n";
+                }
             }
         }
 

--- a/content/documentation/language/functions-and-recursion.md
+++ b/content/documentation/language/functions-and-recursion.md
@@ -40,7 +40,7 @@ Variadic functions use `&`:
 (fn [a b c &]) ; A variadic function with extra arguments ignored
 
 (fn ; A multi-arity function
-  ([] "hi") 
+  ([] "hi")
   ([name] (str "hi " name))
   ([greeting name & rest] (str greeting " " name rest)))
 ```
@@ -124,8 +124,8 @@ Private functions don't export from the namespace. Two forms:
   {:private true}
   [a b]
   (+ a b))
-  
-(defn- my-private-add-function 
+
+(defn- my-private-add-function
   [a b]
   (+ a b))
 ```

--- a/content/documentation/language/lazy-sequences.md
+++ b/content/documentation/language/lazy-sequences.md
@@ -112,14 +112,14 @@ Because the pipeline is lazy, you can compose transformations over a data source
 
 These return lazy sequences, so you rarely need to write `lazy-seq` yourself:
 
-- `range` — lazy sequence of numbers
-- `iterate` — infinite sequence by repeatedly applying a function
-- `repeat` — infinite sequence of a repeated value
-- `cycle` — infinite sequence by cycling through a collection
-- `map` — lazy transformation
-- `filter` — lazy filtering
-- `take` — first `n` elements (realizes them)
-- `drop` — skips first `n` elements (stays lazy)
+- `range`: lazy sequence of numbers
+- `iterate`: infinite sequence by repeatedly applying a function
+- `repeat`: infinite sequence of a repeated value
+- `cycle`: infinite sequence by cycling through a collection
+- `map`: lazy transformation
+- `filter`: lazy filtering
+- `take`: first `n` elements (realizes them)
+- `drop`: skips first `n` elements (stays lazy)
 
 ```phel
 (println (take 10 (iterate (fn [x] (* 2 x)) 1)))
@@ -176,7 +176,7 @@ Force a lazy sequence when you need all of it:
 (println (last (range 1000000)))
 ```
 
-**2. Lazy sequences in tests** — realize before asserting, otherwise you compare against an unrealized thunk:
+**2. Lazy sequences in tests**: realize before asserting, otherwise you compare against an unrealized thunk:
 
 ```phel skip
 (is (= expected (doall lazy-result)))  ; force realization
@@ -207,7 +207,7 @@ Force a lazy sequence when you need all of it:
 
 ## Further reading
 
-- [Cheat sheet — lazy sequences](/documentation/reference/cheat-sheet/#lazy-sequences) for a one-screen reference, including lazy file I/O (`line-seq`, `file-seq`, `csv-seq`).
+- [Cheat sheet: lazy sequences](/documentation/reference/cheat-sheet/#lazy-sequences) for a one-screen reference, including lazy file I/O (`line-seq`, `file-seq`, `csv-seq`).
 - [Data structures](/documentation/language/data-structures/) for the sequence functions that consume and transform these collections.
 - [Cookbook](/documentation/guides/cookbook/) for lazy pipelines applied to real tasks.
-- [Clojure: lazy sequences](https://clojure.org/reference/sequences) — the model Phel follows.
+- [Clojure: lazy sequences](https://clojure.org/reference/sequences): the model Phel follows.

--- a/content/documentation/language/reader-shortcuts.md
+++ b/content/documentation/language/reader-shortcuts.md
@@ -194,7 +194,7 @@ Type hints use the same syntax: `^int`, `^"?int"`, `^{:tag "\\Foo\\Bar"}`. See [
 
 ## See also
 
-- [Basic Types](/documentation/language/basic-types) — tagged literals, regex literals, deref, and comments in depth
-- [Functions and Recursion](/documentation/language/functions-and-recursion) — the `#(...)` shorthand and typed defns
-- [Macros](/documentation/language/macros) — quasiquote and auto-gensym hygiene in practice
-- [Cheat Sheet](/documentation/reference/cheat-sheet) — the one-page syntax overview
+- [Basic Types](/documentation/language/basic-types): tagged literals, regex literals, deref, and comments in depth
+- [Functions and Recursion](/documentation/language/functions-and-recursion): the `#(...)` shorthand and typed defns
+- [Macros](/documentation/language/macros): quasiquote and auto-gensym hygiene in practice
+- [Cheat Sheet](/documentation/reference/cheat-sheet): the one-page syntax overview

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -749,8 +749,8 @@ class MyExistingClass {
 
   public function myExistingMethod(...$arguments) {
     return $this->callPhel(
-        'my.phel.namespace', 
-        'phel-function-name', 
+        'my.phel.namespace',
+        'phel-function-name',
         ...$arguments
     );
   }

--- a/content/documentation/reference/errors.md
+++ b/content/documentation/reference/errors.md
@@ -26,7 +26,7 @@ A symbol could not be resolved to a definition in the current scope.
 
 **Common cause:** A typo, a missing `(:require ...)` for the namespace the symbol lives in, an alias that does not match, or using a binding before it is defined.
 
-**Fix:** Check the spelling, require the namespace (e.g. `(:require phel.string :as str)` for `str/...`), or move the definition above its first use. The error message suggests near matches.
+**Fix:** Check the spelling, require the namespace (e.g. `(:require phel\string :as str)` for `str/...`), or move the definition above its first use. The error message suggests near matches.
 
 ### PHEL002 : Arity error
 

--- a/content/documentation/tooling/php-tools.md
+++ b/content/documentation/tooling/php-tools.md
@@ -19,7 +19,7 @@ Any PHP function via `php/` prefix:
 ;; int(4)
 ```
 
-```phel 
+```phel
 ;; Directly dumping the result of a function
 (php/var_dump (+ 3 3))
 ;; OUTPUT:

--- a/content/documentation/web/framework-integration.md
+++ b/content/documentation/web/framework-integration.md
@@ -240,8 +240,8 @@ Phel models data as immutable values, not mutable identity-tracked objects. An O
 
 Two small libraries cover it:
 
-- [phel-sql](https://github.com/phel-lang/phel-sql) — HoneySQL-style. Map in, `[sql params]` out. No driver.
-- [phel-pdo](https://github.com/phel-lang/phel-pdo) — runs `[sql params]`, returns rows as maps.
+- [phel-sql](https://github.com/phel-lang/phel-sql): HoneySQL-style. Map in, `[sql params]` out. No driver.
+- [phel-pdo](https://github.com/phel-lang/phel-pdo): runs `[sql params]`, returns rows as maps.
 
 ```phel skip
 (ns shop.catalog
@@ -315,16 +315,16 @@ Every struct already implements `\Countable`, `\ArrayAccess`, and `\IteratorAggr
 
 Two related forms help framework integration:
 
-- `(defenum Status :active "active" :inactive "inactive")` — a native PHP backed enum (Doctrine/Symfony columns) plus a `Status?` predicate. An enum can implement interfaces and carry methods, reusing `defstruct`'s inline-impl machinery.
-- `(defexception NotFound \RuntimeException)` — an exception extending a chosen parent, so framework `catch` blocks match by type.
+- `(defenum Status :active "active" :inactive "inactive")`: a native PHP backed enum (Doctrine/Symfony columns) plus a `Status?` predicate. An enum can implement interfaces and carry methods, reusing `defstruct`'s inline-impl machinery.
+- `(defexception NotFound \RuntimeException)`: an exception extending a chosen parent, so framework `catch` blocks match by type.
 
 For the full semantics of typed emission, native enums, and exceptions, see [Native enums and exceptions](/documentation/php-interop/#native-enums-and-exceptions) and the rest of the [PHP Interop](/documentation/php-interop/) reference.
 
 ### Controllers, transactions, migrations
 
-- **Routes/commands:** an exported `defn` can carry `^{:php/attr [:Symfony.Component.Routing.Attribute/Route "/products/{id}"]}`, so `phel export` emits the `#[Route]` on the generated wrapper — no hand-written controller shim.
+- **Routes/commands:** an exported `defn` can carry `^{:php/attr [:Symfony.Component.Routing.Attribute/Route "/products/{id}"]}`, so `phel export` emits the `#[Route]` on the generated wrapper: no hand-written controller shim.
 - **Transactions:** wrap writes with phel-pdo's transaction helpers; keep the pure work outside the transaction and only the effect inside.
-- **Migrations:** stay in PHP-land — reuse `doctrine/migrations` or your framework's tool. Phel does not need its own.
+- **Migrations:** stay in PHP-land: reuse `doctrine/migrations` or your framework's tool. Phel does not need its own.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Two independent docs-quality fixes for the site.

### 1. Error-reference learn-more links wiped on every deploy

The deploy build runs `build/generate-error-reference.php`, which rebuilt `content/documentation/reference/errors.md` from the generator's `ENTRIES` table. The curated **Learn more:** cross-links (PHEL005, PHEL008, PHEL009, PHEL010) lived only in the committed markdown, so every deploy silently stripped them.

Fix: encode the links as an optional `learnMore` field in `ErrorReferenceGenerator::ENTRIES` and render it, making regeneration idempotent. Also corrected the PHEL001 require example to the canonical backslash namespace form (`phel\string`, matching the snippet-verified docs).

### 2. Em-dashes in content

Replaced `—` separators with colons across three content pages (`lazy-sequences`, `reader-shortcuts`, `framework-integration`) for punctuation consistency.

## Verification

- `vendor/bin/phpunit --filter Error` -> 2/2 pass.
- Regenerating `errors.md` now reproduces the curated content exactly (idempotent).
- `composer test:snippets` on the touched pages -> pass.
- `zola build` -> clean.