### PR TITLE
fix: drop duplicate auto page list on the documentation landing

### DIFF
--- a/templates/section.html
+++ b/templates/section.html
@@ -6,17 +6,11 @@
 <div class="page">
     {% block content %}
     <div class="page__content" style="max-width: 800px; margin: 0 auto; padding: 0 20px;">
+        {# The documentation landing curates its own navigation in the body
+           (Pick your path, New here? Start here, Browse by section), and the
+           full page tree is in the left sidebar. An auto-generated page list
+           here just duplicates both, so it is intentionally omitted. #}
         {{ section.content | safe }}
-        
-        {% if section.pages %}
-        <ul>
-            {% for page in section.pages %}
-            <li>
-                <a href="{{ page.path }}">{{ page.title }}</a>
-            </li>
-            {% endfor %}
-        </ul>
-        {% endif %}
     </div>
     {% endblock %}
 </div>


### PR DESCRIPTION
**Reported by @Chemaclass:** the `/documentation/` landing showed the curated "New here? Start here" path near the top and, further down, a second bare bullet list of every page (Why Phel?, Configuration, Testing, Debugging, ...).

That second list came from the default `section.html` template auto-appending `section.pages`. The landing already curates its navigation in the body (Pick your path, New here? Start here, Browse by section) and the full tree is in the left sidebar, so the auto-list duplicated both.

- Removed the auto `<ul>` from `section.html`.
- `section.html` is used **only** by the documentation landing (homepage uses `index.html`; every other section uses `section-page.html`/`practice-section.html`/`blog.html`/`releases.html`), so nothing else is affected.
- Audited the other section landings: their bodies are prose-only, so their card grid is the single source, no duplication to fix.
- All previously listed pages remain reachable via the sidebar.

Verified locally: `zola build` + `zola check` pass; the duplicate list is gone and the curated content is intact.

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL