### PR TITLE
ref: single-source the guided Start here path

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
         <svg class="homepage-cta-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
         Quick start
       </a>
-      <a href="/documentation/getting-started" class="homepage-cta-button homepage-cta-secondary">
+      <a href="/documentation/" class="homepage-cta-button homepage-cta-secondary">
         <svg class="homepage-cta-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
         Read docs
       </a>


### PR DESCRIPTION
The homepage hero's **Read docs** CTA pointed straight to `getting-started`, bypassing the curated `/documentation/` landing that holds the canonical "New here? Start here" guided path. Repointing it keeps that path a single source of truth: the homepage now hands off to the orientation map instead of competing with it.

No duplicated step list existed to remove, the full ordered sequence already lives only in `content/documentation/_index.md`; this closes the funnel loop.

Closes #255

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL