### PR TITLE
docs: assign one canonical role per doc section and cross-link overlaps

### DIFF
--- a/content/blog/2025-12-03-writing-your-first-macro.md
+++ b/content/blog/2025-12-03-writing-your-first-macro.md
@@ -8,6 +8,8 @@ If you have played with [threading macros](/blog/threading-macros) or [pattern m
 
 PHP developers sometimes reach for `eval()` or code generation tools when they need to produce code dynamically. Clojure developers know a better way: macros. Phel brings that same power to the PHP ecosystem, letting you extend the language at compile time instead of juggling strings at runtime.
 
+> **Canonical reference:** this is a narrative walkthrough. For the concise language reference on macros, see [Macros](/documentation/language/macros/).
+
 ## Functions vs macros: when code is data
 
 Regular functions receive values and return values. Macros receive *code* and return *code*. The transformation happens at compile time, so there is zero runtime cost.

--- a/content/blog/2026-04-17-destructuring-deep-dive.md
+++ b/content/blog/2026-04-17-destructuring-deep-dive.md
@@ -11,6 +11,8 @@ If you have read the [immutability post](/blog/immutability-in-phel) you already
 
 PHP gives you array unpacking (`[$a, $b] = [1, 2]`) and keyed destructuring (`['name' => $name] = $data`). Phel gives you a tiny pattern language that works in `let`, function parameters, and `loop` bindings, with nesting, defaults, rest capture, and aliasing.
 
+> **Canonical reference:** this is a narrative deep dive. For the concise language reference on destructuring, see [Destructuring](/documentation/language/destructuring/).
+
 ## The shape is the code
 
 The rule is one line: **write the shape of the data on the left, put the data on the right**. Phel walks both together and binds names wherever you wrote a symbol.

--- a/content/documentation/guides/cookbook.md
+++ b/content/documentation/guides/cookbook.md
@@ -7,6 +7,8 @@ aliases = ["/documentation/cookbook", "/documentation/one-liners"]
 
 Practical, self-contained Phel recipes for everyday tasks. Copy one, adapt it, ship it.
 
+> **Recipes, not concepts.** Each entry is a task-oriented snippet. For the language concepts behind them, see the [Language](/documentation/language/) section; for quick syntax lookup, the [Cheat Sheet](/documentation/reference/cheat-sheet/).
+
 ## Read and process a CSV file
 
 Read CSV into a vector of maps, headers as keys.

--- a/content/documentation/language/error-handling.md
+++ b/content/documentation/language/error-handling.md
@@ -7,6 +7,8 @@ aliases = ["/documentation/error-handling"]
 
 How Phel signals and recovers from failures: `throw` to raise, `try`/`catch`/`finally` to handle, and `ex-info` to carry structured data with an error. Phel uses PHP's exception machinery, so any PHP `Throwable` works here.
 
+> This page is the canonical guide to handling errors in your code. Chasing a specific `[PHEL...]` compiler error code instead? See the [Error Reference](/documentation/reference/errors/).
+
 ## Throwing
 
 <!-- phel-test: skip -->

--- a/content/documentation/reference/errors.md
+++ b/content/documentation/reference/errors.md
@@ -4,6 +4,8 @@ weight = 3
 description = "Every Phel compiler error code (PHEL001-PHEL310), what it means, and how to fix it."
 +++
 
+> This page is the canonical index of compiler error **codes**. To learn how to `throw`, `catch`, and attach data to errors in your own code, see [Error handling](/documentation/language/error-handling/).
+
 Phel compiler errors are tagged with a stable code like `[PHEL001]`. The code
 survives wording changes, so it is the reliable thing to search for. An error
 prints as the code, a message, the source location, a snippet of the offending

--- a/content/practice/basic.md
+++ b/content/practice/basic.md
@@ -5,6 +5,8 @@ weight = 1
 
 Welcome to Phel! These exercises ease you into prefix notation, basic types, and the REPL feel. Fire up the [Phel REPL](/documentation/tooling/repl) and try each one before peeking at the solution.
 
+> **Concept reference:** these exercises practice [Basic Types](/documentation/language/basic-types/). Read that page for the full theory.
+
 {% question(difficulty="easy") %}
 Compute `1 + 1`.
 {% end %}

--- a/content/practice/control-flow.md
+++ b/content/practice/control-flow.md
@@ -5,6 +5,8 @@ weight = 4
 
 Decisions and loops without mutable variables. Each tool here fits a different shape of problem - learn when to reach for which.
 
+> **Concept reference:** these exercises practice [Control Flow](/documentation/language/control-flow/). Read that page for the full theory.
+
 {% question(difficulty="easy") %}
 Define `absolute` returning the absolute value of a number using `if`.
 <!-- phel-test: skip -->

--- a/content/practice/data-structures.md
+++ b/content/practice/data-structures.md
@@ -5,6 +5,8 @@ weight = 2
 
 Phel ships with four go-to collections: vectors, maps, sets, and lists. They share two superpowers - **immutability** (every "change" returns a new value) and **structural sharing** (so it stays fast). Let's meet them.
 
+> **Concept reference:** these exercises practice [Data Structures](/documentation/language/data-structures/). Read that page for the full theory.
+
 {% question(difficulty="easy") %}
 Build a vector with the elements `2`, `"nice"`, and `true`.
 {% end %}

--- a/content/practice/functions-and-bindings.md
+++ b/content/practice/functions-and-bindings.md
@@ -5,6 +5,8 @@ weight = 3
 
 Functions and names are the bread and butter of any Phel program. You'll learn to bind values, define functions, scope locals, destructure inputs, and build closures that remember.
 
+> **Concept reference:** these exercises practice [Functions and Recursion](/documentation/language/functions-and-recursion/) and [Global and Local Bindings](/documentation/language/global-and-local-bindings/). Read those pages for the full theory.
+
 {% question(difficulty="easy") %}
 Use `def` to bind the name `greeting` to `"Hello, Phel!"`. Then evaluate `greeting`.
 {% end %}

--- a/content/practice/working-with-collections.md
+++ b/content/practice/working-with-collections.md
@@ -5,6 +5,8 @@ weight = 5
 
 This is where Phel sings. `map`, `filter`, `reduce`, threading macros, list comprehensions, and destructuring turn data wrangling into a readable pipeline.
 
+> **Concept reference:** these exercises practice [Data Structures](/documentation/language/data-structures/) and [Lazy Sequences](/documentation/language/lazy-sequences/). Read those pages for the full theory.
+
 {% question(difficulty="medium") %}
 Increment every number in `[4 7 9 10]`. Use `map`.
 {% end %}


### PR DESCRIPTION
Removes the "which page is the real one?" ambiguity by giving every topic a single canonical home and pointing overlapping pages at it (pointers only, no content deleted).

### Canonical-role map

| Topic | Canonical page | Now links to it |
|-------|----------------|-----------------|
| Basic types | `language/basic-types` | `practice/basic` |
| Data structures / collections | `language/data-structures` (+ `lazy-sequences`) | `practice/data-structures`, `practice/working-with-collections` |
| Functions & bindings | `language/functions-and-recursion` + `global-and-local-bindings` | `practice/functions-and-bindings` |
| Control flow | `language/control-flow` | `practice/control-flow` |
| Macros | `language/macros` | blog `writing-your-first-macro` |
| Destructuring | `language/destructuring` | blog `destructuring-deep-dive` |
| Error handling (concepts) | `language/error-handling` | `reference/errors` (reciprocal) |
| Error codes | `reference/errors` | `language/error-handling` (reciprocal) |
| Task recipes | `guides/cookbook` | links out to Language + Cheat Sheet for concepts |

### Section roles
- **Language** = canonical concept reference
- **Practice** = exercises (drill), link to Language
- **Guides / Cookbook** = task recipes, link to Language for concepts
- **Reference** = lookup surfaces (error codes, cheat sheet, API)
- **Blog** = narrative deep dives, link to canonical language page

No URLs changed, so no redirects needed. Verified locally: `zola build` + `zola check` pass, no em-dash in content.

Closes #259

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL