### PR TITLE
chore: drop MIT license note from footer copyright

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -85,7 +85,7 @@
     <div class="footer-bottom">
         <div class="footer-bottom-container">
             <div class="footer-copyright">
-                &copy; <time datetime="{{now() | date(format='%Y')}}">2020-{{now() | date(format="%Y")}}</time> Phel Language. Released under the MIT License.
+                &copy; <time datetime="{{now() | date(format='%Y')}}">2020-{{now() | date(format="%Y")}}</time> Phel Language.
             </div>
             <div class="footer-badges">
                 <span class="footer-badge">PHP 8.4+ Required</span>


### PR DESCRIPTION
Removes the "Released under the MIT License." text from the footer copyright line, per request. The copyright now reads simply "© 2020-2026 Phel Language."

License info remains available via the GitHub source repo.