### PR TITLE
fix: point top-nav Documentation link to /documentation/ landing

### DIFF
--- a/templates/navigation/top-navigation.html
+++ b/templates/navigation/top-navigation.html
@@ -1,6 +1,6 @@
 <ul class=top-navigation>
     <li class="top-navigation__item {% if current_path and current_path is starting_with('/documentation/') and not current_path is starting_with('/documentation/reference/api/') %}active{% endif %}">
-        <a href="/documentation/getting-started/">Documentation</a>
+        <a href="/documentation/">Documentation</a>
     </li>
     <li class="top-navigation__item {% if current_path and current_path is starting_with('/documentation/reference/api/') %}active{% endif %}">
         <a href="/documentation/reference/api/">API</a>


### PR DESCRIPTION
Points the top-nav **Documentation** entry to `/documentation/` so visitors hit the orientation page (the "New here? Start here" map and "Browse by section" cards) before diving into a specific page.

Active-state highlight is unchanged: it keys on `starting_with('/documentation/')`, still matches.

Closes #256

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL