### PR TITLE
feat: show REPL run duration in status bar

### DIFF
--- a/static/wasm-repl/index.html
+++ b/static/wasm-repl/index.html
@@ -427,12 +427,15 @@
           showResult('', 'normal');
           setLoading(true);
 
+          const t0 = performance.now();
           const ret = ccall('phpw_with_args', 'string', ['string', 'string', 'string'], [
             '/app/src/wasm-entry/entry-point.php',
           ]);
+          const elapsed = Math.max(1, Math.round(performance.now() - t0));
 
           const hasError = errBuffer.some((line) => !isDeprecatedNotice(line) && line.trim().length > 0);
           const kind = hasError ? 'error' : 'normal';
+          statusEl.textContent = hasError ? `Finished with errors in ${elapsed} ms` : `Ran in ${elapsed} ms`;
           const filtered = buffer.filter((line) => !isDeprecatedNotice(line));
           const text = filtered.join('');
           if (text.trim().length > 0) {
@@ -448,6 +451,7 @@
         } catch (e) {
           console.error('[phel-wasm] run failed:', e);
           showResult(String(e), 'error');
+          statusEl.textContent = 'Run failed. Check console.';
         } finally {
           isRunning = false;
           setLoading(false);


### PR DESCRIPTION
## What

After each run the status bar reports the eval time, e.g. `Ran in 42 ms` (or `Finished with errors in 42 ms` when the run produced errors, `Run failed. Check console.` on a thrown exception).

## Why

There was no feedback that a run actually happened or how long it took. A live timing readout confirms the runtime is responsive and gives a tangible sense of WASM performance.

Part of a series improving the `/repl` page UX.