### PR TITLE
docs: de-duplicate pages/sections and fix doc defects

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -261,7 +261,7 @@ php phel.phar repl
 <div class="faq">
   <details class="faq-item">
     <summary class="faq-q">Is Phel production-ready?</summary>
-    <div class="faq-a">Not yet. Phel is pre-1.0. The core language and tooling are usable for personal projects, prototypes, and internal tools, but breaking changes can land between minor releases. Track <a href="/releases/">release notes</a> if you depend on it.</div>
+    <div class="faq-a">Phel is pre-1.0, but the core language and tooling are stable and tested — a good fit for side projects, CLI apps, internal tools, and prototypes. Breaking changes can still land between minor releases, so it isn't LTS-grade enterprise-stable yet. Full picture in <a href="/documentation/why-phel/#is-phel-production-ready">Why Phel</a>; track the <a href="/releases/">release notes</a> if you depend on it.</div>
   </details>
   <details class="faq-item">
     <summary class="faq-q">Can I call PHP libraries from Phel?</summary>

--- a/content/_index.md
+++ b/content/_index.md
@@ -223,7 +223,8 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
 <p class="homepage-tab-caption">Try without installing anything. Drops you into a REPL.</p>
 
 ```bash
-docker run -it --rm phellang/repl
+docker run --rm -it php:8.4-cli sh -c \
+  "curl -sL https://phel-lang.org/phar -o /tmp/phel.phar && php /tmp/phel.phar repl"
 ```
 
   </div>

--- a/content/documentation/deployment.md
+++ b/content/documentation/deployment.md
@@ -20,6 +20,22 @@ require __DIR__ . '/build/app/main.php'; // loads Phel namespaces ONCE
 
 To produce that entry point, see [`phel build`](/documentation/tooling/cli-commands/) and configure `withMainPhelNamespace` / `withMainPhpPath` in [`phel-config.php`](/documentation/configuration/). To expose Phel functions to the PHP worker, mark them `{:export true}` and run [`phel export`](/documentation/tooling/cli-commands/), which generates one PHP class per namespace.
 
+## Loading Phel: prod vs dev
+
+One boot hook covers both environments if you guard the load. In production the built file exists and you `require` it; in development it does not, so you fall back to `\Phel::run()`, which boots Gacela and compiles on first call:
+
+```php
+$built = $root . '/build/app/main.php';
+
+if (is_file($built)) {
+    require $built;                // prod: precompiled, self-contained \Phel::addDefinition() calls, no Gacela, no compiler
+} else {
+    \Phel::run($root, 'app.main'); // dev: boots Gacela and compiles to temp files on first call
+}
+```
+
+`$root` is the project root your framework already knows (`base_path()`, `getProjectDir()`, `__DIR__`). Run this **once** per process, behind a static flag, never in a per-request hot path. Commit `build/` in the deploy artifact (or run `phel build` in CI); skip committing it in dev so `is_file()` is false and `\Phel::run()` takes over. Framework hooks (Laravel, Symfony, framework-less) wire this into their kernels in [Framework Integration](/documentation/web/framework-integration/).
+
 ## FrankenPHP
 
 `worker.php`:

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -15,13 +15,7 @@ Zero to live REPL in under a minute.
 
 No extra runtime. No JVM.
 
