### PR TITLE
ci: serialize deploys with a concurrency group

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,13 @@ on:
       - master
   workflow_dispatch:
 
+# Serialize deploys: the FTP mirror is last-writer-wins, so parallel runs from
+# back-to-back merges can clobber newer content. Queue runs instead of cancelling
+# so every push still ships, in order.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`main.yml` (FTP deploy) had no concurrency control. Merging several PRs back-to-back fired one deploy run per push, all running in parallel. The `lftp mirror` step is last-writer-wins, so a slower run could finish last and overwrite newer content.

This actually happened on 2026-06-14: merging #235 -> #236 -> #237 in sequence, #236's deploy finished last and clobbered #237's pages (prod showed the version bump + errors fix but was missing the feature docs until a manual re-deploy).

## Change

Add a top-level `concurrency` block:

```yaml
concurrency:
  group: deploy
  cancel-in-progress: false
```

`cancel-in-progress: false` queues runs rather than cancelling them, so every push still ships, in order: no clobbering, no dropped deploys.