### PR TITLE
feat: add a live filter to the PHP Interop page

### DIFF
--- a/content/documentation/php-interop.md
+++ b/content/documentation/php-interop.md
@@ -2,6 +2,9 @@
 title = "PHP Interop"
 weight = 50
 description = "Call PHP functions, build objects, work with PHP arrays, and catch PHP exceptions from Phel."
+
+[extra]
+scripts = ["interop-filter.js"]
 +++
 
 ## Globals and constants

--- a/static/interop-filter.js
+++ b/static/interop-filter.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Only activate on the PHP interop page
+  if (!window.location.pathname.includes('php-interop')) return;
+
+  const content = document.querySelector('.page-content');
+  if (!content) return;
+
+  // Create filter input (reuses the .cheat-filter styles)
+  const filterWrapper = document.createElement('div');
+  filterWrapper.className = 'cheat-filter';
+  filterWrapper.innerHTML = `
+    <input type="search" class="cheat-filter-input" placeholder="Filter interop topics... (e.g., new, method, static, exception)" autocomplete="off" spellcheck="false">
+    <span class="cheat-filter-count"></span>
+  `;
+
+  // Insert at the top of content, after the first heading (or first element)
+  const anchor = content.querySelector('h1') || content.firstElementChild;
+  if (anchor && anchor.nextSibling) {
+    content.insertBefore(filterWrapper, anchor.nextSibling);
+  } else {
+    content.prepend(filterWrapper);
+  }
+
+  const input = filterWrapper.querySelector('.cheat-filter-input');
+  const countEl = filterWrapper.querySelector('.cheat-filter-count');
+
+  // Group by h2 headings and their content until the next h2
+  const sections = [];
+  let currentSection = null;
+
+  Array.from(content.children).forEach(el => {
+    if (el.tagName === 'H2') {
+      currentSection = { heading: el, elements: [], text: '' };
+      sections.push(currentSection);
+    } else if (currentSection && !el.classList.contains('cheat-filter')) {
+      currentSection.elements.push(el);
+      currentSection.text += ' ' + el.textContent.toLowerCase();
+    }
+  });
+
+  sections.forEach(s => {
+    s.text = s.heading.textContent.toLowerCase() + s.text;
+  });
+
+  function filter(query) {
+    const q = query.toLowerCase().trim();
+    let visible = 0;
+
+    sections.forEach(section => {
+      const match = !q || section.text.includes(q);
+      section.heading.style.display = match ? '' : 'none';
+      section.elements.forEach(el => el.style.display = match ? '' : 'none');
+      if (match) visible++;
+    });
+
+    countEl.textContent = `(${visible}/${sections.length} topics)`;
+  }
+
+  filter('');
+
+  input.addEventListener('input', (e) => filter(e.target.value));
+  input.addEventListener('search', (e) => filter(e.target.value));
+});


### PR DESCRIPTION
The PHP Interop page packs 31 `h2` sections into one ~21 KB page. This adds the same sticky filter shipped for the cookbook and cheat sheet, so a specific interop topic is one keystroke away, with a live `(n/31 topics)` count.

- Reuses the `.cheat-filter` markup and styles, **no new CSS**.
- New `static/interop-filter.js`, groups by `h2`.
- Degrades gracefully without JS; leaves the global `/` search shortcut intact.

Verified locally: `zola build` + `zola check` pass; script tag injected and asset copied to output.

Closes #258

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL