### PR TITLE
feat: add difficulty and read-time badges to doc pages

### DIFF
--- a/content/documentation/language/async.md
+++ b/content/documentation/language/async.md
@@ -2,6 +2,9 @@
 title = "Async & Concurrency"
 weight = 16
 description = "Run work concurrently with Phel's two fiber-based layers: top-level promises and futures, plus an AMPHP event loop for timers, IO, and fan-out"
+
+[extra]
+difficulty = "advanced"
 +++
 
 Phel ships two concurrency layers built on PHP fibers. Both let independent work overlap on a single thread; neither parallelizes CPU work across cores. Pick the layer that matches your context, then reach for the [async API reference](/documentation/reference/api/async/) for the full signature of every function.

--- a/content/documentation/language/basic-types.md
+++ b/content/documentation/language/basic-types.md
@@ -3,6 +3,9 @@ title = "Basic Types"
 weight = 1
 description = "Phel's primitive values: nil, booleans, numbers, strings, keywords, plus truthiness, equality, and reader literals"
 aliases = ["/documentation/basic-types", "/documentation/arithmetic", "/documentation/truth-and-boolean-operations"]
+
+[extra]
+difficulty = "beginner"
 +++
 
 The building blocks of every Phel program: literals, numbers, strings, keywords, and the truthiness rules that differ from PHP.

--- a/content/documentation/language/control-flow.md
+++ b/content/documentation/language/control-flow.md
@@ -3,6 +3,9 @@ title = "Control flow"
 weight = 4
 description = "Branch, loop, and build collections with if, cond, case, loop/recur, for, and thread macros like cond->"
 aliases = ["/documentation/control-flow"]
+
+[extra]
+difficulty = "beginner"
 +++
 
 Everything that decides what runs next: conditionals (`if`, `cond`, `case`), iteration (`loop`/`recur`, `foreach`, `for`), and conditional threading.

--- a/content/documentation/language/data-structures.md
+++ b/content/documentation/language/data-structures.md
@@ -3,6 +3,9 @@ title = "Data structures"
 weight = 2
 description = "Phel's persistent collections: lists, vectors, maps, sets, structs, plus core functions like conj, assoc, get-in, and into"
 aliases = ["/documentation/data-structures"]
+
+[extra]
+difficulty = "beginner"
 +++
 
 Phel's four core collections are lists, vectors, maps, and sets. All are **persistent** (immutable): an operation returns a new version that shares structure with the old one, and the original never changes.

--- a/content/documentation/language/destructuring.md
+++ b/content/documentation/language/destructuring.md
@@ -3,6 +3,9 @@ title = "Destructuring"
 weight = 6
 description = "Bind names to values inside vectors, lists, and maps by shape in let, function params, and loop"
 aliases = ["/documentation/destructuring"]
+
+[extra]
+difficulty = "intermediate"
 +++
 
 Destructuring binds names to values inside data structures. Describe the shape, Phel binds the pieces.

--- a/content/documentation/language/error-handling.md
+++ b/content/documentation/language/error-handling.md
@@ -3,6 +3,9 @@ title = "Error handling"
 weight = 7
 description = "Throw and catch exceptions, handle PHP exceptions, attach data with ex-info, and decide when to throw vs return nil"
 aliases = ["/documentation/error-handling"]
+
+[extra]
+difficulty = "intermediate"
 +++
 
 How Phel signals and recovers from failures: `throw` to raise, `try`/`catch`/`finally` to handle, and `ex-info` to carry structured data with an error. Phel uses PHP's exception machinery, so any PHP `Throwable` works here.

--- a/content/documentation/language/functions-and-recursion.md
+++ b/content/documentation/language/functions-and-recursion.md
@@ -3,6 +3,9 @@ title = "Functions and Recursion"
 weight = 5
 description = "Define functions with fn and defn, use multi-arity and variadics, recurse safely with recur, and dispatch with multimethods"
 aliases = ["/documentation/functions-and-recursion"]
+
+[extra]
+difficulty = "intermediate"
 +++
 
 Define and compose behavior: anonymous and named functions, multiple arities, tail-safe recursion with `recur`, and runtime polymorphism with multimethods.

--- a/content/documentation/language/global-and-local-bindings.md
+++ b/content/documentation/language/global-and-local-bindings.md
@@ -3,6 +3,9 @@ title = "Global and local bindings"
 weight = 3
 description = "Bind values to names with def and let, rebind dynamic vars with binding, and manage mutable state with atoms"
 aliases = ["/documentation/global-and-local-bindings"]
+
+[extra]
+difficulty = "beginner"
 +++
 
 How you name things in Phel: `def` for globals, `let` for locals, `binding` for dynamic vars, and `atom` for the rare mutable state.

--- a/content/documentation/language/interfaces.md
+++ b/content/documentation/language/interfaces.md
@@ -3,6 +3,9 @@ title = "Interfaces"
 weight = 9
 description = "Define contracts with definterface, implement them in structs, extend types with protocols, and dispatch via hierarchies"
 aliases = ["/documentation/interfaces"]
+
+[extra]
+difficulty = "advanced"
 +++
 
 Interfaces define contracts: sets of methods that structs implement. They map directly to PHP interfaces. Protocols and hierarchies extend the same idea to types you do not control.

--- a/content/documentation/language/lazy-sequences.md
+++ b/content/documentation/language/lazy-sequences.md
@@ -3,6 +3,9 @@ title = "Lazy Sequences"
 weight = 11
 description = "Defer computation with lazy-seq and lazy-cat, build infinite sequences, and avoid the common laziness pitfalls."
 aliases = ["/documentation/lazy-sequences"]
+
+[extra]
+difficulty = "advanced"
 +++
 
 Lazy sequences defer computation until values are actually needed. This lets you describe infinite or expensive collections, then realize only the part you consume.

--- a/content/documentation/language/macros.md
+++ b/content/documentation/language/macros.md
@@ -3,6 +3,9 @@ title = "Macros"
 weight = 10
 description = "Write compile-time code that rewrites code: defmacro, quasiquote, macroexpand, gensym hygiene, and when a macro is worth it"
 aliases = ["/documentation/macros"]
+
+[extra]
+difficulty = "advanced"
 +++
 
 Macros are compile-time callables. They receive unevaluated code as data, transform it, and return new code for the compiler to process. This lets you add new syntax that functions cannot express.

--- a/content/documentation/language/namespaces.md
+++ b/content/documentation/language/namespaces.md
@@ -3,6 +3,9 @@ title = "Namespaces"
 weight = 8
 description = "Declare namespaces with ns, require Phel modules and PHP classes, and use aliases, :refer, and namespaced keywords"
 aliases = ["/documentation/namespaces"]
+
+[extra]
+difficulty = "intermediate"
 +++
 
 How Phel organizes code across files: every file declares a namespace with `ns`, then pulls in Phel modules and PHP classes through requires.

--- a/content/documentation/language/numeric-tower.md
+++ b/content/documentation/language/numeric-tower.md
@@ -2,6 +2,9 @@
 title = "Numeric Tower"
 weight = 15
 description = "Phel's five numeric shapes (int, BigInt, Ratio, BigDecimal, float), when each appears, and how arithmetic dispatches across them"
+
+[extra]
+difficulty = "intermediate"
 +++
 
 Phel numbers are not a single type. Arithmetic, comparisons, and predicates dispatch across **five scalar shapes**, picking the most precise representation that fits. This page explains each shape and the rules that govern how they interact.

--- a/content/documentation/language/reader-conditionals.md
+++ b/content/documentation/language/reader-conditionals.md
@@ -2,6 +2,9 @@
 title = "Reader Conditionals"
 weight = 14
 description = "Write platform-specific code in shared .cljc source files with #?() and #?@(), resolved at parse time using :phel and :default keys"
+
+[extra]
+difficulty = "advanced"
 +++
 
 Reader conditionals let one source file hold platform-specific code. They resolve during the **parsing phase**, before compilation, so the analyzer and emitter only ever see the selected form. Phel picks the `:phel` branch, ignores other platforms (`:clj`, `:cljs`, ...), and falls back to `:default` when present.

--- a/content/documentation/language/reader-shortcuts.md
+++ b/content/documentation/language/reader-shortcuts.md
@@ -2,6 +2,9 @@
 title = "Reader Shortcuts"
 weight = 13
 description = "Compact catalog of the reader macros and special syntax the Phel reader expands at read time: literals, quote/quasiquote, tagged literals, anonymous functions, reader conditionals, and metadata."