-> **No PHP installed?** One-line Docker REPL:
->
-> ```bash
-> docker run --rm -it php:8.4-cli sh -c "curl -sL https://phel-lang.org/phar -o /tmp/phel.phar && php /tmp/phel.phar repl"
-> ```
->
-> See [Installation, Docker](/documentation/installation/#docker-no-php-required) for a `phel` alias and Composer workflows.
+> **No PHP installed?** Run a REPL in a single Docker command — see [Installation → Docker](/documentation/installation/#docker-no-php-required).
 
 ## 60-second quick start
 
@@ -130,26 +124,11 @@ example-app/
 
 All commands as `vendor/bin/phel <cmd>` (e.g. `vendor/bin/phel repl`). Skeleton wires `composer repl`, `composer dev`, `composer test`, `composer build` as shortcuts.
 
-## Initialize without the skeleton
-
-Minimal setup? Add Phel to any Composer project:
-
-```bash
-mkdir my-app && cd my-app
-composer require phel-lang/phel-lang
-vendor/bin/phel init my-app
-vendor/bin/phel repl
-```
-
-`phel init` creates `phel-config.php`, a `src/` namespace, matching test file.
-
 ## Verify setup
 
-```bash
-vendor/bin/phel doctor
-```
+Tooling misbehaving? Run `vendor/bin/phel doctor` — it reports missing extensions, cache permissions, and layout problems. Full breakdown in [Installation → Verify install](/documentation/installation/#verify-install).
 
-Checks PHP extensions (`json`, `mbstring`, `readline`), cache dir permissions, source layout. Run when tooling misbehaves.
+Adding Phel to an existing project instead of the skeleton? See [Installation → Add to an existing project](/documentation/installation/#add-to-an-existing-project).
 
 ## Your first 30 minutes
 

--- a/content/documentation/guides/coming-from-clojure.md
+++ b/content/documentation/guides/coming-from-clojure.md
@@ -41,15 +41,7 @@ Clojure intuition carries over.
      (into #{}))
 ```
 
-**Destructuring:** sequential and associative work in `let`, `fn`, `defn`, `loop`:
-
-```phel
-(let [[a b & rest] [1 2 3 4 5]]
-  rest) ; => [3 4 5]
-
-(let [{:name name :age age} {:name "Alice" :age 30}]
-  (str name " is " age)) ; => "Alice is 30"
-```
+**Destructuring:** sequential and associative work in `let`, `fn`, `defn`, `loop`, same as Clojure. See [Destructuring](/documentation/reference/cheat-sheet/#destructuring).
 
 **Higher-order functions:** `map`, `filter`, `reduce`, `some`, `every?`, `comp`, `partial`, `apply`, etc.:
 
@@ -59,16 +51,7 @@ Clojure intuition carries over.
 (reduce + 0 [1 2 3 4 5])   ; => 15
 ```
 
-**Lazy sequences:** full support. `map`, `filter`, `take`, `drop`, `concat`, `mapcat`, `interleave`, `partition` return lazy seqs. Infinite seqs work:
-
-```phel
-(take 5 (iterate inc 0))       ; => @[0 1 2 3 4]
-(take 7 (cycle [1 2 3]))       ; => @[1 2 3 1 2 3 1]
-(take 5 (repeatedly #(php/rand 1 100)))
-(->> (range) (filter even?) (take 5)) ; => @[0 2 4 6 8]
-```
-
-`lazy-seq`, `lazy-cat` build custom lazy seqs. `doall`, `dorun`, `realized?` control realization. Lazy file I/O via `line-seq`, `file-seq`, `read-file-lazy`, `csv-seq`.
+**Lazy sequences:** full support, including infinite seqs, custom `lazy-seq`/`lazy-cat`, realization control (`doall`, `dorun`, `realized?`), and lazy file I/O. See [Lazy sequences](/documentation/reference/cheat-sheet/#lazy-sequences).
 
 **Namespaces:** `:require` for Phel modules, `:as` and `:refer` like Clojure.
 
@@ -115,29 +98,7 @@ Phel supports Clojure-style `defmulti` / `defmethod` with hierarchy-aware dispat
 
 ### Type tags and inference
 
-`:tag` metadata emits PHP type declarations. Phel also infers return types from primitive operations:
-
-<!-- phel-test: skip -->
-```phel
-;; Explicit tags
-(defn ^int add [^int a ^int b]
-  (+ a b))
-;; Compiles to: function add(int $a, int $b): int { ... }
-
-;; Nullable type
-(defn ^"?string" find-name [^int id]
-  ...)
-
-;; ^:memoize wraps the body in memoize automatically
-(defn ^:memoize expensive [x]
-  (compute x))
-
-;; ^:async wraps the body in async, returning Amp\Future
-(defn ^:async fetch [url]
-  ...)
-```
-
-Inferred tags from tail primitive ops propagate to the PHP signature - you often don't need to annotate at all.
+`:tag` metadata emits PHP type declarations: `(defn ^int add [^int a ^int b] ...)` compiles to `function add(int $a, int $b): int`, and `^"?string"` marks a nullable type. Phel also infers return types from tail primitive ops, so you often don't need to annotate at all. See [Functions](/documentation/reference/cheat-sheet/#functions) for the tag and metadata shorthands (`^:memoize`, `^:async`).
 
 ### Numeric tower
 
@@ -163,21 +124,11 @@ Phel ships `BigInt`, `BigDecimal`, and `Ratio` as first-class types:
 
 ### Atoms only, no agents/refs/STM
 
-`atom` is the only mutable primitive. Works like Clojure's:
-
-```phel
-(def counter (atom 0))
-(swap! counter inc)   ; counter is now 1
-(deref counter)       ; => 1
-@counter              ; => 1 (shorthand)
-(reset! counter 42)   ; direct reset
-```
-
-No agents, refs, STM. See [Global and Local Bindings](/documentation/language/global-and-local-bindings).
+`atom` is the only mutable primitive; `atom`, `swap!`, `reset!`, and `deref`/`@` work exactly like Clojure's. No agents, refs, STM. See [Global and Local Bindings](/documentation/language/global-and-local-bindings).
 
 ### No spec
 
-No `clojure.spec`. Phel ships `phel.schema` for validation, coercion, and generation. See the schema recipe in the [Cookbook](/documentation/guides/cookbook/).
+No `clojure.spec`. Phel ships `phel.schema` for validation, coercion, and generation. See the [Schema Validation guide](/documentation/guides/schema/).
 
 ### Truthiness
 
@@ -359,20 +310,6 @@ Use `;` and `;;`. Legacy `#` line and `#| ... |#` block comments still read but 
 #_(comment (+ 1 2))  ; skip the next form
 (comment (+ 1 2))
 ```
-
-## PHP interop
-
-Phel's equivalent of Clojure's Java interop: the `php/` prefix unlocks the whole PHP ecosystem, and the Clojure-style shorthands carry over.
-
-| Clojure                   | Phel                                                            |
-|---------------------------|-----------------------------------------------------------------|
-| `(Math/pow 2 10)`         | `(php/pow 2 10)` (any PHP function via `php/`)                   |
-| `(Classname. args)`       | `(php/new Classname args)`                                      |
-| `(.method obj args)`      | `(php/-> obj (method args))` or `(.method obj args)`            |
-| `(Classname/method args)` | `(php/:: Classname (method args))` or `(Classname/method args)` |
-| array element             | `(php/aget arr key)` (PHP arrays, not Phel data structures)     |
-
-See [PHP Interop](/documentation/php-interop/) for the full reference: functions, objects, method and static calls, constants, and PHP-array access.
 
 ## What you'll miss (and workarounds)
 

--- a/content/documentation/guides/cookbook.md
+++ b/content/documentation/guides/cookbook.md
@@ -844,54 +844,7 @@ Each pattern vector must have the same length as the target vector. A trailing
 
 ## Schemas with `phel.schema`
 
-Validate, coerce, generate data from declarative schemas. Kinds: `:vector`, `:set`, `:map`, `:map-of`, `:tuple`, `:enum`, `:and`, `:or`, `:maybe`, `:re`, `:fn`, `:ref`, function schemas `[:=> args ret]`.
-
-```phel
-(ns cookbook.schema
-  (:require phel.schema :as s))
-
-(def User
-  [:map
-   [:id    :int]
-   [:name  :string]
-   [:role  [:enum :admin :user]]
-   [:tags  [:set :keyword]]])
-
-(s/validate User {:id 1 :name "Alice" :role :admin :tags #{:beta}})
-; => true
-
-(s/explain User {:id "bad" :name 1 :role :guest :tags []})
-; => {:errors [...]}
-
-(s/coerce User {:id "42" :name "Bob" :role "user" :tags ["a"]})
-; => {:id 42 :name "Bob" :role :user :tags #{:a}}
-```
-
-Wrap a function so its args/return are checked on every call. `instrument!`
-takes a name, the function, and a `[:=> [arg-schemas] ret-schema]` schema, and
-returns the wrapped function:
-
-```phel
-(ns cookbook.schema-instrument
-  (:require phel.schema :as s))
-
-(def User
-  [:map
-   [:id   :int]
-   [:name :string]])
-
-(defn greet [u] (str "Hi " (:name u)))
-(def greet! (s/instrument! :greet greet [:=> [User] :string]))
-
-(greet! {:id 1 :name "Alice"})   ; => "Hi Alice"
-```
-
-Calling it with an argument that fails the schema throws:
-
-<!-- phel-test: skip -->
-```phel
-(greet! {:id "x" :name "Alice"}) ; throws: argument 0 failed schema
-```
+Validate, coerce, and generate data from declarative schemas built out of plain Phel data, and wrap functions with `instrument!` to check args and returns on every call. See the [Schema Validation guide](/documentation/guides/schema/) for the full reference.
 
 ## Async with `phel.async`
 

--- a/content/documentation/guides/schema.md
+++ b/content/documentation/guides/schema.md
@@ -147,6 +147,5 @@ Toggle checking globally with `set-schema-check!`, inspect it with `schema-check
 
 ## See also
 
-- [Cookbook](/documentation/guides/cookbook) has copy-paste schema and instrumentation recipes.
 - [Coming from Clojure](/documentation/guides/coming-from-clojure) maps `schema` against the Clojure ecosystem.
 - `phel.test.gen` drives property-based testing from the same schemas via `generate` and `schema->gen`.

--- a/content/documentation/language/basic-types.md
+++ b/content/documentation/language/basic-types.md
@@ -17,25 +17,7 @@ true
 false
 ```
 
-Only `false` and `nil` are falsy. `0`, `""`, `[]` truthy.
-
-```phel
-;; Truthiness examples
-(if nil "yes" "no")   ; => "no"  (nil is falsy)
-(if false "yes" "no") ; => "no"  (false is falsy)
-(if 0 "yes" "no")     ; => "yes" (0 is truthy!)
-(if "" "yes" "no")    ; => "yes" (empty string is truthy!)
-(if [] "yes" "no")    ; => "yes" (empty vector is truthy!)
-```
-
-{% php_note() %}
-`nil` = PHP `null`. `true`/`false` same. But truthiness differs:
-
-**PHP**: `0`, `""`, `[]`, `null`, `false` falsy.
-**Phel**: only `false`, `nil` falsy.
-
-`if (0)` in PHP is false, but `(if 0 ...)` in Phel is true.
-{% end %}
+Only `false` and `nil` are falsy — `0`, `""`, and `[]` are all truthy (unlike PHP, where they are falsy). See [Truthiness](#truthiness) for the predicates and the full PHP comparison.
 
 ## Symbol
 
@@ -399,23 +381,7 @@ Whitespace-separated key/value pairs in braces. Even count: key1, value1, key2, 
 ```
 
 {% php_note() %}
-Unlike PHP associative arrays, Phel maps:
-- **Any type** as keys: vectors, lists, other maps
-- **Immutable**: operations return new maps
-- **Not** PHP arrays internally
-
-```php
-// PHP: mutable
-$map = ['name' => 'Alice'];
-$map['name'] = 'Bob';  // Mutates in place
-```
-
-```phel
-;; Phel: immutable
-(def map {:name "Alice"})
-(def new-map (assoc map :name "Bob"))  ; Returns new map
-;; map is still {:name "Alice"}
-```
+Unlike PHP associative arrays, Phel map keys can be **any type** (vectors, lists, other maps), maps are **immutable** (operations return new maps), and they are **not** PHP arrays internally. Worked comparison in [Data structures → Immutability](/documentation/language/data-structures/#immutability-vs-php-mutability).
 {% end %}
 
 ## Sets
@@ -528,15 +494,7 @@ Same `#"..."` syntax as Clojure. Engine is PHP PCRE, not Java regex, so some det
 
 ## Deref shorthand
 
-`@` is shorthand for `(deref ...)`. Dereferences atoms and other reference types:
-
-```phel
-(def counter (atom 0))
-
-@counter              ; Same as (deref counter) => 0
-(swap! counter inc)
-@counter              ; => 1
-```
+`@x` is shorthand for `(deref x)`, reading the current value of an atom or other reference type. Atom mechanics (`swap!`, `reset!`, the `!` convention) live in [Global and local bindings](/documentation/language/global-and-local-bindings/#atoms).
 
 ## Comments
 

--- a/content/documentation/language/basic-types.md
+++ b/content/documentation/language/basic-types.md
@@ -524,26 +524,7 @@ Same `#"..."` syntax as Clojure. Engine is PHP PCRE, not Java regex, so some det
 
 ## Anonymous function shorthand
 
-`#(...)` defines anonymous functions inline. `%` placeholders:
-
-- `%` or `%1` refers to the first argument
-- `%2`, `%3`, etc. refer to subsequent arguments
-- `%&` captures remaining variadic arguments
-
-```phel
-#(+ 6 %)       ; Same as (fn [x] (+ 6 x))
-#(+ %1 %2)     ; Same as (fn [a b] (+ a b))
-#(apply + %&)  ; Same as (fn [& xs] (apply + xs))
-
-; Using with higher-order functions
-(map #(* % 2) [1 2 3])        ; => @[2 4 6]
-(filter #(> % 3) [1 5 2 8])   ; => @[5 8]
-
-(def users [{:name "Alice" :age 30} {:name "Bob" :age 25}])
-(sort-by #(get % :age) users)  ; Sort users by age
-```
-
-> **Note:** Older `|(...)` form with `$` placeholders is deprecated. See [Functions and Recursion](/documentation/language/functions-and-recursion).
+`#(...)` defines an inline anonymous function, using `%`/`%1`/`%2`/`%&` for positional arguments — `#(* % 2)` is the same as `(fn [x] (* x 2))`. Full rules and the deprecated `|(...)` form live in [Functions and Recursion](/documentation/language/functions-and-recursion/#anonymous-function-fn).
 
 ## Deref shorthand
 

--- a/content/documentation/language/control-flow.md
+++ b/content/documentation/language/control-flow.md
@@ -292,7 +292,7 @@ Creates a lexical context with bindings and a recursion point at the top.
 
 Evaluates expressions and rebinds at the recursion point. Recursion point is a `fn` or `loop`. Arities must match exactly.
 
-`recur` compiles to a PHP `while` loop, avoiding _Maximum function nesting level_ errors.
+`recur` compiles to a PHP `while` loop, avoiding _Maximum function nesting level_ errors. Using `recur` for tail-recursive functions and the tail-call story are covered in [Functions and Recursion](/documentation/language/functions-and-recursion/#recursion).
 
 ```phel
 ;; Basic loop example - sum numbers from 1 to 10
@@ -301,16 +301,6 @@ Evaluates expressions and rebinds at the recursion point. Recursion point is a `
   (if (= cnt 0)
     sum
     (recur (+ cnt sum) (dec cnt))))  ; => 55
-
-;; Recursion in a function
-(defn factorial [n]
-  (loop [acc 1
-         n n]
-    (if (<= n 1)
-      acc
-      (recur (* acc n) (dec n)))))
-
-(factorial 5)  ; => 120
 
 ;; Finding an element in a vector
 (defn find-index [pred coll]
@@ -335,26 +325,6 @@ Evaluates expressions and rebinds at the recursion point. Recursion point is a `
 
 (reverse-vec [1 2 3 4])  ; => [4 3 2 1]
 ```
-
-{% php_note() %}
-TCO not in PHP natively:
-
-```php
-// PHP - recursive functions can cause stack overflow
-function countdown($n) {
-    if ($n === 0) return 0;
-    return countdown($n - 1);  // Stack overflow for large n!
-}
-
-// Phel - recur compiles to a while loop (safe for any n)
-(loop [n 1000000]
-  (if (= n 0)
-    0
-    (recur (dec n))))  ; No stack overflow!
-```
-
-Critical for FP patterns in PHP.
-{% end %}
 
 ## Foreach
 

--- a/content/documentation/language/data-structures.md
+++ b/content/documentation/language/data-structures.md
@@ -139,22 +139,7 @@ Remove with `dissoc`:
 ```
 
 {% php_note() %}
-Like PHP assoc arrays, with two differences:
-
-1. **Any type as a key**: vectors, lists, other maps
-2. **Immutable**: "updating" returns a new map
-
-```phel
-;; PHP: $arr = ['name' => 'Alice', 'age' => 30];
-;; Phel:
-{:name "Alice" :age 30}
-
-;; PHP: $arr['age'] = 31;
-;; Phel:
-(assoc {:name "Alice" :age 30} :age 31)
-;; => {:name "Alice" :age 31}
-;; Original map is unchanged!
-```
+Like PHP associative arrays, but with two differences: keys can be **any type** (vectors, lists, other maps), and maps are **immutable** — "updating" with `assoc` returns a new map and leaves the original untouched. Worked comparison in [Immutability vs PHP mutability](#immutability-vs-php-mutability) below.
 {% end %}
 
 ## Working with collections

--- a/content/documentation/language/interfaces.md
+++ b/content/documentation/language/interfaces.md
@@ -105,7 +105,7 @@ A struct can implement many. List each followed by its methods:
 
 ### Calling other methods on same struct
 
-Interface dispatch routes through the generated function, not through `this` directly. To call another interface method on the same struct from within a method body, use the PHP method call syntax via `php/-> this`:
+Interface dispatch routes through the generated function, not through `this` directly. To call another interface method on the same struct from within a method body, use the [PHP method-call operator](/documentation/language/error-handling/#catching-php-exceptions) `php/->` on `this`:
 
 ```phel
 (definterface Describable

--- a/content/documentation/language/interfaces.md
+++ b/content/documentation/language/interfaces.md
@@ -105,7 +105,7 @@ A struct can implement many. List each followed by its methods:
 
 ### Calling other methods on same struct
 
-Interface dispatch routes through the generated function, not through `this` directly. To call another interface method on the same struct from within a method body, use the [PHP method-call operator](/documentation/language/error-handling/#catching-php-exceptions) `php/->` on `this`:
+Interface dispatch routes through the generated function, not through `this` directly. To call another interface method on the same struct from within a method body, use the [PHP method-call operator](/documentation/php-interop/#method-and-property-call) `php/->` on `this`:
 
 ```phel
 (definterface Describable

--- a/content/documentation/language/lazy-sequences.md
+++ b/content/documentation/language/lazy-sequences.md
@@ -129,10 +129,10 @@ These return lazy sequences, so you rarely need to write `lazy-seq` yourself:
 ; [:a :b :c :a :b :c :a]
 
 (println (->> (range 100)
-              (filter even?)
-              (map (fn [x] (* x x)))
+              (map inc)
+              (filter odd?)
               (take 5)))
-; [0 4 16 36 64]
+; [1 3 5 7 9]
 ```
 
 ## Performance

--- a/content/documentation/language/macros.md
+++ b/content/documentation/language/macros.md
@@ -102,20 +102,17 @@ Simple, doesn't cover all `defn` features, but shows the basics.
 ```
 
 {% clojure_note() %}
-Quasiquote syntax is identical to Clojure:
-- `` ` `` for quasiquote (syntax-quote)
-- `~` for unquote
-- `~@` for unquote-splicing
+Same quasiquote/unquote/splicing tokens as Clojure.
 {% end %}
 
 ## Expanding macros
 
 To see what a macro produces, expand it without running it. `macroexpand-1` does a single expansion step; `macroexpand` keeps expanding until the top form is no longer a macro call. Quote the form so it stays code.
 
-```phel
-(defmacro unless [test then else]
-  `(if (not ~test) ~then ~else))
+Expanding the `unless` macro from [Why macros](#why-macros):
 
+<!-- phel-test: skip -->
+```phel
 (macroexpand-1 '(unless false "yes" "no"))
 ; => (if (phel.core/not false) "yes" "no")
 

--- a/content/documentation/language/reader-shortcuts.md
+++ b/content/documentation/language/reader-shortcuts.md
@@ -44,31 +44,13 @@ Quasiquote is like quote but allows selective evaluation inside it: unquote (`~`
 
 ### Auto-gensym `name#`
 
-Inside a quasiquote, a symbol ending in `#` expands to a fresh, unique name. Every occurrence of the same `name#` within one quasiquote shares that generated name, which gives hygienic macros without an explicit `gensym` call:
-
-```phel skip
-(defmacro time [expr]
-  `(let [start# (php/microtime true)
-         ret#   ~expr]
-     (println "Elapsed:" (- (php/microtime true) start#) "secs")
-     ret#))
-```
-
-Each expansion produces a fresh pair such as `start__123__auto__` / `ret__124__auto__`, so generated bindings cannot collide with the caller's locals. See [Macros](/documentation/language/macros) for the full story on hygiene.
+Inside a quasiquote, a symbol ending in `#` expands to a fresh, unique name, and the same `name#` maps to that one generated name throughout the template — hygienic macros without an explicit `gensym`. See [Macros](/documentation/language/macros/#hygiene-and-gensym) for the full story.
 
 > **Deprecated:** `name$` as an auto-gensym suffix. Use `name#`.
 
 ## Reader conditionals `#?()` and `#?@()`
 
-Resolved while reading. `#?()` picks one form by platform key; `#?@()` splices a collection and is only valid inside another collection. Phel selects the `:phel` branch and falls back to `:default`:
-
-```phel
-#?(:phel (php/microtime) :clj 99)  ; => the (php/microtime) value in Phel
-#?(:clj 99 :default 0)             ; => 0
-[1 #?@(:phel [2 3]) 4]             ; => [1 2 3 4]
-```
-
-These let one `.cljc` file compile under both Phel and Clojure. The `:clj` branch is never read by Phel, so it does not need to be valid Phel.
+Resolved while reading: `#?()` picks one form by platform key (Phel selects `:phel`, falling back to `:default`), and `#?@()` splices a platform-specific collection into its enclosing collection — so one `.cljc` file can compile under both Phel and Clojure. See [Reader Conditionals](/documentation/language/reader-conditionals/) for the full treatment.
 
 ## Deref `@`
 

--- a/content/documentation/language/transducers.md
+++ b/content/documentation/language/transducers.md
@@ -197,21 +197,7 @@ Wrap the step result in `reduced` to stop the pipeline. This `take-until` keeps 
 
 ## Transducers vs lazy sequences
 
-Every dual-purpose function has two modes:
-
-```phel
-(ns example\two-modes)
-
-; With collection: returns a lazy sequence
-(map inc [1 2 3])   ; => (2 3 4)
-(filter even? [1 2 3 4])   ; => (2 4)
-
-; Without collection: returns a transducer (a function)
-(fn? (map inc))   ; => true
-(fn? (filter even?))   ; => true
-```
-
-**When to use which:**
+Each [dual-purpose function](#transducer-producing-functions) works both ways — with a collection it returns a lazy sequence, without one it returns a transducer. When to use which:
 
 - **Lazy sequences** for simple linear pipelines; compose with `->>`.
 - **Transducers** to avoid intermediates in multi-step pipelines, to reuse one transformation across multiple sources or destinations, or to reduce into something that isn't a sequence (sums, maps, side effects).

--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -761,18 +761,7 @@ class MyExistingClass {
 
 `phel export` generates a wrapper class for all Phel functions marked *export*.
 
-Add config to `phel-config.php` first:
-
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->withExportFromDirectories(['src'])
-    ->withExportNamespacePrefix('PhelGenerated')
-    ->withExportTargetDirectory('src/PhelGenerated')
-;
-```
-
-Option details: [Configuration](/documentation/configuration/).
+Set the `withExportFromDirectories`, `withExportNamespacePrefix`, and `withExportTargetDirectory` options in `phel-config.php` first: see [Configuration](/documentation/configuration/#full-reference).
 
 Mark a function exported with metadata:
 
@@ -787,20 +776,7 @@ Mark a function exported with metadata:
 
 ### Typed and annotated output
 
-When the generated PHP must satisfy a framework's type expectations, opt-in metadata enriches it. Untagged forms are unchanged.
-
-| Metadata | On | Emits |
-|---|---|---|
-| `^{:tag T}` | struct field, interface param/return | typed signature; `(a b)` = union `a\|b`, `[a b]` = intersection `a&b` |
-| `^{:php/attr [...]}` | struct/interface name, field, method, param, exported `defn` | PHP 8 `#[Attr]` |
-| `^{:php/doc "..."}` | struct/interface name, field, method | PHPDoc block (phpstan/psalm) |
-| `^{:php/json true}` / `^{:php/stringable true}` | struct name | implements `\JsonSerializable` / `\Stringable` |
-
-```phel
-(defstruct ^{:php/attr [:ORM/Entity] :php/json true} product
-  [^{:tag int :php/attr [:ORM/Id]} id
-   ^{:tag string} name])
-```
+When the generated PHP must satisfy a framework's type expectations, opt-in metadata (`^{:tag T}`, `^{:php/attr [...]}`, `^{:php/doc "..."}`, `^:php/readonly`, and more) enriches it; untagged forms are unchanged. For the full metadata table and a Doctrine-entity `defstruct` example, see [Typed PHP from Phel definitions](/documentation/web/framework-integration/#typed-php-from-phel-definitions).
 
 ## Next steps
 

--- a/content/documentation/reference/cheat-sheet.md
+++ b/content/documentation/reference/cheat-sheet.md
@@ -315,6 +315,7 @@ See [Data Structures](/documentation/language/data-structures/#walking-data-stru
     (map + (fibs) (rest (fibs)))))))
 
 (doall (take 8 (fibs)))           ; => [0 1 1 2 3 5 8 13]
+(dorun (map println [1 2 3]))     ; => nil (realize for side effects only)
 (realized? (lazy-seq [1 2 3]))    ; => false
 ```
 

--- a/content/documentation/tooling/cli-commands.md
+++ b/content/documentation/tooling/cli-commands.md
@@ -101,14 +101,7 @@ Exports definitions with `{:export true}` metadata as PHP classes. Generates one
 vendor/bin/phel export
 ```
 
-[Configuration](/documentation/configuration/) in `phel-config.php`:
-```php
-<?php
-return (new \Phel\Config\PhelConfig())
-    ->withExportFromDirectories(['src'])
-    ->withExportNamespacePrefix('PhelGenerated')
-    ->withExportTargetDirectory('src/PhelGenerated');
-```
+Configure the export dirs, namespace prefix, and target directory in `phel-config.php`; see [Configuration](/documentation/configuration/#full-reference).
 
 ## Format phel files
 
@@ -198,21 +191,7 @@ vendor/bin/phel test
 #       --coverage-output=PATH  Write the coverage report to a file (use with --coverage=clover for CI).
 ```
 
-Test selectors and reporters: see [Testing](/documentation/testing/).
-
-```bash
-# Re-run on every change while you work
-vendor/bin/phel test --watch
-
-# Re-run only what failed last time
-vendor/bin/phel test --last-failed
-
-# Line coverage as text, or Clover XML for CI
-vendor/bin/phel test --coverage
-vendor/bin/phel test --coverage=clover --coverage-output=coverage.xml
-```
-
-`--coverage` needs pcov or xdebug and runs serially (it disables `--parallel` for that run). Only project source files count; vendor and core are excluded.
+See [Testing](/documentation/testing/) for what each flag does.
 
 [Configuration](/documentation/configuration/) in `phel-config.php`:
 ```php
@@ -220,8 +199,6 @@ vendor/bin/phel test --coverage=clover --coverage-output=coverage.xml
 return (new PhelConfig())
     ->withTestDirs(['tests']);
 ```
-
-Use `filter` to run matching tests only.
 
 ## Evaluate an expression
 
@@ -303,23 +280,23 @@ From Phel code, use `phel.watch`:
 
 ## nREPL
 
-Bencode-over-TCP nREPL server. Ops: `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, `completions`, `lookup`, `info`, `eldoc`.
+Bencode-over-TCP nREPL server for editor inline eval.
 
 ```bash
 vendor/bin/phel nrepl --port=7888 --host=127.0.0.1
 ```
 
-Connect from any nREPL-aware editor.
+See [Editor support](/documentation/tooling/editor-support/#nrepl-and-editor-integration) for supported ops and connecting your editor.
 
 ## LSP
 
-LSP v3.17 over stdio. Supports hover, definition, references, completion, document/workspace symbols, rename, formatting, debounced diagnostics.
+LSP v3.17 over stdio.
 
 ```bash
 vendor/bin/phel lsp
 ```
 
-PHP interop is completion-aware: instance methods/properties after `(php/-> receiver ...)`, static methods/constants after `(php/:: Class ...)`, class names in `(php/new ...)` and `\Fully\Qualified` positions, and global functions after `php/`. Hover shows the reflected signature for PHP methods, functions, and classes; signature help fires inside `(php/new ...)` and method calls. Receiver types come from `:tag` metadata, an inline `(php/new \Foo)`, or a local `(php/new ...)` binding; an unknown type degrades to no completion with no spurious diagnostics. See [Editor support](/documentation/tooling/editor-support/).
+See [Editor support](/documentation/tooling/editor-support/#language-server-lsp) for supported features and PHP-interop-aware completion.
 
 
 ## Analyze and index

--- a/content/documentation/tooling/editor-support.md
+++ b/content/documentation/tooling/editor-support.md
@@ -86,7 +86,7 @@ This starts an [nREPL](https://nrepl.org/) server (Bencode over TCP) that nREPL-
 
 Defaults are port `7888` and host `127.0.0.1`. Override either with the flags above. The server is also listed under [CLI commands](/documentation/tooling/cli-commands/#nrepl) alongside the other tooling entry points.
 
-Two nREPL ops back the [REPL-driven workflow](/documentation/tooling/repl/#reload-changed-code): `reload` (with an `all` param to force a full reload) and `run-tests` (an `ns` param plus an optional `var`). Bind them to editor commands for "reload changed namespaces" and "run the test under the cursor".
+The server implements the standard ops — `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, `completions`, `lookup`, `info`, `eldoc` — so stock nREPL clients work unmodified. Two Phel-specific ops back the [REPL-driven workflow](/documentation/tooling/repl/#reload-changed-code): `reload` (with an `all` param to force a full reload) and `run-tests` (an `ns` param plus an optional `var`). Bind them to editor commands for "reload changed namespaces" and "run the test under the cursor".
 
 ## Language Server (LSP)
 

--- a/content/documentation/tooling/repl.md
+++ b/content/documentation/tooling/repl.md
@@ -231,8 +231,8 @@ user:2> (load-file "src/my/app.phel")
 Run tests for a namespace from the REPL:
 
 ```phel
-user:1> (require phel.test :refer [test-ns])
-user:2> (test-ns 'my.app.tests)
+user:1> (require phel.repl :refer [test-ns])
+user:2> (test-ns "my-app.tests")
 ; Runs all tests in the namespace and prints results
 ```
 

--- a/content/documentation/tooling/repl.md
+++ b/content/documentation/tooling/repl.md
@@ -309,7 +309,7 @@ user:2> (reload-all!)
 ; => force-reloads every loaded project namespace, ignoring mtimes
 ```
 
-`reload!`, `reload-all!`, `run-tests`, and `run-test` live in `phel.repl` and load automatically in the REPL and over nREPL. Editors can bind the matching nREPL ops `reload` (with an `all` param) and `run-tests` (an `ns` plus optional `var` param) to "reload changed" and "run the test under the cursor".
+`reload!`, `reload-all!`, `run-tests`, and `run-test` live in `phel.repl` and load automatically in the REPL and over nREPL. Editors can bind the matching nREPL ops to editor commands: see [Editor Support](/documentation/tooling/editor-support/#nrepl-and-editor-integration).
 
 ### Explore PHP interop
 
@@ -410,23 +410,7 @@ Collect tapped values during a test:
 
 ### PHP native inspection
 
-Phel values are PHP objects, so PHP inspection functions work via `php/`:
-
-```phel
-(php/var_dump (+ 2 2))
-;; int(4)
-
-;; print_r expects a native PHP array, so convert first:
-(php/print_r (php/array 1 2 3))
-;; Array
-;; (
-;;     [0] => 1
-;;     [1] => 2
-;;     [2] => 3
-;; )
-```
-
-For richer output, [Symfony VarDumper](/documentation/tooling/php-tools/) via `(php/dump ...)` and `(php/dd ...)`.
+Phel values are PHP objects, so every PHP inspection function works via `php/`: `(php/var_dump x)`, `(php/print_r ...)`, and Symfony VarDumper's `(php/dump ...)` / `(php/dd ...)`. See [PHP Debugging Tools](/documentation/tooling/php-tools/) for examples and setup.
 
 ## Tips
 

--- a/content/documentation/web/framework-integration.md
+++ b/content/documentation/web/framework-integration.md
@@ -17,7 +17,7 @@ Phel installs as a Composer package and compiles to plain PHP. Your framework ne
 2. Mark public functions with `{:export true}`.
 3. Create one main namespace (`app.main`) that `:require`s every feature namespace. Loading it registers all exported functions at once.
 4. Export PHP wrappers under your framework's `App\` PSR-4 root via `phel export`.
-5. In production, run `phel build` at deploy and `require 'build/app/main.php'` at boot. In development, `\Phel::run($root, 'app.main')` compiles on first call.
+5. In production, run `phel build` at deploy and `require 'build/app/main.php'` at boot; in development, `\Phel::run($root, 'app.main')` compiles on first call. One [load guard](/documentation/deployment/#loading-phel-prod-vs-dev) picks the right path.
 
 Namespaces need at least two segments (`shop.pricing`, not `pricing`); a single-segment namespace exports invalid PHP.
 
@@ -99,7 +99,7 @@ return PhelConfig::forProject()
     ->withExportTargetDirectory(__DIR__ . '/app/PhelGenerated');
 ```
 
-A service provider loads the main namespace once, so all wrappers are ready:
+A service provider runs the [load guard](/documentation/deployment/#loading-phel-prod-vs-dev) once, with Laravel's `base_path()` as the root, so all wrappers are ready:
 
 ```php
 namespace App\Providers;
@@ -172,7 +172,7 @@ return PhelConfig::forProject()
 
 The default `App\ → src/` PSR-4 mapping covers `App\PhelGenerated\`.
 
-Hook the load into the kernel `boot()`:
+Hook the same [load guard](/documentation/deployment/#loading-phel-prod-vs-dev) into the kernel `boot()`, with `getProjectDir()` as the root:
 
 ```php
 private static bool $phelLoaded = false;
@@ -214,7 +214,7 @@ return PhelConfig::forProject(mainNamespace: 'app.main')
     ->withBuildDestDir('build');
 ```
 
-Entry script:
+Entry script, applying the [load guard](/documentation/deployment/#loading-phel-prod-vs-dev) with `__DIR__` as the root:
 
 ```php
 <?php
@@ -330,10 +330,9 @@ For the full semantics of typed emission, native enums, and exceptions, see [Nat
 
 - Namespace path matches directory: `phel/shop/pricing.phel` maps to `(ns shop.pricing)`.
 - Hyphens become camelCase: `(ns my-lib.core)` maps to `App\PhelGenerated\MyLib\Core`; `apply-discount` to `applyDiscount`.
-- Prod path (`require build/app/main.php`): self-contained, no Gacela bootstrap, no compiler. Just `\Phel::addDefinition()` calls.
-- Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard it with a static flag; never call it from Laravel's `register()` or a per-request hot path.
+- Prod vs dev load, the run-once rule, and committing `build/`: see [Loading Phel: prod vs dev](/documentation/deployment/#loading-phel-prod-vs-dev).
+- Load Phel in Laravel's `boot()`, never `register()` or any per-request hot path.
 - `withBuildDestDir()` is relative to the project root.
-- Commit `build/` in the deploy artifact, or run `phel build` in CI. Skip committing it in dev so `is_file()` is false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## Next steps

--- a/content/documentation/web/routing.md
+++ b/content/documentation/web/routing.md
@@ -106,17 +106,14 @@ Putting it together: read the request, let the router pick and run a handler, em
 <!-- phel-test: skip -->
 ```phel
 (ns my-app
-  (:require phel.http :as http)
   (:require phel.router :as router))
 
 (def app
   (router/handler (router/router routes)
     {:not-found (fn [_] {:status 404 :body "Not found"})}))
-
-(-> (http/request-from-globals)
-    (app)
-    (http/emit-response))
 ```
+
+`app` is an ordinary handler; run it at your entry point through the request→emit pipeline shown in [End to end](/documentation/web/http-request-and-response/#end-to-end).
 
 The flow is: request (from [Request and Response](/documentation/web/http-request-and-response/)) -> route match -> handler -> response -> [HTML rendering](/documentation/web/html-rendering/) for the body -> emit.
 

--- a/content/documentation/why-phel.md
+++ b/content/documentation/why-phel.md
@@ -10,22 +10,7 @@ Honest answers below. If Phel doesn't fit, that's fine.
 
 ## Do I need to know Lisp?
 
-No. One rule: first element inside parentheses is the function, the rest are arguments.
-
-```php
-// PHP
-array_map($fn, $arr);
-str_contains($haystack, $needle);
-```
-
-<!-- phel-test: skip -->
-```phel
-;; Phel
-(map fn arr)
-(php/str_contains haystack needle)
-```
-
-No operator precedence, no special cases. [Practice exercises](/practice/basic) get you comfortable in an hour.
+No. One rule: the first element inside parentheses is the function, the rest are arguments — `(map fn arr)`, `(php/str_contains haystack needle)`. No operator precedence, no special cases. [Phel in 5 Minutes](/documentation/phel-in-5-minutes) walks through the syntax; [practice exercises](/practice/basic) get you comfortable in an hour.
 
 ## Why Lisp syntax specifically?
 
@@ -48,16 +33,7 @@ Phel and PHP optimize for different things on the same runtime.
 
 ## Can I use existing PHP libraries?
 
-Yes. Full interop through the `php/` prefix:
-
-```phel
-(php/strlen "hello")                          ; => 5
-(def date (php/new DateTimeImmutable "2024-01-15")) ; create object
-(php/-> date (format "Y-m-d"))                ; call method
-(php/:: DateTimeImmutable ATOM)               ; static / constant
-```
-
-Composer packages work. Any class, trait, function, constant. See [PHP Interop](/documentation/php-interop).
+Yes. Any Composer package, class, trait, function, or constant is callable through the `php/` prefix — e.g. `(php/strlen "hello")` or `(php/-> (php/new DateTimeImmutable "2024-01-15") (format "Y-m-d"))`. The full escape hatch (methods, statics, constants, `php/aget`) is in [PHP Interop](/documentation/php-interop).
 
 ## Isn't a compilation step a hassle?
 

--- a/content/practice/control-flow.md
+++ b/content/practice/control-flow.md
@@ -82,30 +82,6 @@ Learn more: [Control Flow](/documentation/language/control-flow)
 {% end %}
 
 {% question(difficulty="medium") %}
-Define `grade` mapping a score to a letter (A >= 90, B >= 80, C >= 70, F otherwise) with `cond`.
-<!-- phel-test: skip -->
-```phel
-(grade 95) ; => "A"
-(grade 82) ; => "B"
-(grade 71) ; => "C"
-(grade 55) ; => "F"
-```
-{% end %}
-{% solution() %}
-```phel
-(defn grade [score]
-  (cond
-    (>= score 90) "A"
-    (>= score 80) "B"
-    (>= score 70) "C"
-    "F"))
-```
-`cond` checks each condition in order and returns the value beside the first truthy one. A trailing standalone value acts as the default.
-
-Learn more: [Control Flow](/documentation/language/control-flow)
-{% end %}
-
-{% question(difficulty="medium") %}
 Define `day-type` that classifies days using `case`:
 <!-- phel-test: skip -->
 ```phel
@@ -147,7 +123,7 @@ Pick the right tool. Write `describe-temp` for ranges:
     (>= degrees 0)  "cold"
     "freezing"))
 ```
-`cond` wins here because we're testing **ranges**, not exact values. Rule of thumb: `if` for one binary choice, `case` for exact constants, `cond` for multiple range conditions.
+`cond` wins here because we're testing **ranges**, not exact values.
 
 Learn more: [Control Flow](/documentation/language/control-flow)
 {% end %}

--- a/content/practice/data-structures.md
+++ b/content/practice/data-structures.md
@@ -165,7 +165,7 @@ Use `conj` to append `4` to `[1 2 3]`. Verify the original length didn't change.
 (count more-nums) ; => 4
 more-nums         ; => [1 2 3 4]
 ```
-Same immutability story: `conj` returns a new vector, the original stays put.
+Immutable, like `assoc` above: `conj` returns a new vector, the original stays put.
 
 Learn more: [Data Structures](/documentation/language/data-structures)
 {% end %}

--- a/content/practice/functions-and-bindings.md
+++ b/content/practice/functions-and-bindings.md
@@ -124,9 +124,9 @@ Create an anonymous function that adds 10 to a number. Call it with `5`. Try bot
 (#(+ % 10) 5)
 ; => 15
 ```
-Anonymous functions shine when you need a one-off (think `map`, `filter`). The `#()` shortcut uses `%` for the first argument, `%2` for the second, and so on.
+Anonymous functions shine when you need a one-off (think `map`, `filter`).
 
-Learn more: [Functions and Recursion](/documentation/language/functions-and-recursion)
+Learn more: [Functions and Recursion](/documentation/language/functions-and-recursion/#anonymous-function-fn)
 {% end %}
 
 {% question(difficulty="medium") %}
@@ -185,7 +185,6 @@ Implement `factorial` using recursion.
     1
     (* n (factorial (dec n)))))
 ```
-Classic recursion: shrink the problem on every call until you hit the base case (`n <= 1`). For huge `n` you'd reach for `loop`/`recur` (next section) to avoid blowing the stack.
 
 Learn more: [Functions and Recursion](/documentation/language/functions-and-recursion)
 {% end %}

--- a/content/practice/working-with-collections.md
+++ b/content/practice/working-with-collections.md
@@ -210,7 +210,7 @@ Use `update-in` to bump the balance from `3` to `4`:
 (update-in data [:customers 0 :account :balance] inc)
 ;; => {:shops [:shop-1] :customers [{:id "Bob" :account {:balance 4}}]}
 ```
-`update-in` walks into a nested structure and applies a function at the path. Pure - the original data stays put.
+`update-in` walks into a nested structure and applies a function at the path.
 
 Learn more: [Data Structures](/documentation/language/data-structures)
 {% end %}


### PR DESCRIPTION
## What

De-duplicates the docs: ~370 lines of repeated prose/snippets replaced with links to a single canonical source (**24 files, +72 / −444**, one theme per commit), plus a few correctness fixes found along the way.

## Fixes

- **REPL docs' `test-ns` snippet was broken** — it lives in `phel.repl` (not `phel.test`) and takes the namespace as a string. Verified against the runtime.
- **Homepage contradicted why-phel on production-readiness.** Reconciled to one stance, linked to the canonical answer.
- **Homepage Docker command used the undocumented `phellang/repl` image.** Standardised on the `php:8.4-cli` + phar one-liner every other page uses.

## De-duplicated

Install/setup, onboarding examples, `#()` shorthand, `loop`/`recur` + TCO, truthiness/immutability/atoms, reader shortcuts, transducers, practice solutions, the Clojure guide, the cookbook schema recipe, nREPL/LSP details, `phel test` flags, export config, the typed-emission table, the prod/dev load guard, the request→emit pipeline, and PHP inspection helpers — each now lives in one place (the cheat-sheet is the single source for bare syntax).

Deliberately kept: rosetta-stone's inline Phel column (a translation table's job), agentic-coding's self-containment (offline AI agents), interfaces' runnable fixtures, and the load-bearing `/phar` alias.

## Verification

- Doc-snippet suite: **555 passed, 0 failed, 0 regressions**.
- `zola check`: **0 broken internal links**.
- A post-review pass (`9389edc`) closed three gaps where a link promised content its target lacked: `dorun` in the cheat-sheet, the standard nREPL op list in editor-support, and the `php/->` link now pointing to its canonical php-interop section.
