### PR TITLE
docs: document phel 0.44 tooling features

### DIFF
--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -58,6 +58,7 @@ return (new \Phel\Config\PhelConfig())
     ->withEnableCompiledCodeCache(true)
     ->withEnableAsserts(true)
     ->withWarnDeprecations(false)
+    ->withOptimizationLevel(0)
     ->withMainPhelNamespace('your-ns.index')
     ->withMainPhpPath('out/index.php')
     ->withBuildDestDir('out')
@@ -85,17 +86,20 @@ return (new \Phel\Config\PhelConfig())
 | `withEnableCompiledCodeCache`          | Compiled-code cache for tests/builds. Default `true`.                                                  |
 | `withEnableAsserts`                    | Toggle runtime `assert` checks.                                                                        |
 | `withWarnDeprecations`                 | Emit warnings on deprecated APIs.                                                                      |
+| `withOptimizationLevel`                | Compiler optimization level (`0` = off, `2` = inline + tail-call rewrite). See [Performance](/documentation/performance/#optimization-levels). |
 | `withMainPhelNamespace`                | Entry ns for `phel build`.                                                                             |
 | `withMainPhpPath`                      | Generated PHP entry path.                                                                              |
 | `withBuildDestDir`                     | Output directory for `phel build`.                                                                     |
 | `withExportFromDirectories`            | Source dirs scanned by `phel export`.                                                                  |
 | `withExportNamespacePrefix`            | PHP namespace prefix for exported wrappers.                                                            |
 | `withExportTargetDirectory`            | Output dir for `phel export`. See [PHP Interop](/documentation/php-interop/#calling-phel-from-php).    |
-| `withBuildConfig` / `withExportConfig` | Replace nested config objects wholesale (rarely needed).                                               |
+| `withBuildConfig` / `withExportConfig` | Tune the nested build/export config. Pass a configurator closure to adjust it in place, or a config object to replace it wholesale. |
 
 </details>
 
 > **Note:** Old `setX()` setters are deprecated and emit notices. Use the `withX()` chain, the API is immutable.
+
+To see the merged result of all of this (and which file each value came from), run `phel config`. See [CLI commands](/documentation/tooling/cli-commands/#inspect-configuration).
 
 ## Next steps
 

--- a/content/documentation/performance.md
+++ b/content/documentation/performance.md
@@ -92,6 +92,14 @@ Level 2 trade-offs:
 - Tail-call rewriting eliminates per-iteration PHP stack frames (deep self-recursion no longer overflows) at the cost of a shorter stack trace inside the loop.
 - Changing the level invalidates the compiled-code cache and the incremental `phel build` output, so the next run recompiles everything once.
 
+### Spot build bloat
+
+`phel build --report` prints a per-namespace breakdown after the build: namespace count, each namespace's compiled size, the total, the fresh/cached split, and build time. Use it to catch a namespace that compiles much larger than expected and to confirm CI builds hit the cache.
+
+```bash
+vendor/bin/phel build --report
+```
+
 ## Faster functions
 
 A few language features pay off in hot paths. They are covered in full under [Functions and Recursion](/documentation/language/functions-and-recursion/#return-and-parameter-types-tag); the performance angle:

--- a/content/documentation/testing.md
+++ b/content/documentation/testing.md
@@ -267,6 +267,36 @@ Run namespaces across subprocess workers to speed up large suites:
 
 Auto-disabled for `--reporter=tap`, `--list`, and when a profiler hook is installed.
 
+### Watch mode
+
+Re-run the selected tests on every change to a `.phel` file or `phel-config.php` under the project source and test directories. Combine it with selectors to tighten the loop to what you are working on:
+
+```bash
+./vendor/bin/phel test --watch
+./vendor/bin/phel test --watch --ns=my-app.users.*   # only this namespace
+```
+
+Press `Ctrl+C` to stop. A failed `=` assertion prints an expected/actual diff with a caret at the first difference, and `FAIL`/`ERROR` headlines carry the failing `deftest` name and location (`FAIL my-test (file.phel:4)`).
+
+### Re-run failures
+
+After a run, re-run only the tests that failed instead of the whole suite. The failing set is read from `<phel-dir>/last-failed.txt`:
+
+```bash
+./vendor/bin/phel test --last-failed
+./vendor/bin/phel test --last-failed --repeat=20   # hammer the flaky ones
+```
+
+### Coverage
+
+Collect line coverage mapped back to your `.phel` sources. Requires the `pcov` or `xdebug` extension (you get a clear error otherwise), and runs serially: `--parallel` is disabled for the run. Only project source files count; vendor and core are excluded.
+
+```bash
+./vendor/bin/phel test --coverage                      # per-file + total %, as text
+./vendor/bin/phel test --coverage=clover \
+  --coverage-output=coverage.xml                       # Clover XML for CI (Codecov etc.)
+```
+
 {% php_note() %}
 Test command similar to PHPUnit:
 

--- a/content/documentation/tooling/cli-commands.md
+++ b/content/documentation/tooling/cli-commands.md
@@ -31,6 +31,8 @@ vendor/bin/phel init
 #       --dry-run         Show what would be created without writing anything
 #       --no-gitignore    Skip generating .gitignore
 #       --no-tests        Skip generating a test file
+#   -t, --template[=NAME] Scaffold from a bundled example; omit the value to list
+#       --list-templates  List available project templates and exit
 ```
 
 Defaults to **Flat** layout (`src/`, `tests/`). `--nested` for `src/phel/`. `--minimal` for a single root file.
@@ -46,6 +48,17 @@ vendor/bin/phel init my-app --nested
 vendor/bin/phel init my-app --dry-run
 ```
 
+Scaffold from a bundled, runnable example instead of a bare skeleton. The template's namespaces, `composer.json`, and entry points are renamed to your project name. Composes with `--dry-run` and `--force`.
+
+```bash
+# List the bundled templates
+vendor/bin/phel init --list-templates
+# http-json-api, todo-app, cli-wordcount
+
+# Scaffold a project from a template
+vendor/bin/phel init my-api --template=http-json-api
+```
+
 ## Build the project
 
 ```bash
@@ -56,9 +69,21 @@ vendor/bin/phel build
 # Options:
 #       --cache|--no-cache            Enable cache
 #       --source-map|--no-source-map  Enable source maps
+#   -O, --optimization-level=LEVEL    Override configured level (0 = off, 2 = inline + tail-call rewrite)
+#       --report                      Print a build report (namespaces, sizes, time)
 ```
 
 Compiles Phel to PHP, writing to the configured main path (entry point `out/index.php`). Run the resulting PHP directly. Skips recompilation, improving runtime.
+
+```bash
+# Build with optimizations on (inlining + self-recursive tail-call rewriting)
+vendor/bin/phel build -O 2
+
+# Print a build summary to spot bloat and verify CI builds
+vendor/bin/phel build --report
+```
+
+`-O` overrides the level set via `withOptimizationLevel(...)` in `phel-config.php`. See [Performance](/documentation/performance/) for what each level does. `--report` prints namespace count, per-namespace compiled size, total size, the fresh/cached breakdown, and build time.
 
 [Configuration](/documentation/configuration/) in `phel-config.php`:
 ```php
@@ -165,9 +190,29 @@ vendor/bin/phel test
 #       --seed=INT          Seed used for randomized order.
 #       --random-order      Run tests in random order (uses --seed if given).
 #       --parallel=N        Run namespaces in subprocess workers: int, "auto" (capped at 8), or "max".
+#       --watch             Re-run selected tests on every .phel / phel-config.php change.
+#       --last-failed       Re-run only tests that failed on the previous run.
+#       --slowest=N         Print the N slowest tests after the summary (0 disables).
+#       --stack-trace       Print the full PHP stack trace for each errored test.
+#       --coverage[=FORMAT] Collect line coverage (text|clover) via pcov or xdebug.
+#       --coverage-output=PATH  Write the coverage report to a file (use with --coverage=clover for CI).
 ```
 
 Test selectors and reporters: see [Testing](/documentation/testing/).
+
+```bash
+# Re-run on every change while you work
+vendor/bin/phel test --watch
+
+# Re-run only what failed last time
+vendor/bin/phel test --last-failed
+
+# Line coverage as text, or Clover XML for CI
+vendor/bin/phel test --coverage
+vendor/bin/phel test --coverage=clover --coverage-output=coverage.xml
+```
+
+`--coverage` needs pcov or xdebug and runs serially (it disables `--parallel` for that run). Only project source files count; vendor and core are excluded.
 
 [Configuration](/documentation/configuration/) in `phel-config.php`:
 ```php
@@ -274,6 +319,8 @@ LSP v3.17 over stdio. Supports hover, definition, references, completion, docume
 vendor/bin/phel lsp
 ```
 
+PHP interop is completion-aware: instance methods/properties after `(php/-> receiver ...)`, static methods/constants after `(php/:: Class ...)`, class names in `(php/new ...)` and `\Fully\Qualified` positions, and global functions after `php/`. Hover shows the reflected signature for PHP methods, functions, and classes; signature help fires inside `(php/new ...)` and method calls. Receiver types come from `:tag` metadata, an inline `(php/new \Foo)`, or a local `(php/new ...)` binding; an unknown type degrades to no completion with no spurious diagnostics. See [Editor support](/documentation/tooling/editor-support/).
+
 
 ## Analyze and index
 
@@ -318,6 +365,27 @@ vendor/bin/phel profile path/to/file.phel
 #   --output=PATH     Write report to PATH
 ```
 
+
+## Inspect configuration
+
+Print the effective configuration and where each part comes from. Useful when a `phel-config.php`, a `phel-config-local.php` override, or the `PHEL_DIR` env var is not taking effect as you expect.
+
+```bash
+vendor/bin/phel config
+# Sources:
+#  - project root: /path/to/project
+#  - phel-config.php: not found, using auto-detected defaults
+#  - phel-config-local.php: not present
+#  - PHEL_DIR env: (unset)
+#
+# Effective config:
+# { "src-dirs": ["src"], "test-dirs": ["tests"], ... }
+
+# Machine-readable: just the effective config as JSON
+vendor/bin/phel config --json
+```
+
+See [Configuration](/documentation/configuration/) for every setter.
 
 ## Clear caches
 

--- a/content/documentation/tooling/cli-commands.md
+++ b/content/documentation/tooling/cli-commands.md
@@ -147,11 +147,11 @@ Run a file or namespace:
 vendor/bin/phel run
 # Usage:
 #   run [options] [--] <path> [<argv>...]
-# 
+#
 # Arguments:
 #   path                  The file path that you want to run.
 #   argv                  Optional arguments
-# 
+#
 # Options:
 #   -t, --with-time       With time awareness
 ```

--- a/content/documentation/tooling/editor-support.md
+++ b/content/documentation/tooling/editor-support.md
@@ -86,6 +86,25 @@ This starts an [nREPL](https://nrepl.org/) server (Bencode over TCP) that nREPL-
 
 Defaults are port `7888` and host `127.0.0.1`. Override either with the flags above. The server is also listed under [CLI commands](/documentation/tooling/cli-commands/#nrepl) alongside the other tooling entry points.
 
+Two nREPL ops back the [REPL-driven workflow](/documentation/tooling/repl/#reload-changed-code): `reload` (with an `all` param to force a full reload) and `run-tests` (an `ns` param plus an optional `var`). Bind them to editor commands for "reload changed namespaces" and "run the test under the cursor".
+
+## Language Server (LSP)
+
+For editors that speak the Language Server Protocol rather than nREPL, Phel ships an LSP server (v3.17 over stdio, JSON-RPC with `Content-Length` framing):
+
+```bash
+vendor/bin/phel lsp
+```
+
+It provides hover, go-to-definition, find-references, completion, document and workspace symbols, rename, formatting, and debounced diagnostics. On top of Phel symbols, completion is PHP-interop-aware:
+
+- instance methods and properties after `(php/-> receiver ...)`
+- static methods and constants after `(php/:: Class ...)`
+- class names in `(php/new ...)` and `\Fully\Qualified` positions
+- global functions after the `php/` prefix
+
+Hover shows the reflected signature for PHP methods, functions, and classes, and signature help fires inside `(php/new ...)` and method calls. The receiver's type is inferred from `:tag` metadata, an inline `(php/new \Foo)`, or a local `(php/new ...)` binding; when the type is unknown, completion simply does nothing rather than emitting noise or false diagnostics.
+
 ## Next steps
 
 - [REPL](/documentation/tooling/repl/) - the interactive loop your editor connects to

--- a/content/documentation/tooling/repl.md
+++ b/content/documentation/tooling/repl.md
@@ -236,6 +236,14 @@ user:2> (test-ns 'my.app.tests)
 ; Runs all tests in the namespace and prints results
 ```
 
+`phel.repl` also exposes `run-tests` and `run-test`, which load the namespace first if needed: `run-tests` takes one or more namespace symbols, `run-test` a single fully qualified test symbol:
+
+<!-- phel-test: skip -->
+```phel
+user:3> (run-tests 'my-app.users-test 'my-app.handlers-test)
+user:4> (run-test 'my-app.users-test/creates-a-user)
+```
+
 See also [Testing](/documentation/testing/) for `reset-stats`, `get-stats`, and `restore-stats`.
 
 ## Auto-injected utilities
@@ -287,6 +295,21 @@ user:8> (fizzbuzz 7)
 user:9> (map fizzbuzz (range 1 16))
 @[1 2 "Fizz" 4 "Buzz" "Fizz" 7 8 "Fizz" "Buzz" 11 "Fizz" 13 14 "FizzBuzz"]
 ```
+
+### Reload changed code
+
+Edit files in your editor and pull the changes into the running REPL without restarting it. `(reload!)` re-evaluates only project namespaces whose source changed since the last load, plus their dependents, in dependency order:
+
+<!-- phel-test: skip -->
+```phel
+user:1> (reload!)
+; => @[my-app.users my-app.handlers]   ; reloaded the changed ns and what depends on it
+
+user:2> (reload-all!)
+; => force-reloads every loaded project namespace, ignoring mtimes
+```
+
+`reload!`, `reload-all!`, `run-tests`, and `run-test` live in `phel.repl` and load automatically in the REPL and over nREPL. Editors can bind the matching nREPL ops `reload` (with an `all` param) and `run-tests` (an `ns` plus optional `var` param) to "reload changed" and "run the test under the cursor".
 
 ### Explore PHP interop
 


### PR DESCRIPTION
## Summary

The 0.43/0.44 releases added a batch of tooling features that were not yet documented on the site. This fills those gaps. Every flag, command, and function was verified against the installed 0.44 runtime (`phel help <cmd>`, `phel doc <fn>`).

## What's documented

**CLI commands** (`tooling/cli-commands.md`)
- `phel config` (new "Inspect configuration" section) + `--json`
- `phel init --template=<name>` / `--list-templates`
- `phel build -O <level>` and `--report`
- `phel test` flags: `--coverage`/`--coverage-output`, `--watch`, `--last-failed`, `--slowest`, `--stack-trace`
- LSP section expanded with the PHP-interop completion/hover/signature-help

**Testing** (`testing.md`)
- new Watch mode, Re-run failures, and Coverage sections

**REPL** (`tooling/repl.md`)
- `(reload!)` / `(reload-all!)` workflow, `(run-tests ...)` / `(run-test ...)`

**Editor support** (`tooling/editor-support.md`)
- new Language Server (LSP) section incl. PHP interop, plus the `reload` / `run-tests` nREPL ops

**Performance** (`performance.md`)
- `phel build --report` for spotting build bloat

**Configuration** (`configuration.md`)
- `withOptimizationLevel`, the `withBuildConfig`/`withExportConfig` configurator-closure form, and a pointer to `phel config`

## Verification

- `composer test:snippets` -> 565/565 pass, 0 regressions.
- `zola build` -> clean, internal links resolve.
- No em-dashes introduced.

Builds on #235 (the 0.44 version bump).