### PR TITLE
fix: add top margin to homepage 'Phel by example' heading

### DIFF
--- a/css/components/homepage.css
+++ b/css/components/homepage.css
@@ -803,6 +803,11 @@
   flex-wrap: wrap;
 }
 
+/* Separate the "Phel by example" heading from the CTA buttons above it */
+.homepage-cta + h2 {
+  margin-top: var(--space-2xl);
+}
+
 .homepage-cta-button {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What

Adds `margin-top: var(--space-2xl)` to the `Phel by example` heading via `.homepage-cta + h2`, separating it from the CTA buttons above.

## Why

The heading sat flush against the `Try Phel with Docker` / `Read Documentation` / `Practice Exercises` button row, with no breathing room. The adjacent-sibling selector scopes the fix to this one heading, leaving other homepage section headings untouched.