### PR TITLE
feat: add persona chooser to homepage and documentation landing

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -34,6 +34,31 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
   </div>
 </section>
 
+<section class="homepage-section">
+
+## Choose your path
+
+<div class="section-page-list">
+  <a href="/documentation/phel-in-5-minutes/" class="section-page-card">
+    <h3 class="section-page-card__title">New to Lisp</h3>
+    <p class="section-page-card__desc">Never seen syntax like this? Learn to read Phel in five minutes, no install needed.</p>
+  </a>
+  <a href="/documentation/guides/rosetta-stone/" class="section-page-card">
+    <h3 class="section-page-card__title">Coming from PHP</h3>
+    <p class="section-page-card__desc">Map everyday PHP to its Phel equivalent, side by side.</p>
+  </a>
+  <a href="/documentation/guides/coming-from-clojure/" class="section-page-card">
+    <h3 class="section-page-card__title">Coming from Clojure</h3>
+    <p class="section-page-card__desc">Know Clojure? See what carries over and what changes on the PHP runtime.</p>
+  </a>
+  <a href="/documentation/reference/api/" class="section-page-card">
+    <h3 class="section-page-card__title">Just the API</h3>
+    <p class="section-page-card__desc">Skip the prose. Jump straight to every function in every namespace.</p>
+  </a>
+</div>
+
+</section>
+
 <section class="homepage-section homepage-section--alt">
 
 ## Phel by example

--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -9,6 +9,27 @@ insert_anchor_links = "right"
 
 Phel is a functional Lisp that compiles to PHP: persistent data structures, immutability by default, and macros, all running on your existing PHP runtime.
 
+## Pick your path
+
+<div class="section-page-list">
+  <a href="/documentation/phel-in-5-minutes/" class="section-page-card">
+    <h3 class="section-page-card__title">New to Lisp</h3>
+    <p class="section-page-card__desc">Never seen syntax like this? Learn to read Phel in five minutes, no install needed.</p>
+  </a>
+  <a href="/documentation/guides/rosetta-stone/" class="section-page-card">
+    <h3 class="section-page-card__title">Coming from PHP</h3>
+    <p class="section-page-card__desc">Map everyday PHP to its Phel equivalent, side by side.</p>
+  </a>
+  <a href="/documentation/guides/coming-from-clojure/" class="section-page-card">
+    <h3 class="section-page-card__title">Coming from Clojure</h3>
+    <p class="section-page-card__desc">Know Clojure? See what carries over and what changes on the PHP runtime.</p>
+  </a>
+  <a href="/documentation/reference/api/" class="section-page-card">
+    <h3 class="section-page-card__title">Just the API</h3>
+    <p class="section-page-card__desc">Skip the prose. Jump straight to every function in every namespace.</p>
+  </a>
+</div>
+
 ## New here? Start here
 
 1. [Phel in 5 Minutes](/documentation/phel-in-5-minutes/) - never seen a Lisp? Learn to read Phel, no install needed


### PR DESCRIPTION
Adds a **persona chooser** card row so visitors self-select a path in one click, on both the homepage ("Choose your path") and the documentation landing ("Pick your path"):

| Card | Goes to |
|------|---------|
| New to Lisp | Phel in 5 Minutes |
| Coming from PHP | Rosetta Stone |
| Coming from Clojure | Coming from Clojure |
| Just the API | API reference |

Juniors keep the guided linear path directly below; seniors skip straight to what maps to what they know. Reuses the existing theme-aware `.section-page-card` grid, so **no new CSS**. Verified locally with `zola build` and `zola check`.

Closes #254

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL