### PR TITLE
feat: surface Agent Setup from homepage and doc landing

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -55,6 +55,10 @@ title = "Phel: A Functional Lisp Dialect for PHP Developers"
     <h3 class="section-page-card__title">Just the API</h3>
     <p class="section-page-card__desc">Skip the prose. Jump straight to every function in every namespace.</p>
   </a>
+  <a href="/documentation/reference/agent-setup/" class="section-page-card">
+    <h3 class="section-page-card__title">Coding with AI</h3>
+    <p class="section-page-card__desc">Pairing with Claude Code, Cursor, or Copilot? One command wires your agent to Phel.</p>
+  </a>
 </div>
 
 </section>

--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -28,6 +28,10 @@ Phel is a functional Lisp that compiles to PHP: persistent data structures, immu
     <h3 class="section-page-card__title">Just the API</h3>
     <p class="section-page-card__desc">Skip the prose. Jump straight to every function in every namespace.</p>
   </a>
+  <a href="/documentation/reference/agent-setup/" class="section-page-card">
+    <h3 class="section-page-card__title">Coding with AI</h3>
+    <p class="section-page-card__desc">Pairing with Claude Code, Cursor, or Copilot? One command wires your agent to Phel.</p>
+  </a>
 </div>
 
 ## New here? Start here


### PR DESCRIPTION
Adds a **Coding with AI** persona card to both the homepage "Choose your path" and the documentation "Pick your path" grids, linking to the new [Agent Setup](/documentation/reference/agent-setup/) page. Agent users now have a path to the one-command skill install from the two main entry points.

- Reuses the existing `.section-page-card` grid, **no new CSS**.
- Top navigation unchanged (per decision).
- Verified: `zola build` + `zola check` pass, both cards render, link resolves, no em-dash.

Closes #271

https://claude.ai/code/session_019DGjraYHqzM52W23vbpGxL