### PR TITLE
chore: bump phel-lang to 0.49.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -157,16 +157,16 @@
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.18.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "d4f91871da18de2cdcc651c571d3932489436411"
+                "reference": "611b04e178e72d8cf068a7102e29b0815320d33e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/d4f91871da18de2cdcc651c571d3932489436411",
-                "reference": "d4f91871da18de2cdcc651c571d3932489436411",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/611b04e178e72d8cf068a7102e29b0815320d33e",
+                "reference": "611b04e178e72d8cf068a7102e29b0815320d33e",
                 "shasum": ""
             },
             "require": {
@@ -231,7 +231,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.18.0"
+                "source": "https://github.com/gacela-project/gacela/tree/1.19.0"
             },
             "funding": [
                 {
@@ -239,7 +239,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-20T05:33:57+00:00"
+            "time": "2026-07-23T07:07:01+00:00"
         },
         {
             "name": "phel-lang/phel-lang",
@@ -4091,5 +4091,5 @@
     "platform-overrides": {
         "php": "8.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Automated bump of `phel-lang/phel-lang` to 0.49.0 via build/upgrade-ecosystem.sh from the phel-lang repo. Tests passed locally before push.