+
+[extra]
+difficulty = "intermediate"
 +++
 
 The **reader** turns source text into Phel data before the compiler sees it. Along the way it expands a handful of single-character and `#`-prefixed shortcuts into ordinary forms. Knowing what each one desugars to makes unfamiliar code readable: every shortcut on this page is just a shorter spelling of a regular call or form.

--- a/content/documentation/language/transducers.md
+++ b/content/documentation/language/transducers.md
@@ -2,6 +2,9 @@
 title = "Transducers"
 weight = 12
 description = "Build composable, allocation-free transformation pipelines that decouple the transformation from the consumer, and write your own custom transducers"
+
+[extra]
+difficulty = "advanced"
 +++
 
 Transducers are composable transformation pipelines that decouple *what* you do to a sequence of values (map, filter, take) from *how* you consume the result (build a vector, sum, write to a file). They turn one reducing function into another, fusing every step into a single pass with no intermediate collections.

--- a/css/components/documentation.css
+++ b/css/components/documentation.css
@@ -348,3 +348,67 @@ h6:hover .zola-anchor {
 .dark .agent-doc-cta__hint {
   color: var(--color-dark-text-secondary);
 }
+
+/* Page meta: difficulty badge + estimated read time (see templates/page.html). */
+.page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: -0.25rem 0 1.5rem;
+  font-size: var(--text-sm);
+}
+
+.page-meta__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  font-weight: 600;
+  line-height: 1.6;
+  border: 1px solid transparent;
+}
+
+.page-meta__badge--beginner {
+  background: #e7f6ec;
+  color: #1a7f43;
+  border-color: #b7e4c7;
+}
+
+.page-meta__badge--intermediate {
+  background: #fdf3e0;
+  color: #9a6a00;
+  border-color: #f5d99a;
+}
+
+.page-meta__badge--advanced {
+  background: #fbe9e9;
+  color: #b23434;
+  border-color: #f2c4c4;
+}
+
+.page-meta__readtime {
+  color: var(--color-light-text-secondary);
+}
+
+.dark .page-meta__badge--beginner {
+  background: rgba(45, 168, 96, 0.16);
+  color: #6ee7a0;
+  border-color: rgba(45, 168, 96, 0.4);
+}
+
+.dark .page-meta__badge--intermediate {
+  background: rgba(214, 158, 46, 0.16);
+  color: #f2c368;
+  border-color: rgba(214, 158, 46, 0.4);
+}
+
+.dark .page-meta__badge--advanced {
+  background: rgba(214, 78, 78, 0.16);
+  color: #f19595;
+  border-color: rgba(214, 78, 78, 0.4);
+}
+
+.dark .page-meta__readtime {
+  color: var(--color-dark-text-secondary);
+}

--- a/templates/page.html
+++ b/templates/page.html
@@ -6,6 +6,16 @@
     {% set crumb_page = page %}
     {% include "partials/breadcrumb.html" %}
     <h1>{{page.title}}</h1>
+    {% if page.path is starting_with("/documentation/") %}
+        <div class="page-meta">
+            {% if page.extra.difficulty is defined %}
+                <span class="page-meta__badge page-meta__badge--{{ page.extra.difficulty }}">{{ page.extra.difficulty | title }}</span>
+            {% endif %}
+            {% if page.reading_time %}
+                <span class="page-meta__readtime">{{ page.reading_time }} min read</span>
+            {% endif %}
+        </div>
+    {% endif %}
     {% set show_toc = page.path is starting_with("/documentation/") and page.toc and page.toc | length >= 2 %}
     {% if show_toc %}
         {% include "page/table-of-content-mobile.html" %}


### PR DESCRIPTION
Gives every documentation page a depth signal so both audiences can self-pace: an optional **difficulty** chip (`beginner` / `intermediate` / `advanced`, from `[extra] difficulty` frontmatter) and an **estimated read time** from Zola's `page.reading_time`.

- Rendered under the title in `templates/page.html`, only on `/documentation/*`.
- Pages without a difficulty show read time only, no layout break (verified on installation page).
- Badge carries a **text label**, not color alone; theme-aware (light + dark).
- Seeds `difficulty` across the whole **Language** section (16 pages); other sections can be filled incrementally.
- Built CSS is gitignored and rebuilt by CI, so only source (`css/components/documentation.css`) is committed.

Verified locally: `npm run build-css-prod`, `zola build`, `zola check` all pass; badge + read time render correctly.

Closes #260

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL