### PR TITLE
feat: add a live filter to the Cookbook

### DIFF
--- a/content/documentation/guides/cookbook.md
+++ b/content/documentation/guides/cookbook.md
@@ -3,6 +3,9 @@ title = "Cookbook"
 weight = 4
 description = "Runnable Phel recipes for files, JSON, HTTP, dates, error handling, schemas, state, and data-transformation pipelines"
 aliases = ["/documentation/cookbook", "/documentation/one-liners"]
+
+[extra]
+scripts = ["cookbook-filter.js"]
 +++
 
 Practical, self-contained Phel recipes for everyday tasks. Copy one, adapt it, ship it.

--- a/static/cookbook-filter.js
+++ b/static/cookbook-filter.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Only activate on the cookbook page
+  if (!window.location.pathname.includes('cookbook')) return;
+
+  const content = document.querySelector('.page-content');
+  if (!content) return;
+
+  // Create filter input (reuses the .cheat-filter styles)
+  const filterWrapper = document.createElement('div');
+  filterWrapper.className = 'cheat-filter';
+  filterWrapper.innerHTML = `
+    <input type="search" class="cheat-filter-input" placeholder="Filter recipes... (e.g., csv, http, dates, schema)" autocomplete="off" spellcheck="false">
+    <span class="cheat-filter-count"></span>
+  `;
+
+  // Insert at the top of content, after the first heading (or first element)
+  const anchor = content.querySelector('h1') || content.firstElementChild;
+  if (anchor && anchor.nextSibling) {
+    content.insertBefore(filterWrapper, anchor.nextSibling);
+  } else {
+    content.prepend(filterWrapper);
+  }
+
+  const input = filterWrapper.querySelector('.cheat-filter-input');
+  const countEl = filterWrapper.querySelector('.cheat-filter-count');
+
+  // Group by h2 headings and their content until the next h2
+  const sections = [];
+  let currentSection = null;
+
+  Array.from(content.children).forEach(el => {
+    if (el.tagName === 'H2') {
+      currentSection = { heading: el, elements: [], text: '' };
+      sections.push(currentSection);
+    } else if (currentSection && !el.classList.contains('cheat-filter')) {
+      currentSection.elements.push(el);
+      currentSection.text += ' ' + el.textContent.toLowerCase();
+    }
+  });
+
+  sections.forEach(s => {
+    s.text = s.heading.textContent.toLowerCase() + s.text;
+  });
+
+  function filter(query) {
+    const q = query.toLowerCase().trim();
+    let visible = 0;
+
+    sections.forEach(section => {
+      const match = !q || section.text.includes(q);
+      section.heading.style.display = match ? '' : 'none';
+      section.elements.forEach(el => el.style.display = match ? '' : 'none');
+      if (match) visible++;
+    });
+
+    countEl.textContent = `(${visible}/${sections.length} recipes)`;
+  }
+
+  filter('');
+
+  input.addEventListener('input', (e) => filter(e.target.value));
+  input.addEventListener('search', (e) => filter(e.target.value));
+});


### PR DESCRIPTION
The cookbook is a single ~33 KB page with 19 recipe sections. This adds a sticky filter box that hides non-matching recipes as you type and shows a live `(n/19 recipes)` count, so a specific task is one keystroke away.

- Reuses the cheat-sheet `.cheat-filter` markup and styles, so **no new CSS**.
- New `static/cookbook-filter.js`, groups by `h2` like the cheat-sheet filter.
- Degrades gracefully without JS: full page and anchors still work.
- Does **not** hijack the `/` key (unlike the cheat sheet), so the global search shortcut stays usable here.

Verified locally: `zola build` + `zola check` pass; script tag injected into the built page and asset copied to output.

Closes #257

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL